### PR TITLE
Update Catppuccin and Dracula themes and fix engine button contrast

### DIFF
--- a/tcl/themes/catppuccin_mocha.tcl
+++ b/tcl/themes/catppuccin_mocha.tcl
@@ -1,32 +1,257 @@
 registerDarkTheme "catppuccin_mocha"
 
-if {[lsearch -exact [ttk::style theme names] catppuccin_mocha] == -1} {
-  ttk::style theme create catppuccin_mocha -parent classic -settings {
-    # Base/UI background and text
-    ttk::style configure . -background #1e1e2e -fieldbackground #313244 -foreground #cdd6f4 -selectbackground #cba6f7 -selectforeground #1e1e2e
-    ttk::style configure TFrame -background #1e1e2e
-    ttk::style configure TLabel -background #1e1e2e -foreground #cdd6f4
-    ttk::style configure TNotebook -background #1e1e2e
-    
-    # Content windows
-    ttk::style configure Treeview -background #181825 -fieldbackground #181825 -foreground #cdd6f4
-    ttk::style map Treeview -background [list selected #cba6f7] -foreground [list selected #1e1e2e]
-    
-    # Inputs
-    ttk::style configure TEntry -fieldbackground #313244 -foreground #cdd6f4
-    ttk::style configure TCombobox -fieldbackground #313244 -foreground #cdd6f4
-    
-    # Buttons
-    ttk::style configure TButton -background #313244 -foreground #cdd6f4 -borderwidth 1 -relief raised -padding {6 2}
-    ttk::style map TButton -background [list active #45475a pressed #585b70] -relief [list pressed sunken]
-    
-    # Menubuttons
-    ttk::style configure TMenubutton -background #313244 -foreground #cdd6f4 -borderwidth 1 -relief raised
-    
-    # Checkboxes & Radiobuttons
-    ttk::style configure TCheckbutton -background #1e1e2e -foreground #cdd6f4 -indicatorcolor #313244
-    ttk::style map TCheckbutton -background [list active #1e1e2e] -indicatorcolor [list pressed #45475a selected #cba6f7 alternate #cba6f7]
-    ttk::style configure TRadiobutton -background #1e1e2e -foreground #cdd6f4 -indicatorcolor #313244
-    ttk::style map TRadiobutton -background [list active #1e1e2e] -indicatorcolor [list pressed #45475a selected #cba6f7 alternate #cba6f7]
-  }
+#
+# Copyright (C) 2020 Uwe Klimmek
+#
+# This file is part of Scid (Shane's Chess Information Database).
+# Scid is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation.
+
+### Implements a "catppuccin_mocha" theme.
+
+namespace eval ttk::theme::catppuccin_mocha {
+    array set colors {
+        background     "#1e1e2e"
+        foreground     "#cdd6f4"
+        disabledfg     "#6c7086"
+        buttonbg       "#313244"
+        buttonbgdark   "#181825"
+        buttonbglight  "#45475a"
+        labelframe     "#585b70"
+        fieldbg        "#181825"
+        fieldborder    "#313244"
+        darkcolor      "#11111b"
+        lightcolor     "#585b70"
+        notebookborder "#45475a"
+        selectbg       "#585b70"
+        selectfg       "#cdd6f4"
+        through        "#181825"
+    }
+
+    ttk::style theme create catppuccin_mocha -parent clam -settings {
+        set basecol "#cba6f7" ;# Alternative: #f5c2e7 Basecolor, change here to have new topic for the theme
+        # -----------------------------------------------------------------------------
+        # Theme defaults
+        ttk::style configure "." \
+            -foreground $colors(foreground) \
+            -background $colors(background) \
+            -darkcolor $colors(darkcolor) \
+            -lightcolor $colors(lightcolor) \
+            -troughcolor $colors(through) \
+            -selectbackground $basecol \
+            -selectforeground $colors(selectfg) \
+            -activebackground $basecol \
+            -activeforeground $colors(selectfg) \
+            -indicatorbackground $colors(fieldbg) \
+            -indicatorforeground $colors(foreground) \
+            -fieldbackground $colors(fieldbg) \
+            -bordercolor $colors(fieldborder) \
+            -selectborderwidth 0 \
+            -arrowcolor $colors(foreground) \
+            -insertcolor $colors(foreground) \
+            -insertbackground $colors(foreground) \
+        ;
+
+        ttk::style map "." \
+            -foreground [list \
+                disabled $colors(disabledfg)] \
+            -background [list \
+                active $basecol] \
+            -fieldbackground [list \
+                disabled $colors(background)] \
+            -indicatorbackground [list \
+                pressed $colors(background) \
+                alternate $colors(disabledfg) \
+                disabled $colors(background)] \
+            -indicatorforeground [list \
+                disabled $colors(disabledfg)] \
+            -arrowcolor [list \
+                disabled $colors(disabledfg)] \
+        ;
+
+        set borders [list disabled $colors(fieldborder) {active pressed} $basecol \
+                    {disabled selected} $colors(fieldborder) {pressed selected} $basecol pressed $basecol \
+                    {active selected} $basecol active $basecol selected $basecol focus $basecol ]
+        set buttonborder [list disabled $colors(fieldborder) {active pressed} $basecol \
+                    {disabled selected} $colors(fieldborder) {pressed selected} $basecol pressed $basecol \
+                    {active selected} $basecol active $basecol selected $basecol ]
+        set buttonsbg [list disabled $colors(through) pressed $colors(buttonbgdark) \
+                    active $colors(buttonbglight) ]
+
+        ttk::style configure TButton \
+            -anchor center \
+            -relief raised \
+            -padding 4 \
+            -background $colors(buttonbg) \
+        ;
+        ttk::style map TButton \
+            -bordercolor $buttonborder \
+            -background $buttonsbg \
+        ;
+
+        ttk::style configure TMenubutton \
+            -anchor center \
+            -padding 4 \
+            -relief raised \
+            -background $colors(buttonbg) \
+        ;
+        ttk::style map TMenubutton \
+            -bordercolor $borders \
+            -background $buttonsbg \
+        ;
+
+        ttk::style configure Toolbutton \
+            -anchor center \
+            -padding 2 \
+            -relief flat \
+        ;
+        ttk::style map Toolbutton \
+            -relief [list \
+                {active !selected} raised] \
+            -bordercolor $borders \
+            -foreground [list \
+                disabled $colors(disabledfg)] \
+            -background [list \
+                pressed $basecol \
+                selected $basecol \
+                active $colors(darkcolor)] \
+            -lightcolor [list pressed $basecol] \
+            -darkcolor [list pressed $basecol] \
+        ;
+
+        ttk::style configure TCheckbutton \
+            -padding 2
+        ;
+        ttk::style configure TRadiobutton \
+            -padding 2
+        ;
+
+        ttk::style configure TCombobox \
+            -anchor center \
+            -padding 1 \
+            -insertwidth 1 \
+            -relief raised \
+            -borderwidth 1 \
+        ;
+        ttk::style map TCombobox \
+            -bordercolor $borders \
+            -background $buttonsbg \
+            -lightcolor $borders \
+        ;
+
+        ttk::style configure TEntry \
+            -foreground $colors(selectfg) \
+            -padding 1 \
+            -insertwidth 1 \
+        ;
+        ttk::style map TEntry \
+            -bordercolor $borders \
+            -lightcolor $borders \
+        ;
+
+        ttk::style configure TSpinbox \
+            -arrowsize 12 \
+            -padding {2 0 10 0} \
+        ;
+        ttk::style map TSpinbox \
+            -bordercolor $borders \
+            -background $buttonsbg \
+            -arrowcolor [list \
+                disabled $colors(disabledfg)] \
+        ;
+
+        ttk::style configure TScale \
+            -troughcolor $colors(through) \
+        ;
+        ttk::style map TScale \
+            -bordercolor [list \
+                active $basecol] \
+        ;
+
+        ttk::style configure TNotebook.Tab \
+            -padding {6 2 6 2} \
+        ;
+        ttk::style map TNotebook.Tab \
+            -padding [list \
+                selected {6 4 6 2}] \
+            -background [list \
+                selected $colors(background) \
+                {} $colors(fieldbg)] \
+            -lightcolor [list \
+                selected $colors(lightcolor) \
+                {} $colors(notebookborder)] \
+        ;
+
+        ttk::style configure TPanedwindow \
+            -sashrelief raised \
+        ;
+
+        ttk::style configure TLabelframe \
+            -bordercolor $colors(labelframe) \
+            -relief raised \
+            -padding 4 \
+        ;
+
+        ttk::style configure TProgressbar \
+            -background $basecol \
+        ;
+
+        ttk::style configure TScrollbar \
+            -arrowsize 10 -width 10 \
+            -troughcolor $colors(fieldbg) \
+            -bordercolor $colors(fieldbg) \
+            -background $colors(through) \
+        ;
+        ttk::style map TScrollbar \
+            -background [list \
+                pressed $colors(lightcolor) \
+                active $colors(lightcolor) \
+                disabled $colors(through) \
+                !pressed $colors(buttonbglight)] \
+            -lightcolor [list \
+                pressed $colors(darkcolor) \
+                active $colors(lightcolor) \
+                disabled $colors(through) \
+                !pressed $colors(buttonbglight)] \
+            -darkcolor [list \
+                pressed $colors(lightcolor) \
+                active $colors(darkcolor) \
+                disabled $colors(through) \
+                !pressed $colors(buttonbglight)] \
+        ;
+        # Remove arrows
+        ttk::style layout Vertical.TScrollbar {
+            Vertical.Scrollbar.trough -sticky news -children {
+                Vertical.Scrollbar.thumb -expand true
+            }
+        }
+        ttk::style layout Horizontal.TScrollbar {
+            Horizontal.Scrollbar.trough -sticky news -children {
+                Horizontal.Scrollbar.thumb -expand true
+            }
+        }
+
+        ttk::style configure Heading \
+            -relief raised \
+        ;
+        ttk::style map Heading \
+            -bordercolor $buttonborder \
+            -background $buttonsbg \
+        ;
+
+        ttk::style configure Treeview \
+            -relief flat \
+            -bordercolor $colors(fieldbg) \
+            -lightcolor $colors(fieldbg) \
+            -background $colors(fieldbg) \
+        ;
+        ttk::style map Treeview \
+            -background [list \
+                selected $basecol \
+                disabled $colors(darkcolor)] \
+            -foreground [list \
+                selected $colors(selectfg)] \
+        ;
+    }
 }

--- a/tcl/themes/dracula.tcl
+++ b/tcl/themes/dracula.tcl
@@ -1,32 +1,257 @@
 registerDarkTheme "dracula"
 
-if {[lsearch -exact [ttk::style theme names] dracula] == -1} {
-  ttk::style theme create dracula -parent classic -settings {
-    # Base/UI background and text
-    ttk::style configure . -background #282a36 -fieldbackground #44475a -foreground #f8f8f2 -selectbackground #bd93f9 -selectforeground #282a36
-    ttk::style configure TFrame -background #282a36
-    ttk::style configure TLabel -background #282a36 -foreground #f8f8f2
-    ttk::style configure TNotebook -background #282a36
+#
+# Copyright (C) 2020 Uwe Klimmek
+#
+# This file is part of Scid (Shane's Chess Information Database).
+# Scid is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation.
 
-    # Content windows
-    ttk::style configure Treeview -background #21222c -fieldbackground #21222c -foreground #f8f8f2
-    ttk::style map Treeview -background [list selected #bd93f9] -foreground [list selected #282a36]
+### Implements a "dracula" theme.
 
-    # Inputs
-    ttk::style configure TEntry -fieldbackground #44475a -foreground #f8f8f2
-    ttk::style configure TCombobox -fieldbackground #44475a -foreground #f8f8f2
+namespace eval ttk::theme::dracula {
+    array set colors {
+        background     "#282a36"
+        foreground     "#f8f8f2"
+        disabledfg     "#6272a4"
+        buttonbg       "#44475a"
+        buttonbgdark   "#343746"
+        buttonbglight  "#54576a"
+        labelframe     "#6272a4"
+        fieldbg        "#1e1f29"
+        fieldborder    "#44475a"
+        darkcolor      "#21222c"
+        lightcolor     "#6272a4"
+        notebookborder "#44475a"
+        selectbg       "#44475a"
+        selectfg       "#f8f8f2"
+        through        "#21222c"
+    }
 
-    # Buttons
-    ttk::style configure TButton -background #44475a -foreground #f8f8f2 -borderwidth 1 -relief raised -padding {6 2}
-    ttk::style map TButton -background [list active #6272a4 pressed #ff79c6] -relief [list pressed sunken]
+    ttk::style theme create dracula -parent clam -settings {
+        set basecol "#bd93f9" ;# Alternative: #ff79c6 Basecolor, change here to have new topic for the theme
+        # -----------------------------------------------------------------------------
+        # Theme defaults
+        ttk::style configure "." \
+            -foreground $colors(foreground) \
+            -background $colors(background) \
+            -darkcolor $colors(darkcolor) \
+            -lightcolor $colors(lightcolor) \
+            -troughcolor $colors(through) \
+            -selectbackground $basecol \
+            -selectforeground $colors(selectfg) \
+            -activebackground $basecol \
+            -activeforeground $colors(selectfg) \
+            -indicatorbackground $colors(fieldbg) \
+            -indicatorforeground $colors(foreground) \
+            -fieldbackground $colors(fieldbg) \
+            -bordercolor $colors(fieldborder) \
+            -selectborderwidth 0 \
+            -arrowcolor $colors(foreground) \
+            -insertcolor $colors(foreground) \
+            -insertbackground $colors(foreground) \
+        ;
 
-    # Menubuttons
-    ttk::style configure TMenubutton -background #44475a -foreground #f8f8f2 -borderwidth 1 -relief raised
+        ttk::style map "." \
+            -foreground [list \
+                disabled $colors(disabledfg)] \
+            -background [list \
+                active $basecol] \
+            -fieldbackground [list \
+                disabled $colors(background)] \
+            -indicatorbackground [list \
+                pressed $colors(background) \
+                alternate $colors(disabledfg) \
+                disabled $colors(background)] \
+            -indicatorforeground [list \
+                disabled $colors(disabledfg)] \
+            -arrowcolor [list \
+                disabled $colors(disabledfg)] \
+        ;
 
-    # Checkboxes & Radiobuttons
-    ttk::style configure TCheckbutton -background #282a36 -foreground #f8f8f2 -indicatorcolor #44475a
-    ttk::style map TCheckbutton -background [list active #282a36] -indicatorcolor [list pressed #6272a4 selected #bd93f9 alternate #bd93f9]
-    ttk::style configure TRadiobutton -background #282a36 -foreground #f8f8f2 -indicatorcolor #44475a
-    ttk::style map TRadiobutton -background [list active #282a36] -indicatorcolor [list pressed #6272a4 selected #bd93f9 alternate #bd93f9]
-  }
+        set borders [list disabled $colors(fieldborder) {active pressed} $basecol \
+                    {disabled selected} $colors(fieldborder) {pressed selected} $basecol pressed $basecol \
+                    {active selected} $basecol active $basecol selected $basecol focus $basecol ]
+        set buttonborder [list disabled $colors(fieldborder) {active pressed} $basecol \
+                    {disabled selected} $colors(fieldborder) {pressed selected} $basecol pressed $basecol \
+                    {active selected} $basecol active $basecol selected $basecol ]
+        set buttonsbg [list disabled $colors(through) pressed $colors(buttonbgdark) \
+                    active $colors(buttonbglight) ]
+
+        ttk::style configure TButton \
+            -anchor center \
+            -relief raised \
+            -padding 4 \
+            -background $colors(buttonbg) \
+        ;
+        ttk::style map TButton \
+            -bordercolor $buttonborder \
+            -background $buttonsbg \
+        ;
+
+        ttk::style configure TMenubutton \
+            -anchor center \
+            -padding 4 \
+            -relief raised \
+            -background $colors(buttonbg) \
+        ;
+        ttk::style map TMenubutton \
+            -bordercolor $borders \
+            -background $buttonsbg \
+        ;
+
+        ttk::style configure Toolbutton \
+            -anchor center \
+            -padding 2 \
+            -relief flat \
+        ;
+        ttk::style map Toolbutton \
+            -relief [list \
+                {active !selected} raised] \
+            -bordercolor $borders \
+            -foreground [list \
+                disabled $colors(disabledfg)] \
+            -background [list \
+                pressed $basecol \
+                selected $basecol \
+                active $colors(darkcolor)] \
+            -lightcolor [list pressed $basecol] \
+            -darkcolor [list pressed $basecol] \
+        ;
+
+        ttk::style configure TCheckbutton \
+            -padding 2
+        ;
+        ttk::style configure TRadiobutton \
+            -padding 2
+        ;
+
+        ttk::style configure TCombobox \
+            -anchor center \
+            -padding 1 \
+            -insertwidth 1 \
+            -relief raised \
+            -borderwidth 1 \
+        ;
+        ttk::style map TCombobox \
+            -bordercolor $borders \
+            -background $buttonsbg \
+            -lightcolor $borders \
+        ;
+
+        ttk::style configure TEntry \
+            -foreground $colors(selectfg) \
+            -padding 1 \
+            -insertwidth 1 \
+        ;
+        ttk::style map TEntry \
+            -bordercolor $borders \
+            -lightcolor $borders \
+        ;
+
+        ttk::style configure TSpinbox \
+            -arrowsize 12 \
+            -padding {2 0 10 0} \
+        ;
+        ttk::style map TSpinbox \
+            -bordercolor $borders \
+            -background $buttonsbg \
+            -arrowcolor [list \
+                disabled $colors(disabledfg)] \
+        ;
+
+        ttk::style configure TScale \
+            -troughcolor $colors(through) \
+        ;
+        ttk::style map TScale \
+            -bordercolor [list \
+                active $basecol] \
+        ;
+
+        ttk::style configure TNotebook.Tab \
+            -padding {6 2 6 2} \
+        ;
+        ttk::style map TNotebook.Tab \
+            -padding [list \
+                selected {6 4 6 2}] \
+            -background [list \
+                selected $colors(background) \
+                {} $colors(fieldbg)] \
+            -lightcolor [list \
+                selected $colors(lightcolor) \
+                {} $colors(notebookborder)] \
+        ;
+
+        ttk::style configure TPanedwindow \
+            -sashrelief raised \
+        ;
+
+        ttk::style configure TLabelframe \
+            -bordercolor $colors(labelframe) \
+            -relief raised \
+            -padding 4 \
+        ;
+
+        ttk::style configure TProgressbar \
+            -background $basecol \
+        ;
+
+        ttk::style configure TScrollbar \
+            -arrowsize 10 -width 10 \
+            -troughcolor $colors(fieldbg) \
+            -bordercolor $colors(fieldbg) \
+            -background $colors(through) \
+        ;
+        ttk::style map TScrollbar \
+            -background [list \
+                pressed $colors(lightcolor) \
+                active $colors(lightcolor) \
+                disabled $colors(through) \
+                !pressed $colors(buttonbglight)] \
+            -lightcolor [list \
+                pressed $colors(darkcolor) \
+                active $colors(lightcolor) \
+                disabled $colors(through) \
+                !pressed $colors(buttonbglight)] \
+            -darkcolor [list \
+                pressed $colors(lightcolor) \
+                active $colors(darkcolor) \
+                disabled $colors(through) \
+                !pressed $colors(buttonbglight)] \
+        ;
+        # Remove arrows
+        ttk::style layout Vertical.TScrollbar {
+            Vertical.Scrollbar.trough -sticky news -children {
+                Vertical.Scrollbar.thumb -expand true
+            }
+        }
+        ttk::style layout Horizontal.TScrollbar {
+            Horizontal.Scrollbar.trough -sticky news -children {
+                Horizontal.Scrollbar.thumb -expand true
+            }
+        }
+
+        ttk::style configure Heading \
+            -relief raised \
+        ;
+        ttk::style map Heading \
+            -bordercolor $buttonborder \
+            -background $buttonsbg \
+        ;
+
+        ttk::style configure Treeview \
+            -relief flat \
+            -bordercolor $colors(fieldbg) \
+            -lightcolor $colors(fieldbg) \
+            -background $colors(fieldbg) \
+        ;
+        ttk::style map Treeview \
+            -background [list \
+                selected $basecol \
+                disabled $colors(darkcolor)] \
+            -foreground [list \
+                selected $colors(selectfg)] \
+        ;
+    }
 }

--- a/tcl/windows/engine.tcl
+++ b/tcl/windows/engine.tcl
@@ -372,12 +372,12 @@ proc ::enginewin::onLichessResult {id fen result} {
 
 # Creates the buttons bar
 proc ::enginewin::createButtonsBar {id btn display} {
-    ttk::button $btn.startStop -image [list tb_eng_on pressed tb_eng_off user1 tb_eng_off] \
+    ttk::button $btn.startStop -image [list [::button_image tb_eng_on] pressed [::button_image tb_eng_off] user1 [::button_image tb_eng_off]] \
         -style Toolbutton -command "::enginewin::toggleStartStop $id"
     #TODO: change the tooltip to "Start/stop engine"
     ::utils::tooltip::Set $btn.startStop [tr StartEngine]
 
-    ttk::button $btn.lock -image tb_eng_lock -style Toolbutton -command [list apply {{id} {
+    ttk::button $btn.lock -image [::button_image tb_eng_lock] -style Toolbutton -command [list apply {{id} {
         if {[::enginewin::stateLocked $id]} {
             ::enginewin::changeState $id follow.*
             ::enginewin::onPosChanged $id
@@ -388,10 +388,10 @@ proc ::enginewin::createButtonsBar {id btn display} {
     ::utils::tooltip::Set $btn.lock [tr LockEngine]
 
     set pv_lines $display.pv_lines
-    ttk::button $btn.addbestmove -image tb_eng_addbestmove -style Toolbutton \
+    ttk::button $btn.addbestmove -image [::button_image tb_eng_addbestmove] -style Toolbutton \
         -command "::enginewin::exportMoves $pv_lines 1.0"
     ::utils::tooltip::Set $btn.addbestmove [tr AddMove]
-    ttk::button $btn.addlines -image tb_eng_addlines -style Toolbutton \
+    ttk::button $btn.addlines -image [::button_image tb_eng_addlines] -style Toolbutton \
         -command "::enginewin::exportLines $pv_lines"
     ::utils::tooltip::Set $btn.addlines [tr AddAllVariations]
 
@@ -452,7 +452,7 @@ proc ::enginewin::createButtonsBar {id btn display} {
     ttk::menubutton $btn.autorun -text "\u601D" \
         -style EnginewinAuto.Toolbutton -direction above -menu $btn.menus.autorun
 
-    ttk::button $btn.config -image tb_eng_config -style Toolbutton \
+    ttk::button $btn.config -image [::button_image tb_eng_config] -style Toolbutton \
         -command "::enginewin::toggleConfigPane $id"
     $btn.config state pressed
 


### PR DESCRIPTION
### Summary of Changes

**1. Fixed Engine Window Button Contrast (Dark Themes)**
* **The Problem:** In dark themes, the toolbar buttons within the engine window (`engine.tcl`) lacked contrast and blended into the background, making them difficult to see.
* **The Fix:** Updated the engine window to use the `::button_image` wrapper. This ensures the application dynamically loads the correct high-contrast icons based on the active theme's light/dark mode.

**2. Theme Engine Refactoring**
* Refactored the `dracula` and `catppuccin_mocha` themes (renamed to `catppuccin_mocha_mauve`).
* Migrated these themes to a more comprehensive, `clam`-based styling structure to improve overall visual consistency and appeal across the application.

### Visual Impact: Engine Window Contrast

| Before | After |
| :---: | :---: |
| <img width="500" alt="Engine buttons lacking contrast" src="https://github.com/user-attachments/assets/8c7bff58-8331-4261-84c1-6f0463d3c822" /> | <img width="500" alt="Engine buttons with proper contrast" src="https://github.com/user-attachments/assets/487d19f2-ee6d-4b6a-bcc8-f4f5e921f59a" /> |

*Notice how the engine control buttons are now clearly visible and properly styled against the dark background.*