### PR TITLE
Add ability to rename and delete custom Game List layouts

### DIFF
--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -1681,6 +1681,8 @@ translate E FindCurrentGame {Find current game}
 translate E DeleteGame {Delete game}
 translate E UndeleteGame {Undelete game}
 translate E ResetSort {Reset sort}
+translate E LayoutExists {Layout '%s' already exists.}
+translate E ConfirmDeleteLayout {Are you sure you want to delete the layout '%s'?}
 
 translate E ConvertNullMove {Convert null moves to comments}
 translate E SetupBoard {Setup Board}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -347,6 +347,7 @@ menuText E GInfoInformant "Configure informant values" 0
 
 # General buttons:
 translate E Back {Back}
+translate E Apply {Apply}
 translate E Browse {Browse}
 translate E Cancel {Cancel}
 translate E Continue {Continue}
@@ -367,6 +368,7 @@ translate E MergeGame {Merge Game}
 translate E MergeGames {Merge Games}
 translate E Preview {Preview}
 translate E Revert {Revert}
+translate E Rename {Rename}
 translate E Save {Save}
 translate E Search {Search}
 translate E Stop {Stop}

--- a/tcl/windows/gamelist.tcl
+++ b/tcl/windows/gamelist.tcl
@@ -999,6 +999,71 @@ proc glist.layout_save {layout} {
   lappend ::glist_Layouts "$new_ly"
 }
 
+proc glist.layout_rename {layout} {
+  set w .glist_rename
+  if {[winfo exists $w]} { destroy $w }
+  win::createDialog $w
+  wm title $w "[tr Rename] $layout"
+
+  pack [ttk::label $w.msg -text "[tr Rename] $layout:"] -padx 10 -pady 5
+  pack [ttk::entry $w.name] -padx 10 -pady 5 -fill x
+  $w.name insert 0 $layout
+  $w.name selection range 0 end
+  focus $w.name
+
+  set f [ttk::frame $w.buttons]
+  pack $f -padx 10 -pady 10 -fill x
+
+  ttk::button $f.ok -text [tr Save] -command "
+    set new_ly \[$w.name get\]
+    if {\$new_ly ne {} && \$new_ly ne {$layout}} {
+      glist.layout_rename_do {$layout} \$new_ly
+    }
+    destroy $w
+  "
+  ttk::button $f.cancel -text [tr Cancel] -command "destroy $w"
+  pack $f.cancel $f.ok -side right -padx 5
+
+  bind $w <Return> [list $f.ok invoke]
+  bind $w <Escape> [list destroy $w]
+}
+
+proc glist.layout_rename_do {old new} {
+  set idx [lsearch -exact $::glist_Layouts $old]
+  if {$idx == -1} return
+  if {[lsearch -exact $::glist_Layouts $new] != -1} {
+    tk_messageBox -icon error -title scidCommunity -message "Layout '$new' already exists."
+    return
+  }
+  set ::glist_Layouts [lreplace $::glist_Layouts $idx $idx $new]
+  set ::glist_ColOrder($new) $::glist_ColOrder($old)
+  set ::glist_ColWidth($new) $::glist_ColWidth($old)
+  set ::glist_ColAnchor($new) $::glist_ColAnchor($old)
+  set ::glist_Sort($new) $::glist_Sort($old)
+  set ::glist_FindBar($new) $::glist_FindBar($old)
+  unset ::glist_ColOrder($old)
+  unset ::glist_ColWidth($old)
+  unset ::glist_ColAnchor($old)
+  unset ::glist_Sort($old)
+  unset ::glist_FindBar($old)
+  options.write
+}
+
+proc glist.layout_delete {layout} {
+  set msg "Are you sure you want to delete the layout '$layout'?"
+  set answer [tk_messageBox -title scidCommunity -icon question -type yesno -message $msg]
+  if {$answer ne "yes"} return
+  set idx [lsearch -exact $::glist_Layouts $layout]
+  if {$idx == -1} return
+  set ::glist_Layouts [lreplace $::glist_Layouts $idx $idx]
+  unset ::glist_ColOrder($layout)
+  unset ::glist_ColWidth($layout)
+  unset ::glist_ColAnchor($layout)
+  unset ::glist_Sort($layout)
+  unset ::glist_FindBar($layout)
+  options.write
+}
+
 
 ##########################################################################
 #private:
@@ -1436,8 +1501,18 @@ proc glist.popupmenu_ {{w} {x} {y} {abs_x} {abs_y} {layout}} {
       -command "glist.layout_apply [winfo parent $w] $layout DEFAULT"
     if {[info exists ::glist_Layouts]} {
       foreach elem $::glist_Layouts {
-        $w.header_menu.layouts add command -label $elem \
-          -command "glist.layout_apply [winfo parent $w] $layout $elem"
+        if {$elem in {RatingDate DateEvent Full}} {
+          $w.header_menu.layouts add command -label $elem \
+            -command "glist.layout_apply [winfo parent $w] $layout $elem"
+        } else {
+          set sub [menu $w.header_menu.layouts.m$elem -tearoff 0]
+          $sub add command -label $elem -state disabled -font font_Bold
+          $sub add separator
+          $sub add command -label [tr Apply] -command "glist.layout_apply [winfo parent $w] $layout $elem"
+          $sub add command -label [tr Rename] -command "glist.layout_rename $elem"
+          $sub add command -label [tr Delete] -command "glist.layout_delete $elem"
+          $w.header_menu.layouts add cascade -label $elem -menu $sub
+        }
       }
     }
     $w.header_menu add cascade -label "Layouts" -menu $w.header_menu.layouts

--- a/tcl/windows/gamelist.tcl
+++ b/tcl/windows/gamelist.tcl
@@ -1014,25 +1014,34 @@ proc glist.layout_rename {layout} {
   set f [ttk::frame $w.buttons]
   pack $f -padx 10 -pady 10 -fill x
 
-  ttk::button $f.ok -text [tr Save] -command "
-    set new_ly \[$w.name get\]
-    if {\$new_ly ne {} && \$new_ly ne {$layout}} {
-      glist.layout_rename_do {$layout} \$new_ly
-    }
-    destroy $w
-  "
-  ttk::button $f.cancel -text [tr Cancel] -command "destroy $w"
+  ttk::button $f.ok -text [tr Save] -command [list glist.layout_rename_validate $w $layout]
+  ttk::button $f.cancel -text [tr Cancel] -command [list destroy $w]
   pack $f.cancel $f.ok -side right -padx 5
 
   bind $w <Return> [list $f.ok invoke]
   bind $w <Escape> [list destroy $w]
 }
 
+proc glist.layout_rename_validate {w layout} {
+  set new_ly [$w.name get]
+  if {$new_ly eq {} || $new_ly eq $layout} {
+    destroy $w
+    return
+  }
+  # Validate the new name - only allow alphanumeric, underscore, and hyphen
+  if {![regexp {^[A-Za-z0-9_-]+$} $new_ly]} {
+    tk_messageBox -icon error -title scidCommunity -message "Invalid layout name. Only letters, numbers, underscore, and hyphen are allowed."
+    return
+  }
+  glist.layout_rename_do $layout $new_ly
+  destroy $w
+}
+
 proc glist.layout_rename_do {old new} {
   set idx [lsearch -exact $::glist_Layouts $old]
   if {$idx == -1} return
   if {[lsearch -exact $::glist_Layouts $new] != -1} {
-    tk_messageBox -icon error -title scidCommunity -message "Layout '$new' already exists."
+    tk_messageBox -icon error -title scidCommunity -message [format $::tr(LayoutExists) $new]
     return
   }
   set ::glist_Layouts [lreplace $::glist_Layouts $idx $idx $new]
@@ -1050,7 +1059,7 @@ proc glist.layout_rename_do {old new} {
 }
 
 proc glist.layout_delete {layout} {
-  set msg "Are you sure you want to delete the layout '$layout'?"
+  set msg [format $::tr(ConfirmDeleteLayout) $layout]
   set answer [tk_messageBox -title scidCommunity -icon question -type yesno -message $msg]
   if {$answer ne "yes"} return
   set idx [lsearch -exact $::glist_Layouts $layout]
@@ -1495,23 +1504,25 @@ proc glist.popupmenu_ {{w} {x} {y} {abs_x} {abs_y} {layout}} {
     #LAYOUTS
     destroy $w.header_menu.layouts
     menu $w.header_menu.layouts
-    $w.header_menu.layouts add command -label $::tr(Save) -command "glist.layout_save $layout"
+    $w.header_menu.layouts add command -label $::tr(Save) -command [list glist.layout_save $layout]
     $w.header_menu.layouts add separator
     $w.header_menu.layouts add command -label $::tr(Defaults) \
-      -command "glist.layout_apply [winfo parent $w] $layout DEFAULT"
+      -command [list glist.layout_apply [winfo parent $w] $layout DEFAULT]
     if {[info exists ::glist_Layouts]} {
+      set idx 0
       foreach elem $::glist_Layouts {
         if {$elem in {RatingDate DateEvent Full}} {
           $w.header_menu.layouts add command -label $elem \
-            -command "glist.layout_apply [winfo parent $w] $layout $elem"
+            -command [list glist.layout_apply [winfo parent $w] $layout $elem]
         } else {
-          set sub [menu $w.header_menu.layouts.m$elem -tearoff 0]
+          set sub [menu $w.header_menu.layouts.m$idx -tearoff 0]
           $sub add command -label $elem -state disabled -font font_Bold
           $sub add separator
-          $sub add command -label [tr Apply] -command "glist.layout_apply [winfo parent $w] $layout $elem"
-          $sub add command -label [tr Rename] -command "glist.layout_rename $elem"
-          $sub add command -label [tr Delete] -command "glist.layout_delete $elem"
+          $sub add command -label [tr Apply] -command [list glist.layout_apply [winfo parent $w] $layout $elem]
+          $sub add command -label [tr Rename] -command [list glist.layout_rename $elem]
+          $sub add command -label [tr Delete] -command [list glist.layout_delete $elem]
           $w.header_menu.layouts add cascade -label $elem -menu $sub
+          incr idx
         }
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rename, delete and save custom game list layouts for better personalization and control.
  * Layout menu now applies default layouts directly; custom layouts show a management submenu with Apply, Rename, and Delete.
  * Save current layout as a custom slot and restore defaults more easily.

* **Localization**
  * Added English translations for "Apply" and "Rename" buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->