### PR TITLE
Only open one clipbase window for Lichess OpenExplore

### DIFF
--- a/tcl/tools/lichess_openex.tcl
+++ b/tcl/tools/lichess_openex.tcl
@@ -1093,8 +1093,19 @@ proc ::lichess_openex::loadGame {gameId} {
         return
     }
 
-    # Open the game list window for clipbase
-    catch { ::windows::gamelist::Open $::clipbase_db }
+    # Open the game list window for clipbase, or refresh if already open
+    set found 0
+    foreach glwin $::windows::gamelist::wins {
+        if {[info exists ::gamelistBase($glwin)] && $::gamelistBase($glwin) == $::clipbase_db} {
+            ::windows::gamelist::Refresh 1 [list $glwin]
+            ::win::makeVisible $glwin
+            set found 1
+            break
+        }
+    }
+    if {!$found} {
+        catch { ::windows::gamelist::Open $::clipbase_db }
+    }
 
     tk_messageBox -icon info -type ok -title "Lichess Opening Explorer" \
         -message "Game loaded into clipbase successfully."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gamelist window handling when importing Lichess games. The application now checks whether a gamelist window is already open for the current database and refreshes it rather than always opening a new window, providing a smoother user experience and reducing window clutter.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whelanh/scidCommunity/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->