### PR TITLE
Open report

### DIFF
--- a/tcl/htext.tcl
+++ b/tcl/htext.tcl
@@ -254,7 +254,7 @@ proc ::htext::extractSectionName {tagName} {
 
 set ::htext::interrupt 0
 
-proc ::htext::display {w helptext {section ""} {fixed 1}} {
+proc ::htext::display {w helptext {section ""} {fixed 1} {baseId ""}} {
   global helpWin
   # set start [clock clicks -milli]
   set helpWin(Indent) 0
@@ -371,10 +371,12 @@ proc ::htext::display {w helptext {section ""} {fixed 1}} {
         set gameTag $tagName
         set tagName "g"
         set gnum [string range $gameTag 2 end]
-        set glCommand "::game::LoadMenu $w [sc_base current] $gnum %X %Y"
+        set useBase $baseId
+        if {$useBase eq ""} { set useBase [sc_base current] }
+        set glCommand "::game::LoadMenu $w $useBase $gnum %X %Y"
         $w tag bind $gameTag <ButtonPress-1> $glCommand
         $w tag bind $gameTag <ButtonPress-$::MB3> \
-            "::gbrowser::new [sc_base current] $gnum"
+            "::gbrowser::new $useBase $gnum"
         $w tag bind $gameTag <Any-Enter> \
             "$w tag configure $gameTag -foreground white
              $w tag configure $gameTag -background DodgerBlue4

--- a/tcl/tools/optable.tcl
+++ b/tcl/tools/optable.tcl
@@ -130,7 +130,7 @@ proc ::optable::makeReportWin {args} {
   }
 
   set refBase $::optable::_refBase
-  if {$refBase > 0} {
+  if {$refBase != -1} {
     set reportBase $refBase
   } else {
     set reportBase [sc_base current]
@@ -370,7 +370,7 @@ proc ::optable::makeReportWin {args} {
   $w.text configure -state normal
   $w.text delete 1.0 end
   regsub -all "\n" $report "<br>" report
-  ::htext::display $w.text $report
+  ::htext::display $w.text $report "" 1 $::optable::_baseNumber
   $w.text configure -state disabled
   unbusyCursor .
 

--- a/tcl/utils/win.tcl
+++ b/tcl/utils/win.tcl
@@ -253,6 +253,8 @@ proc ::win::manageWindow {wnd title} {
 proc ::win::createDialog {w {y 10}} {
 	toplevel $w -padx 10 -pady $y
 	::applyThemeColor_background $w
+	wm transient $w .
+	catch {wm attributes $w -type dialog}
 }
 
 # Make sure that a window is visible


### PR DESCRIPTION
1) Fix links in Opening Report if different database chosen as reference.
2) Mark pop-up windows as transient dialog windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database selection when loading games through dialogs
  * Fixed report generation to properly respect reference base settings
  * Enhanced dialog window management for improved window behavior and proper dialog attributes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->