### PR TITLE
Feature: Add dynamic theme auto-loader for modular theming

### DIFF
--- a/tcl/start.tcl
+++ b/tcl/start.tcl
@@ -467,6 +467,25 @@ proc safeStyle {interp args} {
 # Load default/saved values
 source [file nativename [file join $::scidTclDir "options.tcl"]]
 
+# ----------------------------------------------------------------------
+# Dynamic Theme Auto-Loader
+# Loads custom .tcl themes from the local "themes" subdirectory.
+# DEV NOTE: Consider expanding this to scan a user config folder 
+# (e.g., ~/.scid5.1/themes) in the future for better user customization.
+# ----------------------------------------------------------------------
+set themeDir [file join [file dirname [info script]] "themes"]
+
+if {[file isdirectory $themeDir]} {
+    set themeFiles [glob -nocomplain -directory $themeDir *.tcl]
+
+    foreach themeFile $themeFiles {
+        # Load themes safely; catch errors to prevent startup crashes
+        if {[catch {source $themeFile} err]} {
+            puts stderr "Warning: Failed to load theme file $themeFile - $err"
+        }
+    }
+}
+
 # Create a custom "sand" theme that inherits from classic and adjusts background
 if {[lsearch -exact [ttk::style theme names] sand] == -1} {
   ttk::style theme create sand -parent classic -settings {

--- a/tcl/themes/catppuccin_mocha.tcl
+++ b/tcl/themes/catppuccin_mocha.tcl
@@ -1,0 +1,30 @@
+if {[lsearch -exact [ttk::style theme names] catppuccin_mocha] == -1} {
+  ttk::style theme create catppuccin_mocha -parent classic -settings {
+    # Base/UI background and text
+    ttk::style configure . -background #1e1e2e -fieldbackground #313244 -foreground #cdd6f4 -selectbackground #cba6f7 -selectforeground #1e1e2e
+    ttk::style configure TFrame -background #1e1e2e
+    ttk::style configure TLabel -background #1e1e2e -foreground #cdd6f4
+    ttk::style configure TNotebook -background #1e1e2e
+    
+    # Content windows
+    ttk::style configure Treeview -background #181825 -fieldbackground #181825 -foreground #cdd6f4
+    ttk::style map Treeview -background [list selected #cba6f7] -foreground [list selected #1e1e2e]
+    
+    # Inputs
+    ttk::style configure TEntry -fieldbackground #313244 -foreground #cdd6f4
+    ttk::style configure TCombobox -fieldbackground #313244 -foreground #cdd6f4
+    
+    # Buttons
+    ttk::style configure TButton -background #313244 -foreground #cdd6f4 -borderwidth 1 -relief raised -padding {6 2}
+    ttk::style map TButton -background [list active #45475a pressed #585b70] -relief [list pressed sunken]
+    
+    # Menubuttons
+    ttk::style configure TMenubutton -background #313244 -foreground #cdd6f4 -borderwidth 1 -relief raised
+    
+    # Checkboxes & Radiobuttons
+    ttk::style configure TCheckbutton -background #1e1e2e -foreground #cdd6f4 -indicatorcolor #313244
+    ttk::style map TCheckbutton -background [list active #1e1e2e] -indicatorcolor [list pressed #45475a selected #cba6f7 alternate #cba6f7]
+    ttk::style configure TRadiobutton -background #1e1e2e -foreground #cdd6f4 -indicatorcolor #313244
+    ttk::style map TRadiobutton -background [list active #1e1e2e] -indicatorcolor [list pressed #45475a selected #cba6f7 alternate #cba6f7]
+  }
+}

--- a/tcl/themes/dracula.tcl
+++ b/tcl/themes/dracula.tcl
@@ -1,0 +1,30 @@
+if {[lsearch -exact [ttk::style theme names] dracula] == -1} {
+  ttk::style theme create dracula -parent classic -settings {
+    # Base/UI background and text
+    ttk::style configure . -background #282a36 -fieldbackground #44475a -foreground #f8f8f2 -selectbackground #bd93f9 -selectforeground #282a36
+    ttk::style configure TFrame -background #282a36
+    ttk::style configure TLabel -background #282a36 -foreground #f8f8f2
+    ttk::style configure TNotebook -background #282a36
+
+    # Content windows
+    ttk::style configure Treeview -background #21222c -fieldbackground #21222c -foreground #f8f8f2
+    ttk::style map Treeview -background [list selected #bd93f9] -foreground [list selected #282a36]
+
+    # Inputs
+    ttk::style configure TEntry -fieldbackground #44475a -foreground #f8f8f2
+    ttk::style configure TCombobox -fieldbackground #44475a -foreground #f8f8f2
+
+    # Buttons
+    ttk::style configure TButton -background #44475a -foreground #f8f8f2 -borderwidth 1 -relief raised -padding {6 2}
+    ttk::style map TButton -background [list active #6272a4 pressed #ff79c6] -relief [list pressed sunken]
+
+    # Menubuttons
+    ttk::style configure TMenubutton -background #44475a -foreground #f8f8f2 -borderwidth 1 -relief raised
+
+    # Checkboxes & Radiobuttons
+    ttk::style configure TCheckbutton -background #282a36 -foreground #f8f8f2 -indicatorcolor #44475a
+    ttk::style map TCheckbutton -background [list active #282a36] -indicatorcolor [list pressed #6272a4 selected #bd93f9 alternate #bd93f9]
+    ttk::style configure TRadiobutton -background #282a36 -foreground #f8f8f2 -indicatorcolor #44475a
+    ttk::style map TRadiobutton -background [list active #282a36] -indicatorcolor [list pressed #6272a4 selected #bd93f9 alternate #bd93f9]
+  }
+}


### PR DESCRIPTION
- Implemented an auto-loader in start.tcl to dynamically source .tcl theme files from the tcl/themes/ directory.
- Wrapped the source command in a catch block to prevent startup crashes from malformed custom theme files.
- Added catppuccin_mocha.tcl and dracula.tcl as ready-to-use sample themes.
- Included a DEV note suggesting future expansion to user config directories (e.g., ~/.scid5.1/themes).
<img width="419" height="368" alt="image" src="https://github.com/user-attachments/assets/acc0f8fd-5ff8-4723-a930-d661cd6ca236" />
<img width="421" height="369" alt="image" src="https://github.com/user-attachments/assets/90bb4b5f-b35e-45d4-9b8f-4bef2e23d4ce" />
