### PR TITLE
Allow users to choose FICS background and main text color in the Options/Preferences menu

### DIFF
--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -1604,6 +1604,9 @@ translate E FICSUnrated {Unrated}
 translate E FICSRegisteredPlayer {Registered player only}
 translate E FICSFreePlayer {Free player only}
 translate E FICSNetError {Network error\nCan't connect to }
+translate E OptionsFICS {FICS}
+translate E FICSTerminalColor {Terminal color}
+translate E FICSTextColor {Text color}
 
 # Game review
 translate E GameReview {Game review}

--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -647,6 +647,23 @@ proc configInformant { w } {
 
 ################################################################################
 
+proc configFICS { w } {
+  ttk::label $w.lterm -text [::tr FICSTerminalColor]
+  canvas $w.termSample -width 30 -height 20 -background $::fics::consolebg -highlightthickness 1
+  ttk::button $w.bterm -text "..." -command [list ::fics::chooseTerminalColor $w.termSample]
+
+  ttk::label $w.ltext -text [::tr FICSTextColor]
+  canvas $w.textSample -width 30 -height 20 -background $::fics::consolefg -highlightthickness 1
+  ttk::button $w.btext -text "..." -command [list ::fics::chooseTextColor $w.textSample]
+
+  grid $w.lterm -row 0 -column 0 -sticky w -padx "0 10"
+  grid $w.termSample -row 0 -column 1 -padx "0 5"
+  grid $w.bterm -row 0 -column 2
+  grid $w.ltext -row 1 -column 0 -sticky w -padx "0 10" -pady "10 0"
+  grid $w.textSample -row 1 -column 1 -padx "0 5" -pady "10 0"
+  grid $w.btext -row 1 -column 2 -pady "10 0"
+}
+
 proc getBooksDir { widget } {
   global scidBooksDir
   set dir [tk_chooseDirectory -initialdir $scidBooksDir -parent [winfo toplevel $widget] -mustexist 1]

--- a/tcl/tools/fics.tcl
+++ b/tcl/tools/fics.tcl
@@ -1829,6 +1829,28 @@ namespace eval fics {
     if { ! $::windowsOS } { catch { exec -- kill -s INT [ $::fics::timeseal_pid ] }  }
     ::win::closeWindow .fics
   }
+  ################################################################################
+  # Choose the background color for the FICS console
+  ################################################################################
+  proc chooseTerminalColor { {sample ""} } {
+    set color [tk_chooseColor -initialcolor $::fics::consolebg -title [::tr FICSTerminalColor]]
+    if {$color ne ""} {
+      set ::fics::consolebg $color
+      if {$sample ne ""} { catch {$sample configure -background $color} }
+      catch {.fics.f.top.fconsole.f1.console configure -bg $color}
+    }
+  }
+  ################################################################################
+  # Choose the text (foreground) color for the FICS console
+  ################################################################################
+  proc chooseTextColor { {sample ""} } {
+    set color [tk_chooseColor -initialcolor $::fics::consolefg -title [::tr FICSTextColor]]
+    if {$color ne ""} {
+      set ::fics::consolefg $color
+      if {$sample ne ""} { catch {$sample configure -background $color} }
+      catch {.fics.f.top.fconsole.f1.console configure -fg $color}
+    }
+  }
 }
 ###
 ### End of file: fics.tcl

--- a/tcl/windows/preferences.tcl
+++ b/tcl/windows/preferences.tcl
@@ -64,6 +64,7 @@ proc ::preferences::Open { {toggle ""} } {
   lappend configList [tr OptionsSounds] ::utils::sound::OptionsDialog
   lappend configList [tr OptionsMoves] ::preferences::moves
   lappend configList [tr ConfigureInformant] configInformant
+  lappend configList [tr OptionsFICS] configFICS
   set maxlen 0
   ### create the dialogs
   foreach {m init} $configList {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FICS color customization options to the preferences dialog, allowing users to configure terminal and text colors for the FICS console.

* **Localization**
  * Added new English translation strings for FICS menu labels and color settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->