### PR TITLE
Mousewheel fix win32

### DIFF
--- a/tcl/misc.tcl
+++ b/tcl/misc.tcl
@@ -48,8 +48,8 @@ proc bindMouseWheel {bindtag callback} {
 	    }
 	}
 	win32 {
-	    bind $bindtag <<MWheel>> "[append callback { [expr {-(%d/120)}]}]; break"
-	}
+      bind $bindtag <MouseWheel> "[append callback { [expr {-%D/120}]}]; break"
+  }
 	aqua {
 	    bind $bindtag <MouseWheel> "[append callback { [expr {-(%D)}]} ]; break"
 	}


### PR DESCRIPTION
Hey!

I noticed scroll wasn't working across the app on Windows.  

I've made a commit that changes the win32 branch of logic to use the same <MouseWheel> binding as aqua and X11.  Also I switched %d to %D in the callback string, as it was causing errors.  I looked into it and a %d in this case is detail and %D delta, so I'm confident this is a good fix. 

The last change on the line noted they were using <<MWheel>> to allow for scroll even after window focus loss, but that no longer seems to be an issue. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse-wheel handling on Windows to restore consistent scroll direction and smoother, more reliable scrolling while preserving existing callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->