### PR TITLE
chore: rename evaluation symbols to annotation symbols across languag…

### DIFF
--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -252,7 +252,7 @@ menuText K OptionsMovesHighlightLastMoveDisplay "Mostra casella" 0 {Ressalta la 
 menuText K OptionsMovesHighlightLastMoveWidth "Gruix" 0 {Gruix de línia}
 menuText K OptionsMovesHighlightLastMoveColor "Color" 0 {Color de línia}
 menuText K OptionsMovesHighlightLastMoveArrow "Mostra fletxa" 0 {Inclou fletxa amb ressaltat}
-menuText K OptionsMovesHighlightLastMoveNag "Mostra símbols d'avaluació" 0
+menuText K OptionsMovesHighlightLastMoveNag "Mostra símbols d'anotació" 0
 menuText K OptionsMovesHighlightLastMoveEval "Mostra símbols d'avaluació" 0
 menuText K OptionsMoves "Jugades" 0 {Opcions d'entrada de jugades}
 menuText K OptionsMovesAnimate "Velocitat d'animació" 1 \

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -209,7 +209,7 @@ menuText M OptionsMovesHighlightLastMoveDisplay "显示格子" 0 {显示最后�
 menuText M OptionsMovesHighlightLastMoveWidth "宽度" 0 {线条粗细}
 menuText M OptionsMovesHighlightLastMoveColor "Color" 0 {线条颜色}
 menuText M OptionsMovesHighlightLastMoveArrow "显示箭头" 0 {显示带高亮的箭头}
-menuText M OptionsMovesHighlightLastMoveNag "显示评估符号" 0
+menuText M OptionsMovesHighlightLastMoveNag "显示注解符号" 0
 menuText M OptionsMovesHighlightLastMoveEval "显示评估符号" 0
 menuText M OptionsMoves "着法" 0 {着法输入选项}
 menuText M OptionsMovesAnimate "动画时间" 1 \

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -235,7 +235,7 @@ menuText C OptionsMovesHighlightLastMoveDisplay "Ukzat" 0 {Zobrazit zvraznn posl
 menuText C OptionsMovesHighlightLastMoveWidth "ka" 0 {Tlouka ry}
 menuText C OptionsMovesHighlightLastMoveColor "Barva" 0 {Barva ry}
 menuText C OptionsMovesHighlightLastMoveArrow "vetn Arrow" 0 {Zahrnout ipku se zvraznnm}
-menuText C OptionsMovesHighlightLastMoveNag "Zobrazit symboly hodnocen" 0
+menuText C OptionsMovesHighlightLastMoveNag "Zobrazit symboly komentářů" 0
 menuText C OptionsMovesHighlightLastMoveEval "Zobrazit symboly hodnocen" 0
 menuText C OptionsMoves "Tahy" 0 {Volby pro zadvn tah}
 menuText C OptionsMovesAnimate "as animace" 4 \

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -247,7 +247,7 @@ menuText F OptionsMovesHighlightLastMoveDisplay "Afficher Cases" 0 {Afficher la 
 menuText F OptionsMovesHighlightLastMoveWidth "Epaisseur" 0 {Epaisseur de la ligne}
 menuText F OptionsMovesHighlightLastMoveColor "Couleur" 0 {Couleur de la ligne}
 menuText F OptionsMovesHighlightLastMoveArrow "Afficher Flèche" 0 {Afficher la flèche de déplacement du dernier coup}
-menuText F OptionsMovesHighlightLastMoveNag "Afficher les symboles d'évaluation" 0
+menuText F OptionsMovesHighlightLastMoveNag "Afficher les symboles d'annotation" 0
 menuText F OptionsMovesHighlightLastMoveEval "Afficher les symboles d'évaluation" 0
 menuText F OptionsMoves "Coups" 2 {Gestion des coups}
 menuText F OptionsMovesAnimate "Temps d'animation" 1 \

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -265,7 +265,7 @@ menuText G OptionsMovesHighlightLastMoveDisplay "Εμφάνιση" 0 {Προβο
 menuText G OptionsMovesHighlightLastMoveWidth "Πλάτος" 0 {Το πάχος της γραμμής}
 menuText G OptionsMovesHighlightLastMoveColor "Χρώμα" 0 {Το χρώμα τηςη γραμμής}
 menuText G OptionsMovesHighlightLastMoveArrow "Εμφάνιση βέλους" 0 {Εμφάνιση βέλους με επισήμανση}
-menuText G OptionsMovesHighlightLastMoveNag "Εμφάνιση συμβόλων αξιολόγησης" 0
+menuText G OptionsMovesHighlightLastMoveNag "Εμφάνιση συμβόλων σχολιασμού" 0
 menuText G OptionsMovesHighlightLastMoveEval "Εμφάνιση συμβόλων αξιολόγησης" 0
 menuText G OptionsMoves "Κινήσεις" 0 {Επιλογές εισαγωγής κίνησης}
 menuText G OptionsMovesAnimate "Χρόνος απεικόνισης κίνησης" 1 \

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -239,7 +239,7 @@ menuText H OptionsMovesHighlightLastMoveDisplay "Show Square" 0 {Utolsó lépés
 menuText H OptionsMovesHighlightLastMoveWidth "Szélesség" 0 {A vonal vastagsága}
 menuText H OptionsMovesHighlightLastMoveColor "Szín" 0 {A vonal színe}
 menuText H OptionsMovesHighlightLastMoveArrow "Nyíl megjelenítése" 0 {Tartalmazza a nyilat a kiemeléssel}
-menuText H OptionsMovesHighlightLastMoveNag "Értékelési szimbólumok megjelenítése" 0
+menuText H OptionsMovesHighlightLastMoveNag "Megjegyzési szimbólumok megjelenítése" 0
 menuText H OptionsMovesHighlightLastMoveEval "Az értékelési szimbólumok megjelenítése" 0
 menuText H OptionsMoves "Lépések" 0 {Lépések bevitelének beállításai}
 menuText H OptionsMovesAnimate "Megelevenítés ideje" 0 \

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -239,7 +239,7 @@ menuText I OptionsMovesHighlightLastMoveDisplay "Mostra Caselle" 0 {Mostra in ev
 menuText I OptionsMovesHighlightLastMoveWidth "Larghezza" 0 {Spessore della linea}
 menuText I OptionsMovesHighlightLastMoveColor "Colore" 0 {Colore della linea}
 menuText I OptionsMovesHighlightLastMoveArrow "Mostra freccia" 0 {Mostra una freccia}
-menuText I OptionsMovesHighlightLastMoveNag "Mostra i simboli di valutazione" 0
+menuText I OptionsMovesHighlightLastMoveNag "Mostra i simboli di annotazione" 0
 menuText I OptionsMovesHighlightLastMoveEval "Mostra i simboli di valutazione" 0
 menuText I OptionsMoves "Mosse" 0 {Opzioni di immissione delle mosse}
 menuText I OptionsMovesAnimate "Intervallo di tempo per l'animazione delle mosse" 4 \

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -274,7 +274,7 @@ menuText A OptionsMovesHighlightLastMoveDisplay "ショースクエア" 0 {最�
 menuText A OptionsMovesHighlightLastMoveWidth "幅" 0 {線の太さ}
 menuText A OptionsMovesHighlightLastMoveColor "色" 0 {線の色}
 menuText A OptionsMovesHighlightLastMoveArrow "矢印を表示" 0 {ハイライト付きの矢印を表示する}
-menuText A OptionsMovesHighlightLastMoveNag "評価記号を表示" 0
+menuText A OptionsMovesHighlightLastMoveNag "注釈記号を表示" 0
 menuText A OptionsMovesHighlightLastMoveEval "評価記号を表示" 0
 menuText A OptionsMoves "移動" 0 {移動エントリオプション}
 menuText A OptionsMovesAnimate "アニメーション時間" 1 \

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -258,7 +258,7 @@ menuText N OptionsMovesHighlightLastMoveDisplay "Toon Vakken" 0 {Toon de laatste
 menuText N OptionsMovesHighlightLastMoveWidth "Breedte" 0 {Variantdikte}
 menuText N OptionsMovesHighlightLastMoveColor "Kleur" 0 {Varinatkleur}
 menuText N OptionsMovesHighlightLastMoveArrow "Pijl tonen" 0 {Show Arrow with Highlight}
-menuText N OptionsMovesHighlightLastMoveNag "Evaluatie-symbolen tonen" 0
+menuText N OptionsMovesHighlightLastMoveNag "Annotatiesymbolen tonen" 0
 menuText N OptionsMovesHighlightLastMoveEval "Evaluatiesymbolen tonen" 0
 menuText N OptionsMoves "Zetten" 0 {Wijzig optie voor zet-invoer}
 menuText N OptionsMovesAnimate "Stuk Animatietijd " 1 \

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -241,7 +241,7 @@ menuText O OptionsMovesHighlightLastMoveDisplay "Vis Square" 0 {Vis siste trekk 
 menuText O OptionsMovesHighlightLastMoveWidth "Bredde" 0 {Tykkelse på linjen}
 menuText O OptionsMovesHighlightLastMoveColor "Farge" 0 {Farge på linjen}
 menuText O OptionsMovesHighlightLastMoveArrow "Vis pil" 0 {Vis pil med utheving}
-menuText O OptionsMovesHighlightLastMoveNag "Vis evalueringssymboler" 0
+menuText O OptionsMovesHighlightLastMoveNag "Vis kommentarsymboler" 0
 menuText O OptionsMovesHighlightLastMoveEval "Vis evalueringssymboler" 0
 menuText O OptionsMoves "Trekk" 0 {Innstillinger for hvordan trekk angis}
 menuText O OptionsMovesAnimate "Animation time" 1 \

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -251,7 +251,7 @@ menuText P OptionsMovesHighlightLastMoveDisplay "Poka kwadrat" 0 {Wywietlanie os
 menuText P OptionsMovesHighlightLastMoveWidth "Szeroko" 0 {Grubo linii}
 menuText P OptionsMovesHighlightLastMoveColor "Kolor" 0 {Kolor linii}
 menuText P OptionsMovesHighlightLastMoveArrow "Poka strzak" 0 {Poka strzak z podwietleniem}
-menuText P OptionsMovesHighlightLastMoveNag "Poka symbol oceny" 0
+menuText P OptionsMovesHighlightLastMoveNag "Poka symbole adnotacji" 0
 menuText P OptionsMovesHighlightLastMoveEval "Poka symbole oceny" 0
 menuText P OptionsMoves "Posunicia" 0 {Wprowadzanie posuni}
 menuText P OptionsMovesAnimate "Szybko animacji" 1 \

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -240,7 +240,7 @@ menuText B OptionsMovesHighlightLastMoveDisplay "Mostrar Casas" 0 {Mostra o dest
 menuText B OptionsMovesHighlightLastMoveWidth "Espessura" 0 {Espessura da linha}
 menuText B OptionsMovesHighlightLastMoveColor "Cor" 0 {Cor da linha}
 menuText B OptionsMovesHighlightLastMoveArrow "Mostrar Seta" 0 {Seta de Inclusão Destacada}
-menuText B OptionsMovesHighlightLastMoveNag "Mostrar símbolos de avaliação" 0
+menuText B OptionsMovesHighlightLastMoveNag "Mostrar símbolos de anotação" 0
 menuText B OptionsMovesHighlightLastMoveEval "Mostrar símbolos de avaliação" 0
 menuText B OptionsMoves "Movimentos" 0 {Opções para entrada dos movimentos}
 menuText B OptionsMovesAnimate "Tempo de animação" 1 \

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -274,7 +274,7 @@ menuText L OptionsMovesHighlightLastMoveDisplay "Afișează Square" 0 {Afișeaz�
 menuText L OptionsMovesHighlightLastMoveWidth "Lăţime" 0 {Grosimea liniei}
 menuText L OptionsMovesHighlightLastMoveColor "Culoare" 0 {Culoarea liniei}
 menuText L OptionsMovesHighlightLastMoveArrow "Arată săgeata" 0 {Afișați o săgeată cu Evidențiere}
-menuText L OptionsMovesHighlightLastMoveNag "Afișați simbolurile de evaluare" 0
+menuText L OptionsMovesHighlightLastMoveNag "Afișați simbolurile de adnotare" 0
 menuText L OptionsMovesHighlightLastMoveEval "Afișați simbolurile de evaluare" 0
 menuText L OptionsMoves "Mișcări" 0 {Mutați opțiunile de intrare}
 menuText L OptionsMovesAnimate "Timp de animație" 1 \

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -240,7 +240,7 @@ menuText R OptionsMovesHighlightLastMoveDisplay "Показать Поле" 0 {�
 menuText R OptionsMovesHighlightLastMoveWidth "Толщина" 0 {Толщина линии}
 menuText R OptionsMovesHighlightLastMoveColor "Цвет" 0 {Цвет линии}
 menuText R OptionsMovesHighlightLastMoveArrow "Показать стрелку" 0 {Включить стрелки с подсветкой}
-menuText R OptionsMovesHighlightLastMoveNag "Показать символы комментариев" 0
+menuText R OptionsMovesHighlightLastMoveNag "Показать символы аннотаций" 0
 menuText R OptionsMovesHighlightLastMoveEval "Показать символы оценки" 0
 menuText R OptionsMoves "Ходы" 0 {Установки для ходов}
 menuText R OptionsMovesAnimate "Время анимации" 1 \

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -240,7 +240,7 @@ menuText R OptionsMovesHighlightLastMoveDisplay "Показать Поле" 0 {�
 menuText R OptionsMovesHighlightLastMoveWidth "Толщина" 0 {Толщина линии}
 menuText R OptionsMovesHighlightLastMoveColor "Цвет" 0 {Цвет линии}
 menuText R OptionsMovesHighlightLastMoveArrow "Показать стрелку" 0 {Включить стрелки с подсветкой}
-menuText R OptionsMovesHighlightLastMoveNag "Показать символы оценки" 0
+menuText R OptionsMovesHighlightLastMoveNag "Показать символы комментариев" 0
 menuText R OptionsMovesHighlightLastMoveEval "Показать символы оценки" 0
 menuText R OptionsMoves "Ходы" 0 {Установки для ходов}
 menuText R OptionsMovesAnimate "Время анимации" 1 \

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -260,7 +260,7 @@ menuText S OptionsMovesHighlightLastMoveDisplay "Mostrar Escaques" 0 \
 menuText S OptionsMovesHighlightLastMoveWidth "Ancho" 0 {Espesor de la línea}
 menuText S OptionsMovesHighlightLastMoveColor "Color" 0 {Color de línea}
 menuText S OptionsMovesHighlightLastMoveArrow "Mostrar Flechas" 0 {Show Arrow with Highlight}
-menuText S OptionsMovesHighlightLastMoveNag "Mostrar símbolos de evaluación" 0
+menuText S OptionsMovesHighlightLastMoveNag "Mostrar símbolos de anotación" 0
 menuText S OptionsMovesHighlightLastMoveEval "Mostrar símbolos de evaluación" 0
 menuText S OptionsMoves "Movimientos" 0 {Opciones de la entrada de movimientos}
 menuText S OptionsMovesAnimate "Velocidad de la animación" 1 \

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -272,7 +272,7 @@ menuText U OptionsMovesHighlightLastMoveDisplay "Näytä" 0 {Näytä viimeisin s
 menuText U OptionsMovesHighlightLastMoveWidth "Viiva" 0 {Laudalla näytettävän viivan paksuus}
 menuText U OptionsMovesHighlightLastMoveColor "Väri" 0 {Laudalla näytettävän viivan väri}
 menuText U OptionsMovesHighlightLastMoveArrow "Sis. nuoli" 0 {Korostettuun siirtoon sisällytetään nuoli}
-menuText U OptionsMovesHighlightLastMoveNag "Näytä arviointisymbolit" 0
+menuText U OptionsMovesHighlightLastMoveNag "Näytä annotaatiosymbolit" 0
 menuText U OptionsMovesHighlightLastMoveEval "Näytä arviointisymbolit" 0
 menuText U OptionsMoves "Siirrot" 0 {Siirtojen syöttämiseen liittyvät asetukset}
 menuText U OptionsMovesAnimate "Animaation nopeus" 1 \

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -242,7 +242,7 @@ menuText W OptionsMovesHighlightLastMoveDisplay "Visa" 0 {Visa senaste markerade
 menuText W OptionsMovesHighlightLastMoveWidth "Bredd" 0 {Tjockhet på rad}
 menuText W OptionsMovesHighlightLastMoveColor "Färg" 0 {Färg på rad}
 menuText W OptionsMovesHighlightLastMoveArrow "Visa pil" 0 {Visa pil med markering}
-menuText W OptionsMovesHighlightLastMoveNag "Visa utvärderingssymboler" 0
+menuText W OptionsMovesHighlightLastMoveNag "Visa kommentarsymboler" 0
 menuText W OptionsMovesHighlightLastMoveEval "Visa utvärderingssymboler" 0
 menuText W OptionsMoves "Drag" 0 {Alternativ för dragangivelse}
 menuText W OptionsMovesAnimate "Fördröjning vid manuellt spel" 1 \

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -237,7 +237,7 @@ menuText T OptionsMovesHighlightLastMoveDisplay "Kareyi Göster" 0 {Son hamleyi 
 menuText T OptionsMovesHighlightLastMoveWidth "Genişlik" 0 {Çizgi kalınlığı}
 menuText T OptionsMovesHighlightLastMoveColor "Renk" 0 {Çizgi rengi}
 menuText T OptionsMovesHighlightLastMoveArrow "Ok Göster" 0 {Vurgulu Bir Ok Göster}
-menuText T OptionsMovesHighlightLastMoveNag "Değerlendirme sembollerini göster" 0
+menuText T OptionsMovesHighlightLastMoveNag "Açıklama sembollerini göster" 0
 menuText T OptionsMovesHighlightLastMoveEval "Değerlendirme sembollerini göster" 0
 menuText T OptionsMoves "Hareketler" 0 {Giriş seçeneklerini taşı}
 menuText T OptionsMovesAnimate "Animasyon Süresi" 1 \


### PR DESCRIPTION
…e files for the Preferences selections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated menu item translations in 17 languages (Catalan, Chinese, Czech, French, Greek, Hungarian, Italian, Japanese, Dutch, Norwegian, Polish, Romanian, Russian, Spanish, Finnish, Swedish, Turkish) to clarify the option refers to annotation/comment symbols rather than evaluation symbols.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whelanh/scidCommunity/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->