### PR TITLE
Fix visual snap-back during piece drag-and-drop

### DIFF
--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -1274,7 +1274,17 @@ proc releaseSquare { w x y } {
         # User has dragged to another square, so try to add this as a move:
         set tmp $selectedSq
         set selectedSq -1
+
+        # --- FIX: Temporarily disable animation for mouse drops ---
+        global animateDelay
+        set tempDelay $animateDelay
+        set animateDelay 0
+
         addMove $square $tmp ""
+
+        set animateDelay $tempDelay
+        # ----------------------------------------------------------
+
         ::board::colorSquare $w $square
         ::board::colorSquare $w $tmp
     }


### PR DESCRIPTION
### Description of the Fix
I noticed that when drag-and-dropping a piece, the UI visually snaps the piece back to its origin square before animating the slide to the destination. 

This patch temporarily zeros the `animateDelay` during the drop to make the placement instantaneous. This eliminates the visual "yo-yo" effect and mirrors how Scid 5.2 and Scid vs. PC handle manual mouse drops.

### Visual Comparison

**Before (Current Behavior)**


https://github.com/user-attachments/assets/eb67c2a9-2c73-43a8-bb0c-ca5b06b15c02



**After (With Patch)**


https://github.com/user-attachments/assets/a388575d-a384-433a-85d4-66c13a87cd80



---

**Before you merge this**, I wanted to double-check: was the snap-back behavior implemented intentionally (e.g., to wait for engine move validation before rendering), or is it just an unintended side-effect of the global animation loop? 

Let me know if you prefer a different approach!