### PR TITLE
Add dedicated Tablebase Window (based solely on Lichess API query)

### DIFF
--- a/tcl/game.tcl
+++ b/tcl/game.tcl
@@ -426,6 +426,7 @@ namespace eval ::notify {
     updateAnalysis 1
     updateAnalysis 2
     ::windows::commenteditor::Refresh
+    ::tablebase::window::results
     if {[winfo exists .twinchecker]} { updateTwinChecker }
     if {[winfo exists .bookWin]} { ::book::refresh }
     if {[winfo exists .bookTuningWin]} { ::book::refreshTuning }

--- a/tcl/keyboard.tcl
+++ b/tcl/keyboard.tcl
@@ -95,6 +95,7 @@ proc keyboardShortcuts {w} {
 	bind $w <Control-P> ::plist::toggle
 	bind $w <Control-T> ::tourney::toggle
 	bind $w <Control-X> ::crosstab::Open
+	bind $w <Control-equal> ::tablebase::window::Open
 	bind $w <Control-x> { if {![excludeTextWidget %W]} { ::game::ToggleDeleteFlag } }
 
 

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -1798,6 +1798,7 @@ translate J TBTooMany {Превише комада. Лицхесс постољ�
 translate J TBQuerying {Querying Lichess API...}
 translate J TBError {Грешка при покретању цурл-а за упит Лицхесс-а.}
 translate J TBNotFound {Позиција није пронађена у бази табеле или грешка у АПИ-ју.}
+translate J TBQueryError {Грешка: неисправан одговор Лицхесс-а.}
 translate J TBCategory {Категорија позиције:}
 translate J TBTrainingHidden {(Режим обуке; резултати су скривени)}
 }

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -1789,5 +1789,16 @@ translate J BatchCancel {Откажи}
 translate J BatchCompleted {завршено}
 translate J BatchGames {игрице}
 translate J BatchProcessed {обрађене}
+translate J TablebaseWindow {Таблебасе Виндов}
+translate J TBWinMoves {--- Победнички потези ---}
+translate J TBDrawMoves {--- Покрети цртања ---}
+translate J TBLossMoves {--- Губитни потези ---}
+translate J TBNoMoves {Није пронађен ниједан правни потез.}
+translate J TBTooMany {Превише комада. Лицхесс постоље за сто подржава до 7 комада.}
+translate J TBQuerying {Querying Lichess API...}
+translate J TBError {Грешка при покретању цурл-а за упит Лицхесс-а.}
+translate J TBNotFound {Позиција није пронађена у бази табеле или грешка у АПИ-ју.}
+translate J TBCategory {Категорија позиције:}
+translate J TBTrainingHidden {(Режим обуке; резултати су скривени)}
 }
 # end of english.tcl

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -1748,5 +1748,16 @@ translate b BatchCancel {বাতিল করুন}
 translate b BatchCompleted {সম্পন্ন}
 translate b BatchGames {গেম}
 translate b BatchProcessed {প্রক্রিয়া করা}
+translate b TablebaseWindow {টেবিলবেস উইন্ডো}
+translate b TBWinMoves {--- উইনিং মুভ ---}
+translate b TBDrawMoves {--- অঙ্কন চালনা ---}
+translate b TBLossMoves {--- হারানো চালগুলি ---}
+translate b TBNoMoves {কোন আইনি পদক্ষেপ পাওয়া যায়নি.}
+translate b TBTooMany {অনেক টুকরা. লিচেস টেবিলবেস 7 টুকরা পর্যন্ত সমর্থন করে।}
+translate b TBQuerying {Lichess API জিজ্ঞাসা করা হচ্ছে...}
+translate b TBError {Lichess ক্যোয়ারী করতে কার্ল চালু করতে ত্রুটি৷}
+translate b TBNotFound {টেবিলবেস বা API ত্রুটিতে অবস্থান পাওয়া যায়নি।}
+translate b TBCategory {অবস্থান বিভাগ:}
+translate b TBTrainingHidden {(প্রশিক্ষণ মোড; ফলাফল লুকানো আছে)}
 }
 # end of english.tcl

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -1789,5 +1789,16 @@ translate g BatchCancel {Отказ}
 translate g BatchCompleted {завършен}
 translate g BatchGames {игри}
 translate g BatchProcessed {обработени}
+translate g TablebaseWindow {Прозорец на таблична база}
+translate g TBWinMoves {--- Печеливши движения ---}
+translate g TBDrawMoves {--- Движения за рисуване ---}
+translate g TBLossMoves {--- Губещи ходове ---}
+translate g TBNoMoves {Няма открити законни ходове.}
+translate g TBTooMany {Твърде много парчета. Базата за маса Lichess поддържа до 7 части.}
+translate g TBQuerying {Извършва се заявка за API на Lichess...}
+translate g TBError {Грешка при стартиране на curl за заявка на Lichess.}
+translate g TBNotFound {Позицията не е намерена в табличната база или грешка в API.}
+translate g TBCategory {Категория на позицията:}
+translate g TBTrainingHidden {(Режим на обучение; резултатите са скрити)}
 }
-# end of bulgarian.tcl
+# end of english.tcl

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -1798,6 +1798,7 @@ translate g TBTooMany {Твърде много парчета. Базата за
 translate g TBQuerying {Извършва се заявка за API на Lichess...}
 translate g TBError {Грешка при стартиране на curl за заявка на Lichess.}
 translate g TBNotFound {Позицията не е намерена в табличната база или грешка в API.}
+translate g TBQueryError {Невалиден отговор от API на табличната база.}
 translate g TBCategory {Категория на позицията:}
 translate g TBTrainingHidden {(Режим на обучение; резултатите са скрити)}
 }

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -1793,5 +1793,16 @@ translate K BatchCancel {Cancel·la}
 translate K BatchCompleted {completat}
 translate K BatchGames {jocs}
 translate K BatchProcessed {processats}
+translate K TablebaseWindow {Finestra Tablebase}
+translate K TBWinMoves {--- Moviments guanyadors ---}
+translate K TBDrawMoves {--- Dibuix moviments ---}
+translate K TBLossMoves {--- Moviments perduts ---}
+translate K TBNoMoves {No s'han trobat moviments legals.}
+translate K TBTooMany {Massa peces. La base de taula Lichess admet fins a 7 peces.}
+translate K TBQuerying {Consultant l'API de Lichess...}
+translate K TBError {S'ha produït un error en iniciar curl per consultar Lichess.}
+translate K TBNotFound {No s'ha trobat la posició a la base de taules o error de l'API.}
+translate K TBCategory {Categoria de la posició:}
+translate K TBTrainingHidden {(Mode d'entrenament; els resultats estan ocults)}
 }
 # end of english.tcl

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1724,5 +1724,16 @@ translate M BatchCancel {取消}
 translate M BatchCompleted {完全的}
 translate M BatchGames {游戏}
 translate M BatchProcessed {加工过的}
+translate M TablebaseWindow {表库窗口}
+translate M TBWinMoves {--- 制胜之举 ---}
+translate M TBDrawMoves {--- 绘图动作 ---}
+translate M TBLossMoves {--- 失败动作 ---}
+translate M TBNoMoves {未发现合法动作。}
+translate M TBTooMany {太多了。 Lichess 桌底座最多可容纳 7 块。}
+translate M TBQuerying {正在查询 Lichess API...}
+translate M TBError {启动curl 查询Lichess 时出错。}
+translate M TBNotFound {在表库中找不到位置或 API 错误。}
+translate M TBCategory {职位类别：}
+translate M TBTrainingHidden {（训练模式；结果隐藏）}
 }
 # end of english.tcl

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1733,6 +1733,7 @@ translate M TBTooMany {太多了。 Lichess 桌底座最多可容纳 7 块。}
 translate M TBQuerying {正在查询 Lichess API...}
 translate M TBError {启动curl 查询Lichess 时出错。}
 translate M TBNotFound {在表库中找不到位置或 API 错误。}
+translate M TBQueryError {表库 API 的响应无效。}
 translate M TBCategory {职位类别：}
 translate M TBTrainingHidden {（训练模式；结果隐藏）}
 }

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -1771,5 +1771,16 @@ translate C BatchCancel {Zru¹it}
 translate C BatchCompleted {dokonèeno}
 translate C BatchGames {hry}
 translate C BatchProcessed {zpracováno}
+translate C TablebaseWindow {Okno tabulky}
+translate C TBWinMoves {--- Vítězné tahy ---}
+translate C TBDrawMoves {--- Kreslící pohyby ---}
+translate C TBLossMoves {--- Ztráta tahů ---}
+translate C TBNoMoves {Nebyly nalezeny žádné legální kroky.}
+translate C TBTooMany {Příliš mnoho kusů. Stolová podnož Lichess podporuje až 7 kusů.}
+translate C TBQuerying {Dotazování Lichess API...}
+translate C TBError {Chyba při spouštění curl pro dotaz Lichess.}
+translate C TBNotFound {Pozice nebyla nalezena v tabulce nebo chyba API.}
+translate C TBCategory {Kategorie pozice:}
+translate C TBTrainingHidden {(Tréninkový režim; výsledky jsou skryté)}
 }
 # end of english.tcl

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -1820,5 +1820,16 @@ translate D BatchCancel {Stornieren}
 translate D BatchCompleted {vollendet}
 translate D BatchGames {Spiele}
 translate D BatchProcessed {verarbeitet}
+translate D TablebaseWindow {Tablebase-Fenster}
+translate D TBWinMoves {--- Gewinnzüge ---}
+translate D TBDrawMoves {--- Zeichenbewegungen ---}
+translate D TBLossMoves {--- Züge verlieren ---}
+translate D TBNoMoves {Keine legalen Schritte gefunden.}
+translate D TBTooMany {Zu viele Stücke. Der Lichess-Tischfuß trägt bis zu 7 Teile.}
+translate D TBQuerying {Lichess-API wird abgefragt...}
+translate D TBError {Fehler beim Starten von Curl zur Abfrage von Lichess.}
+translate D TBNotFound {Position in der Tabellenbasis nicht gefunden oder API-Fehler.}
+translate D TBCategory {Positionskategorie:}
+translate D TBTrainingHidden {(Trainingsmodus; Ergebnisse werden ausgeblendet)}
 }
 # end of english.tcl

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -1811,6 +1811,7 @@ translate E TBNoMoves {No legal moves found.}
 translate E TBTooMany {Too many pieces. Lichess tablebase supports up to 7 pieces.}
 translate E TBQuerying {Querying Lichess API...}
 translate E TBError {Error launching curl to query Lichess.}
+translate E TBQueryError {Invalid response from tablebase API.}
 translate E TBNotFound {Position not found in tablebase or API error.}
 translate E TBCategory {Position Category:}
 translate E TBTrainingHidden {(Training mode; results are hidden)}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -1803,5 +1803,16 @@ translate E BatchCancel {Cancel}
 translate E BatchCompleted {completed}
 translate E BatchGames {games}
 translate E BatchProcessed {processed}
+translate E TablebaseWindow {Tablebase Window}
+translate E TBWinMoves {--- Winning Moves ---}
+translate E TBDrawMoves {--- Drawing Moves ---}
+translate E TBLossMoves {--- Losing Moves ---}
+translate E TBNoMoves {No legal moves found.}
+translate E TBTooMany {Too many pieces. Lichess tablebase supports up to 7 pieces.}
+translate E TBQuerying {Querying Lichess API...}
+translate E TBError {Error launching curl to query Lichess.}
+translate E TBNotFound {Position not found in tablebase or API error.}
+translate E TBCategory {Position Category:}
+translate E TBTrainingHidden {(Training mode; results are hidden)}
 }
 # end of english.tcl

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -1777,5 +1777,16 @@ translate F BatchCancel {Annuler}
 translate F BatchCompleted {complété}
 translate F BatchGames {jeux}
 translate F BatchProcessed {traité}
+translate F TablebaseWindow {Fenêtre de la base de table}
+translate F TBWinMoves {--- Mouvements gagnants ---}
+translate F TBDrawMoves {--- Mouvements de dessin ---}
+translate F TBLossMoves {--- Coups perdus ---}
+translate F TBNoMoves {Aucun mouvement légal trouvé.}
+translate F TBTooMany {Trop de pièces. La base de table Lichess prend en charge jusqu'à 7 pièces.}
+translate F TBQuerying {Interrogation de l'API Lichess...}
+translate F TBError {Erreur lors du lancement de curl pour interroger Lichess.}
+translate F TBNotFound {Position introuvable dans la base de table ou erreur API.}
+translate F TBCategory {Catégorie de poste :}
+translate F TBTrainingHidden {(Mode Entraînement ; les résultats sont masqués)}
 }
 # end of english.tcl

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -1798,5 +1798,16 @@ translate G BatchCancel {Ματαίωση}
 translate G BatchCompleted {ολοκληρώθηκε το}
 translate G BatchGames {παιχνίδια}
 translate G BatchProcessed {επεξεργασμένα}
+translate G TablebaseWindow {Παράθυρο βάσης πίνακα}
+translate G TBWinMoves {--- Κινήσεις που κερδίζουν ---}
+translate G TBDrawMoves {--- Κινήσεις σχεδίασης ---}
+translate G TBLossMoves {--- Χάνοντας κινήσεις ---}
+translate G TBNoMoves {Δεν βρέθηκαν νομικές κινήσεις.}
+translate G TBTooMany {Πάρα πολλά κομμάτια. Η επιτραπέζια βάση Lichess υποστηρίζει έως και 7 κομμάτια.}
+translate G TBQuerying {Querying Lichess API...}
+translate G TBError {Σφάλμα κατά την εκκίνηση του curl στο ερώτημα Lichess.}
+translate G TBNotFound {Η θέση δεν βρέθηκε στη βάση του πίνακα ή σφάλμα API.}
+translate G TBCategory {Κατηγορία θέσης:}
+translate G TBTrainingHidden {(Λειτουργία προπόνησης, τα αποτελέσματα είναι κρυφά)}
 }
 # end of english.tcl

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -1749,5 +1749,16 @@ translate V BatchCancel {לְבַטֵל}
 translate V BatchCompleted {הושלם}
 translate V BatchGames {משחקים}
 translate V BatchProcessed {מְעוּבָּד}
+translate V TablebaseWindow {חלון בסיס שולחן}
+translate V TBWinMoves {--- מהלכים מנצחים ---}
+translate V TBDrawMoves {--- ציור מהלכים ---}
+translate V TBLossMoves {--- מהלכים מפסידים ---}
+translate V TBNoMoves {לא נמצאו מהלכים חוקיים.}
+translate V TBTooMany {יותר מדי חתיכות. בסיס השולחן של ליצ'ס תומך בעד 7 חלקים.}
+translate V TBQuerying {מחפש את ממשק API של Lichess...}
+translate V TBError {שגיאה בהפעלת תלתל לשאילתה של Lichess.}
+translate V TBNotFound {המיקום לא נמצא בבסיס הטבלה או בשגיאת API.}
+translate V TBCategory {קטגוריית תפקיד:}
+translate V TBTrainingHidden {(מצב אימון; התוצאות מוסתרות)}
 }
 # end of english.tcl

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -1748,5 +1748,16 @@ translate h BatchCancel {रद्द करना}
 translate h BatchCompleted {पुरा होना}
 translate h BatchGames {खेल}
 translate h BatchProcessed {प्रसंस्कृत}
+translate h TablebaseWindow {टेबलबेस विंडो}
+translate h TBWinMoves {---जीतने की चालें ---}
+translate h TBDrawMoves {--- ड्राइंग चालें ---}
+translate h TBLossMoves {--- हारने वाली चालें ---}
+translate h TBNoMoves {कोई कानूनी कदम नहीं मिला.}
+translate h TBTooMany {बहुत सारे टुकड़े. लाइकेस टेबलबेस 7 टुकड़ों तक का समर्थन करता है।}
+translate h TBQuerying {लाइकेस एपीआई को क्वेरी किया जा रहा है...}
+translate h TBError {लिचेस को क्वेरी करने के लिए कर्ल लॉन्च करने में त्रुटि।}
+translate h TBNotFound {टेबलबेस या एपीआई त्रुटि में स्थिति नहीं मिली।}
+translate h TBCategory {पद श्रेणी:}
+translate h TBTrainingHidden {(प्रशिक्षण मोड; परिणाम छिपे हुए हैं)}
 }
 # end of english.tcl

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -1772,5 +1772,16 @@ translate H BatchCancel {Mégsem}
 translate H BatchCompleted {elkészült}
 translate H BatchGames {játékok}
 translate H BatchProcessed {feldolgozott}
+translate H TablebaseWindow {Táblázatbázis ablak}
+translate H TBWinMoves {--- Nyerő lépések ---}
+translate H TBDrawMoves {--- Rajzmozgások ---}
+translate H TBLossMoves {--- Vesztes mozdulatok ---}
+translate H TBNoMoves {Nem található törvényes lépés.}
+translate H TBTooMany {Túl sok darab. A Lichess asztallap legfeljebb 7 darabot támogat.}
+translate H TBQuerying {Lichess API lekérdezése...}
+translate H TBError {Hiba a curl indításakor a Lichess lekérdezéséhez.}
+translate H TBNotFound {A pozíció nem található a táblázatbázisban vagy API hiba.}
+translate H TBCategory {Pozíció kategória:}
+translate H TBTrainingHidden {(edzési mód; az eredmények rejtettek)}
 }
 # end of english.tcl

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -1772,5 +1772,16 @@ translate I BatchCancel {Cancellare}
 translate I BatchCompleted {completato}
 translate I BatchGames {giochi}
 translate I BatchProcessed {elaborato}
+translate I TablebaseWindow {Finestra della base tabella}
+translate I TBWinMoves {--- Mosse vincenti ---}
+translate I TBDrawMoves {--- Mosse di disegno ---}
+translate I TBLossMoves {--- Mosse Perdenti ---}
+translate I TBNoMoves {Nessuna mossa legale trovata.}
+translate I TBTooMany {Troppi pezzi. Il base tavolo Lichess supporta fino a 7 pezzi.}
+translate I TBQuerying {Interrogazione dell'API Lichess in corso...}
+translate I TBError {Errore durante l'avvio di curl per interrogare Lichess.}
+translate I TBNotFound {Posizione non trovata nella tablebase o errore API.}
+translate I TBCategory {Categoria di posizione:}
+translate I TBTrainingHidden {(Modalità formazione; i risultati sono nascosti)}
 }
 # end of english.tcl

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -1789,5 +1789,16 @@ translate A BatchCancel {キャンセル}
 translate A BatchCompleted {完了しました}
 translate A BatchGames {ゲーム}
 translate A BatchProcessed {処理された}
+translate A TablebaseWindow {テーブルベースウィンドウ}
+translate A TBWinMoves {--- 必勝技 ---}
+translate A TBDrawMoves {--- 描画動作 ---}
+translate A TBLossMoves {--- 負け技 ---}
+translate A TBNoMoves {法的な措置は見つかりませんでした。}
+translate A TBTooMany {ピースが多すぎます。 Lichess テーブルベースは最大 7 個までサポートします。}
+translate A TBQuerying {Lichess API をクエリしています...}
+translate A TBError {Lichess をクエリするためにカールを起動中にエラーが発生しました。}
+translate A TBNotFound {テーブルベースで位置が見つからないか、API エラーです。}
+translate A TBCategory {ポジションカテゴリー:}
+translate A TBTrainingHidden {(トレーニングモード、結果は非表示)}
 }
 # end of english.tcl

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -1789,5 +1789,16 @@ translate k BatchCancel {취소}
 translate k BatchCompleted {완전한}
 translate k BatchGames {계략}
 translate k BatchProcessed {처리됨}
+translate k TablebaseWindow {테이블베이스 창}
+translate k TBWinMoves {--- 승리 동작 ---}
+translate k TBDrawMoves {--- 그리기 동작 ---}
+translate k TBLossMoves {--- 잃어버린 움직임 ---}
+translate k TBNoMoves {법적 움직임이 발견되지 않았습니다.}
+translate k TBTooMany {조각이 너무 많습니다. Lichess 테이블베이스는 최대 7개까지 지원합니다.}
+translate k TBQuerying {Lichess API 쿼리 중...}
+translate k TBError {Lichess를 쿼리하기 위해 컬을 실행하는 중에 오류가 발생했습니다.}
+translate k TBNotFound {테이블베이스 또는 API 오류에서 위치를 찾을 수 없습니다.}
+translate k TBCategory {직위 범주:}
+translate k TBTrainingHidden {(훈련 모드, 결과는 숨겨짐)}
 }
 # end of english.tcl

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -1794,5 +1794,16 @@ translate N BatchCancel {Annuleren}
 translate N BatchCompleted {voltooid}
 translate N BatchGames {spellen}
 translate N BatchProcessed {verwerkt}
+translate N TablebaseWindow {Tablebase-venster}
+translate N TBWinMoves {--- Winnende zetten ---}
+translate N TBDrawMoves {--- Tekenbewegingen ---}
+translate N TBLossMoves {--- Verliezende zetten ---}
+translate N TBNoMoves {Geen legale zetten gevonden.}
+translate N TBTooMany {Te veel stukken. Lichess tafelonderstel ondersteunt maximaal 7 stuks.}
+translate N TBQuerying {Lichess-API opvragen...}
+translate N TBError {Fout bij het starten van curl om Lichess te ondervragen.}
+translate N TBNotFound {Positie niet gevonden in tablebase of API-fout.}
+translate N TBCategory {Functiecategorie:}
+translate N TBTrainingHidden {(Trainingsmodus; resultaten zijn verborgen)}
 }
 # end of english.tcl

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -1771,5 +1771,16 @@ translate O BatchCancel {Kansellere}
 translate O BatchCompleted {fullført}
 translate O BatchGames {spill}
 translate O BatchProcessed {behandlet}
+translate O TablebaseWindow {Tablebase-vindu}
+translate O TBWinMoves {--- Vinnende trekk ---}
+translate O TBDrawMoves {--- Tegning Moves ---}
+translate O TBLossMoves {--- Tapte trekk ---}
+translate O TBNoMoves {Ingen lovlige trekk funnet.}
+translate O TBTooMany {For mange stykker. Lichess bordbunn støtter opptil 7 deler.}
+translate O TBQuerying {Spørrer Lichess API...}
+translate O TBError {Feil ved start av curl for å spørre Lichess.}
+translate O TBNotFound {Finner ikke posisjon i tabellbase eller API-feil.}
+translate O TBCategory {Stillingskategori:}
+translate O TBTrainingHidden {(Opplæringsmodus; resultatene er skjult)}
 }
 # end of english.tcl

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -1791,5 +1791,16 @@ translate P BatchCancel {Anulowaæ}
 translate P BatchCompleted {zakoñczony}
 translate P BatchGames {zawody sportowe}
 translate P BatchProcessed {obrobiony}
+translate P TablebaseWindow {Okno podstawy tabeli}
+translate P TBWinMoves {--- Zwycięskie ruchy ---}
+translate P TBDrawMoves {--- Rysowanie ruchów ---}
+translate P TBLossMoves {--- Utrata ruchów ---}
+translate P TBNoMoves {Nie znaleziono żadnych legalnych ruchów.}
+translate P TBTooMany {Za dużo kawałków. Podstawa stołu Lichess obsługuje do 7 elementów.}
+translate P TBQuerying {Wysyłam zapytanie do API Lichess...}
+translate P TBError {Błąd podczas uruchamiania curl w celu wysłania zapytania do Lichess.}
+translate P TBNotFound {Nie znaleziono pozycji w bazie tabeli lub wystąpił błąd API.}
+translate P TBCategory {Kategoria stanowiska:}
+translate P TBTrainingHidden {(Tryb treningu; wyniki są ukryte)}
 }
 # end of english.tcl

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -1779,5 +1779,16 @@ translate B BatchCancel {Cancelar}
 translate B BatchCompleted {concluído}
 translate B BatchGames {jogos}
 translate B BatchProcessed {processado}
+translate B TablebaseWindow {Janela Base de Tabela}
+translate B TBWinMoves {--- Movimentos vencedores ---}
+translate B TBDrawMoves {--- Movimentos de desenho ---}
+translate B TBLossMoves {--- Movimentos perdidos ---}
+translate B TBNoMoves {Nenhum movimento legal encontrado.}
+translate B TBTooMany {Muitas peças. A base de mesa Lichess suporta até 7 peças.}
+translate B TBQuerying {Consultando API Lichess...}
+translate B TBError {Erro ao iniciar o curl para consultar o Lichess.}
+translate B TBNotFound {Posição não encontrada na base de tabela ou erro de API.}
+translate B TBCategory {Categoria de posição:}
+translate B TBTrainingHidden {(Modo de treinamento; os resultados estão ocultos)}
 }
 # end of english.tcl

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -1789,5 +1789,16 @@ translate L BatchCancel {Anula}
 translate L BatchCompleted {completat}
 translate L BatchGames {jocuri}
 translate L BatchProcessed {prelucrate}
+translate L TablebaseWindow {Fereastra Tablebase}
+translate L TBWinMoves {--- Mișcări câștigătoare ---}
+translate L TBDrawMoves {--- Mișcări de desen ---}
+translate L TBLossMoves {--- Mișcări pierdute ---}
+translate L TBNoMoves {Nu au fost găsite mișcări legale.}
+translate L TBTooMany {Prea multe piese. Baza de masă Lichess acceptă până la 7 piese.}
+translate L TBQuerying {Se interogează API-ul Lichess...}
+translate L TBError {Eroare la lansarea curl pentru a interoga Lichess.}
+translate L TBNotFound {Poziția nu a fost găsită în baza de tabele sau eroare API.}
+translate L TBCategory {Categoria postului:}
+translate L TBTrainingHidden {(Modul de antrenament; rezultatele sunt ascunse)}
 }
 # end of english.tcl

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -1782,6 +1782,7 @@ translate R TBTooMany {Слишком много кусочков. Основа�
 translate R TBQuerying {Запрос API Lichess...}
 translate R TBError {Ошибка при запуске Curl для запроса Lichess.}
 translate R TBNotFound {Позиция не найдена в базе таблиц или ошибка API.}
+translate R TBQueryError {Ошибка при разборе ответа API Lichess.}
 translate R TBCategory {Категория позиции:}
 translate R TBTrainingHidden {(Режим обучения; результаты скрыты)}
 }

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -1773,5 +1773,16 @@ translate R BatchCancel {Отмена}
 translate R BatchCompleted {завершенный}
 translate R BatchGames {игры}
 translate R BatchProcessed {обработано}
+translate R TablebaseWindow {Окно таблицы}
+translate R TBWinMoves {--- Выигрышные ходы ---}
+translate R TBDrawMoves {--- Рисование движений ---}
+translate R TBLossMoves {--- Проигрышные ходы ---}
+translate R TBNoMoves {Законных ходов не обнаружено.}
+translate R TBTooMany {Слишком много кусочков. Основание стола Lichess поддерживает до 7 штук.}
+translate R TBQuerying {Запрос API Lichess...}
+translate R TBError {Ошибка при запуске Curl для запроса Lichess.}
+translate R TBNotFound {Позиция не найдена в базе таблиц или ошибка API.}
+translate R TBCategory {Категория позиции:}
+translate R TBTrainingHidden {(Режим обучения; результаты скрыты)}
 }
 # end of english.tcl

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -2397,5 +2397,27 @@ translate Y BatchCompleted {completed}
 translate Y BatchGames {games}
 # ====== TODO To be translated ======
 translate Y BatchProcessed {processed}
+# ====== TODO To be translated ======
+translate Y TablebaseWindow {Tablebase Window}
+# ====== TODO To be translated ======
+translate Y TBWinMoves {--- Winning Moves ---}
+# ====== TODO To be translated ======
+translate Y TBDrawMoves {--- Drawing Moves ---}
+# ====== TODO To be translated ======
+translate Y TBLossMoves {--- Losing Moves ---}
+# ====== TODO To be translated ======
+translate Y TBNoMoves {No legal moves found.}
+# ====== TODO To be translated ======
+translate Y TBTooMany {Too many pieces. Lichess tablebase supports up to 7 pieces.}
+# ====== TODO To be translated ======
+translate Y TBQuerying {Querying Lichess API...}
+# ====== TODO To be translated ======
+translate Y TBError {Error launching curl to query Lichess.}
+# ====== TODO To be translated ======
+translate Y TBNotFound {Position not found in tablebase or API error.}
+# ====== TODO To be translated ======
+translate Y TBCategory {Position Category:}
+# ====== TODO To be translated ======
+translate Y TBTrainingHidden {(Training mode; results are hidden)}
 }
 # end of serbian.tcl

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -2416,6 +2416,8 @@ translate Y TBError {Error launching curl to query Lichess.}
 # ====== TODO To be translated ======
 translate Y TBNotFound {Position not found in tablebase or API error.}
 # ====== TODO To be translated ======
+translate Y TBQueryError {Error querying tablebase / invalid response.}
+# ====== TODO To be translated ======
 translate Y TBCategory {Position Category:}
 # ====== TODO To be translated ======
 translate Y TBTrainingHidden {(Training mode; results are hidden)}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -1824,5 +1824,16 @@ translate S BatchCancel {Cancelar}
 translate S BatchCompleted {terminado}
 translate S BatchGames {juegos}
 translate S BatchProcessed {procesado}
+translate S TablebaseWindow {Ventana de base de tabla}
+translate S TBWinMoves {--- Movimientos ganadores ---}
+translate S TBDrawMoves {--- Movimientos de dibujo ---}
+translate S TBLossMoves {--- Movimientos perdedores ---}
+translate S TBNoMoves {No se encontraron movimientos legales.}
+translate S TBTooMany {Demasiadas piezas. La base de mesa Lichess admite hasta 7 piezas.}
+translate S TBQuerying {Consultando la API de Lichess...}
+translate S TBError {Error al iniciar curl para consultar Lichess.}
+translate S TBNotFound {Posición no encontrada en la base de tabla o error de API.}
+translate S TBCategory {Categoría de puesto:}
+translate S TBTrainingHidden {(Modo de entrenamiento; los resultados están ocultos)}
 }
 # end of english.tcl

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -1802,5 +1802,16 @@ translate U BatchCancel {Peruuta}
 translate U BatchCompleted {valmiiksi}
 translate U BatchGames {pelejä}
 translate U BatchProcessed {käsitelty}
+translate U TablebaseWindow {Taulukkopohja-ikkuna}
+translate U TBWinMoves {--- Voittoliikkeet ---}
+translate U TBDrawMoves {--- Piirustusliikkeet ---}
+translate U TBLossMoves {--- Liikkeiden häviäminen ---}
+translate U TBNoMoves {Laillisia siirtoja ei löytynyt.}
+translate U TBTooMany {Liian monta kappaletta. Lichess-pöytäjalusta tukee jopa 7 osaa.}
+translate U TBQuerying {Kysellään Lichess-sovellusliittymää...}
+translate U TBError {Virhe käynnistettäessä curl-kyselyä Lichessille.}
+translate U TBNotFound {Sijaintia ei löydy taulukkokannasta tai API-virhe.}
+translate U TBCategory {Aseman luokka:}
+translate U TBTrainingHidden {(Harjoitustila; tulokset piilotetaan)}
 }
 # end of english.tcl

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -1748,5 +1748,16 @@ translate Z BatchCancel {Ghairi}
 translate Z BatchCompleted {imekamilika}
 translate Z BatchGames {michezo}
 translate Z BatchProcessed {imechakatwa}
+translate Z TablebaseWindow {Dirisha la Meza}
+translate Z TBWinMoves {--- Hatua za Ushindi ---}
+translate Z TBDrawMoves {--- Hatua za Kuchora ---}
+translate Z TBLossMoves {--- Kupoteza harakati ----}
+translate Z TBNoMoves {Hakuna hatua za kisheria zilizopatikana.}
+translate Z TBTooMany {Vipande vingi sana. Tablebase ya Lichess inasaidia hadi vipande 7.}
+translate Z TBQuerying {Querying Lichess API...}
+translate Z TBError {Hitilafu imetokea wakati wa kuzindua curl ili kuuliza Lichess.}
+translate Z TBNotFound {Nafasi haipatikani kwenye msingi wa meza au hitilafu ya API.}
+translate Z TBCategory {Kitengo cha Nafasi:}
+translate Z TBTrainingHidden {(Njia ya mafunzo; matokeo yamefichwa)}
 }
 # end of english.tcl

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -1777,5 +1777,16 @@ translate W BatchCancel {Avboka}
 translate W BatchCompleted {avslutad}
 translate W BatchGames {spel}
 translate W BatchProcessed {bearbetas}
+translate W TablebaseWindow {Tabellbasfönster}
+translate W TBWinMoves {--- Vinnande drag ---}
+translate W TBDrawMoves {--- Rita rörelser ---}
+translate W TBLossMoves {--- Förlorade drag ---}
+translate W TBNoMoves {Inga lagliga drag hittades.}
+translate W TBTooMany {För många bitar. Lichess bordsbas stöder upp till 7 delar.}
+translate W TBQuerying {Frågar Lichess API...}
+translate W TBError {Det gick inte att starta curl för att fråga Lichess.}
+translate W TBNotFound {Positionen hittades inte i tabellbasen eller API-fel.}
+translate W TBCategory {Positionskategori:}
+translate W TBTrainingHidden {(Träningsläge; resultaten är dolda)}
 }
 # end of english.tcl

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -1752,5 +1752,16 @@ translate T BatchCancel {İptal etmek}
 translate T BatchCompleted {tamamlanmış}
 translate T BatchGames {oyunlar}
 translate T BatchProcessed {işlenmiş}
+translate T TablebaseWindow {Tablo Tabanı Penceresi}
+translate T TBWinMoves {--- Kazandıran Hareketler ---}
+translate T TBDrawMoves {--- Çizim Hareketleri ---}
+translate T TBLossMoves {--- Kaybetme Hareketleri ---}
+translate T TBNoMoves {Yasal hamle bulunamadı.}
+translate T TBTooMany {Çok fazla parça. Lichess masa tabanı 7 parçaya kadar destekler.}
+translate T TBQuerying {Lichess API'si sorgulanıyor...}
+translate T TBError {Lichess'i sorgulamak için curl başlatılırken hata oluştu.}
+translate T TBNotFound {Tablo tabanında konum bulunamadı veya API hatası.}
+translate T TBCategory {Pozisyon Kategorisi:}
+translate T TBTrainingHidden {(Eğitim modu; sonuçlar gizlenir)}
 }
 # end of english.tcl

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -1758,6 +1758,7 @@ translate Q TBTooMany {Забагато частин. Настільна баз�
 translate Q TBQuerying {Запит Lichess API...}
 translate Q TBError {Помилка запуску curl для запиту Lichess.}
 translate Q TBNotFound {Позиція не знайдена в базі таблиць або помилка API.}
+translate Q TBQueryError {Неправильна відповідь від API бази таблиць.}
 translate Q TBCategory {Категорія посади:}
 translate Q TBTrainingHidden {(Режим навчання; результати приховані)}
 }

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -1749,5 +1749,16 @@ translate Q BatchCancel {Скасувати}
 translate Q BatchCompleted {завершено}
 translate Q BatchGames {ігри}
 translate Q BatchProcessed {оброблені}
+translate Q TablebaseWindow {Вікно бази даних}
+translate Q TBWinMoves {--- Переможні ходи ---}
+translate Q TBDrawMoves {--- Малювання рухів ---}
+translate Q TBLossMoves {--- Програшні ходи ---}
+translate Q TBNoMoves {Законних ходів не знайдено.}
+translate Q TBTooMany {Забагато частин. Настільна база Lichess підтримує до 7 предметів.}
+translate Q TBQuerying {Запит Lichess API...}
+translate Q TBError {Помилка запуску curl для запиту Lichess.}
+translate Q TBNotFound {Позиція не знайдена в базі таблиць або помилка API.}
+translate Q TBCategory {Категорія посади:}
+translate Q TBTrainingHidden {(Режим навчання; результати приховані)}
 }
 # end of english.tcl

--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -238,6 +238,7 @@ $m add checkbutton -label WindowsECO -accelerator "Ctrl+Y" -variable ::windows::
 $m add checkbutton -label WindowsStats -variable ::windows::stats::isOpen -accelerator "Ctrl+I" -command ::windows::stats::Open
 $m add checkbutton -label WindowsTree -variable treeWin -command ::tree::make -accelerator "Ctrl+T"
 $m add checkbutton -label WindowsBook -variable ::book::isOpen -command ::book::open -accelerator "F6"
+$m add checkbutton -label [tr TablebaseWindow] -variable ::tablebase::window::isOpen -command ::tablebase::window::Open -accelerator "Ctrl+="
 $m add command -label WindowsGraph -command ::tools::graphs::score::Refresh
 
 

--- a/tcl/tools/tablebase.tcl
+++ b/tcl/tools/tablebase.tcl
@@ -360,3 +360,284 @@ proc ::tablebase::showError {w message} {
     bind $w <Return> "destroy $w"
     focus $w.error.close
 }
+
+# =======================================================================
+# Lichess Endgame Tablebase Dedicated Window 
+# =======================================================================
+
+namespace eval ::tablebase::window {
+    variable isOpen 0
+    variable tbTraining 0
+    variable requestCount 0
+    variable buffer
+}
+
+# ::tablebase::window::isOpen
+proc ::tablebase::window::isOpen {} {
+    return [winfo exists .tbWin]
+}
+
+# ::tablebase::window::Open
+proc ::tablebase::window::Open {} {
+    set w .tbWin
+    if {[winfo exists $w]} { 
+        wm deiconify $w
+        raise $w
+        return 
+    }
+    
+    ::createToplevel $w
+    ::setTitle $w "scidCommunity: [tr TablebaseWindow]"
+    
+    # Control frame at the bottom
+    pack [ttk::frame $w.b] -side bottom -fill x -pady 5 -padx 5
+    
+    # Results frame (autoscrollText creates the frame)
+    set f $w.pos
+    
+    # Text widget for results
+    autoscrollText y $f $f.text Treeview
+    $f.text configure -width 40 -height 20 -font font_Fixed -wrap none -state normal
+    
+    # Determine if theme is dark by checking the background color's brightness
+    set bg [ttk::style lookup TFrame -background]
+    if {$bg eq ""} { set bg "white" }
+    set isDark 0
+    catch {
+        foreach {r g b} [winfo rgb . $bg] break
+        if {($r*299 + $g*587 + $b*114) / 1000 < 32768} { set isDark 1 }
+    }
+    
+    if {$isDark} {
+        set win_color "#66ff66"  ;# light green
+        set draw_color "#88ccff" ;# light blue
+        set loss_color "#ff6666" ;# light red
+        set move_color "#66ccff" ;# lighter blue for links
+    } else {
+        set win_color "darkgreen"
+        set draw_color "darkblue"
+        set loss_color "darkred"
+        set move_color "blue"
+    }
+    
+    # Text tags for styling
+    $f.text tag configure win_title -foreground $win_color -font font_Bold
+    $f.text tag configure draw_title -foreground $draw_color -font font_Bold
+    $f.text tag configure loss_title -foreground $loss_color -font font_Bold
+    $f.text tag configure move -foreground $move_color
+    $f.text tag bind move <Enter> "$f.text configure -cursor hand2"
+    $f.text tag bind move <Leave> "$f.text configure -cursor {}"
+    
+    pack $f -side top -fill both -expand yes
+    
+    # Buttons
+    ttk::checkbutton $w.b.training -text $::tr(Training) -variable ::tablebase::window::tbTraining -command ::tablebase::window::results
+    ttk::button $w.b.refresh -text "Refresh" -command ::tablebase::window::results
+    dialogbutton $w.b.close -text $::tr(Close) -command "destroy $w"
+    
+    packbuttons right $w.b.close
+    pack $w.b.training $w.b.refresh -side left -padx 2 -pady 2
+    
+    bind $w <Destroy> { set ::tablebase::window::tbTraining 0; set ::tablebase::window::isOpen 0 }
+    wm minsize $w 350 400
+    ::createToplevelFinalize $w
+    
+    set ::tablebase::window::isOpen 1
+    set ::tablebase::window::tbTraining 0
+    ::tablebase::window::results
+}
+
+# ::tablebase::window::results
+proc ::tablebase::window::results {} {
+    set w .tbWin
+    if {![winfo exists $w]} { return }
+    
+    set t $w.pos.text
+    $t configure -state normal
+    $t delete 1.0 end
+    
+    if {$::tablebase::window::tbTraining} {
+        $t insert end "\n [tr TBTrainingHidden]\n"
+        $t configure -state disabled
+        return
+    }
+    
+    # Check piece count
+    set fen [sc_pos fen]
+    set pieces [::tablebase::countPieces $fen]
+    if {$pieces > 7} {
+        $t insert end "\n [tr TBTooMany]\n"
+        $t configure -state disabled
+        return
+    }
+    
+    $t insert end "\n [tr TBQuerying]\n"
+    $t configure -state disabled
+    
+    # URL-encode spaces in FEN for the query string
+    set urlFen [string map {" " "%20"} $fen]
+    set url "$::tablebase::lichessUrl?fen=$urlFen"
+    
+    # Asynchronous curl
+    incr ::tablebase::window::requestCount
+    set currentReq $::tablebase::window::requestCount
+    set ::tablebase::window::buffer($currentReq) ""
+    
+    if {![catch {open "| curl -s --max-time 10 $url" r} fd]} {
+        fconfigure $fd -blocking 0
+        fileevent $fd readable [list ::tablebase::window::curlCallback $fd $fen $currentReq]
+    } else {
+        $t configure -state normal
+        $t delete 1.0 end
+        $t insert end "\n [tr TBError]\n"
+        $t configure -state disabled
+    }
+}
+
+proc ::tablebase::window::curlCallback {fd fen reqId} {
+    set w .tbWin
+    
+    append ::tablebase::window::buffer($reqId) [read $fd]
+    
+    if {[eof $fd]} {
+        set result $::tablebase::window::buffer($reqId)
+        unset ::tablebase::window::buffer($reqId)
+        catch {close $fd}
+        
+        # Only update if this is the most recent request and window exists
+        if {[winfo exists $w] && $reqId == $::tablebase::window::requestCount} {
+            ::tablebase::window::displayResults $result $fen
+        }
+    }
+}
+
+proc ::tablebase::window::compareWin {a b} {
+    set dtzA [expr {abs([lindex $a 0])}]
+    set dtzB [expr {abs([lindex $b 0])}]
+    if {$dtzA != $dtzB} { return [expr {$dtzA - $dtzB}] }
+    set dtmA [lindex $a 1]; set dtmB [lindex $b 1]
+    if {$dtmA ne "" && $dtmB ne ""} { return [expr {abs($dtmA) - abs($dtmB)}] }
+    return 0
+}
+
+proc ::tablebase::window::compareLoss {a b} {
+    set dtzA [expr {abs([lindex $a 0])}]
+    set dtzB [expr {abs([lindex $b 0])}]
+    if {$dtzA != $dtzB} { return [expr {$dtzB - $dtzA}] }
+    set dtmA [lindex $a 1]; set dtmB [lindex $b 1]
+    if {$dtmA ne "" && $dtmB ne ""} { return [expr {abs($dtmB) - abs($dtmA)}] }
+    return 0
+}
+
+proc ::tablebase::window::displayResults {jsonData fen} {
+    set w .tbWin
+    if {![winfo exists $w]} { return }
+    
+    set t $w.pos.text
+    $t configure -state normal
+    $t delete 1.0 end
+    
+    if {[string match "*not found*" $jsonData] || [string match "*error*" $jsonData]} {
+        $t insert end "\n [tr TBNotFound]\n"
+        $t configure -state disabled
+        return
+    }
+    
+    set category ""
+    regexp {"category":"([^"]+)"} $jsonData -> category
+    
+    $t insert end "\n [tr TBCategory] $category\n\n"
+    
+    # Extract the moves array
+    set movesJson ""
+    if {[regexp {"moves":\[(.*?)\]} $jsonData -> movesJson]} {
+        # Parse individual moves manually using regex
+        set moveMatches [regexp -all -inline {\{[^\}]+\}} $movesJson]
+        
+        set winMoves {}
+        set drawMoves {}
+        set lossMoves {}
+        
+        foreach moveObj $moveMatches {
+            set uci ""
+            set san ""
+            set mcat ""
+            set wdl ""
+            set dtz ""
+            set dtm ""
+            
+            regexp {"uci":"([^"]+)"} $moveObj -> uci
+            regexp {"san":"([^"]+)"} $moveObj -> san
+            regexp {"category":"([^"]+)"} $moveObj -> mcat
+            regexp {"wdl":(-?\d+)} $moveObj -> wdl
+            regexp {"dtz":(-?\d+)} $moveObj -> dtz
+            regexp {"dtm":(-?\d+)} $moveObj -> dtm
+            
+            if {$san eq ""} { set san [::tablebase::uciToSan $uci $fen] }
+            
+            # Format display string
+            set displayStr [format "%-8s %-12s DTZ: %-4s" $san $mcat [expr {$dtz ne "" ? abs($dtz) : "-"}]]
+            if {$dtm ne ""} {
+                append displayStr [format " DTM: %-4s" [expr {abs($dtm)}]]
+            }
+            
+            if {$wdl > 0} {
+                lappend winMoves [list $dtz $dtm $displayStr $san]
+            } elseif {$wdl == 0} {
+                lappend drawMoves [list $dtz $dtm $displayStr $san]
+            } else {
+                lappend lossMoves [list $dtz $dtm $displayStr $san]
+            }
+        }
+        
+        set winMoves [lsort -command ::tablebase::window::compareWin $winMoves]
+        set drawMoves [lsort -command ::tablebase::window::compareLoss $drawMoves]
+        set lossMoves [lsort -command ::tablebase::window::compareLoss $lossMoves]
+        
+        if {[llength $winMoves] > 0} {
+            $t insert end " [tr TBWinMoves]\n" win_title
+            foreach m $winMoves { 
+                set san [lindex $m 3]
+                $t insert end "  "
+                $t insert end "[lindex $m 2]" [list move $san]
+                $t insert end "\n"
+                
+                # Make moves clickable
+                $t tag bind $san <ButtonPress-1> [list ::tablebase::window::addMove $san]
+            }
+            $t insert end "\n"
+        }
+        if {[llength $drawMoves] > 0} {
+            $t insert end " [tr TBDrawMoves]\n" draw_title
+            foreach m $drawMoves { 
+                set san [lindex $m 3]
+                $t insert end "  "
+                $t insert end "[lindex $m 2]" [list move $san]
+                $t insert end "\n"
+                $t tag bind $san <ButtonPress-1> [list ::tablebase::window::addMove $san]
+            }
+            $t insert end "\n"
+        }
+        if {[llength $lossMoves] > 0} {
+            $t insert end " [tr TBLossMoves]\n" loss_title
+            foreach m $lossMoves { 
+                set san [lindex $m 3]
+                $t insert end "  "
+                $t insert end "[lindex $m 2]" [list move $san]
+                $t insert end "\n"
+                $t tag bind $san <ButtonPress-1> [list ::tablebase::window::addMove $san]
+            }
+            $t insert end "\n"
+        }
+    } else {
+        $t insert end " [tr TBNoMoves]\n"
+    }
+    
+    $t configure -state disabled
+}
+
+proc ::tablebase::window::addMove {san} {
+    if {[catch {sc_move addSan $san} err] == 0} {
+        updateBoard
+    }
+}

--- a/tcl/tools/tablebase.tcl
+++ b/tcl/tools/tablebase.tcl
@@ -12,7 +12,8 @@ namespace eval ::tablebase {
 #   for Chess960 positions (same pattern as cloud eval / opening explorer).
 #
 proc ::tablebase::buildUrl {fen} {
-    set urlFen [string map {" " "%20"} $fen]
+    # Properly URL-encode the FEN string
+    set urlFen [string map {" " "%20" "+" "%2B" "/" "%2F"} $fen]
     set url "$::tablebase::lichessUrl?fen=$urlFen"
     set gameVariant [sc_game variant]
     if {$gameVariant eq "chess960"} {
@@ -487,8 +488,9 @@ proc ::tablebase::window::results {} {
     incr ::tablebase::window::requestCount
     set currentReq $::tablebase::window::requestCount
     set ::tablebase::window::buffer($currentReq) ""
-    
-    if {![catch {open "| curl -s --max-time 10 $url" r} fd]} {
+
+    # Use list-form open to avoid shell injection
+    if {![catch {open "|[list curl -s --max-time 10 $url]" r} fd]} {
         fconfigure $fd -blocking 0
         fileevent $fd readable [list ::tablebase::window::curlCallback $fd $fen $currentReq]
     } else {
@@ -517,8 +519,11 @@ proc ::tablebase::window::curlCallback {fd fen reqId} {
 }
 
 proc ::tablebase::window::compareWin {a b} {
-    set dtzA [expr {abs([lindex $a 0])}]
-    set dtzB [expr {abs([lindex $b 0])}]
+    # Normalize DTZ to numeric default (0) when empty
+    set rawDtzA [lindex $a 0]
+    set rawDtzB [lindex $b 0]
+    set dtzA [expr {$rawDtzA eq "" ? 0 : abs($rawDtzA)}]
+    set dtzB [expr {$rawDtzB eq "" ? 0 : abs($rawDtzB)}]
     if {$dtzA != $dtzB} { return [expr {$dtzA - $dtzB}] }
     set dtmA [lindex $a 1]; set dtmB [lindex $b 1]
     if {$dtmA ne "" && $dtmB ne ""} { return [expr {abs($dtmA) - abs($dtmB)}] }
@@ -526,8 +531,11 @@ proc ::tablebase::window::compareWin {a b} {
 }
 
 proc ::tablebase::window::compareLoss {a b} {
-    set dtzA [expr {abs([lindex $a 0])}]
-    set dtzB [expr {abs([lindex $b 0])}]
+    # Normalize DTZ to numeric default (0) when empty
+    set rawDtzA [lindex $a 0]
+    set rawDtzB [lindex $b 0]
+    set dtzA [expr {$rawDtzA eq "" ? 0 : abs($rawDtzA)}]
+    set dtzB [expr {$rawDtzB eq "" ? 0 : abs($rawDtzB)}]
     if {$dtzA != $dtzB} { return [expr {$dtzB - $dtzA}] }
     set dtmA [lindex $a 1]; set dtmB [lindex $b 1]
     if {$dtmA ne "" && $dtmB ne ""} { return [expr {abs($dtmB) - abs($dtmA)}] }

--- a/tcl/tools/tablebase.tcl
+++ b/tcl/tools/tablebase.tcl
@@ -5,18 +5,20 @@
 namespace eval ::tablebase {
     # Use HTTPS for the Lichess tablebase API
     variable lichessUrl "https://tablebase.lichess.ovh/standard"
-    variable lichessChess960Url "https://tablebase.lichess.ovh/chess960"
 }
 
-# ::tablebase::getApiUrl
-#   Returns the correct Lichess tablebase API URL based on game variant.
+# ::tablebase::buildUrl
+#   Constructs the tablebase API URL from a FEN, adding variant parameter
+#   for Chess960 positions (same pattern as cloud eval / opening explorer).
 #
-proc ::tablebase::getApiUrl {} {
+proc ::tablebase::buildUrl {fen} {
+    set urlFen [string map {" " "%20"} $fen]
+    set url "$::tablebase::lichessUrl?fen=$urlFen"
     set gameVariant [sc_game variant]
     if {$gameVariant eq "chess960"} {
-        return $::tablebase::lichessChess960Url
+        append url "&variant=chess960"
     }
-    return $::tablebase::lichessUrl
+    return $url
 }
 
 # ::tablebase::countPieces
@@ -42,12 +44,8 @@ proc ::tablebase::countPieces {fen} {
 #   Returns: "winning", "losing", "draw", or "error: <message>"
 #
 proc ::tablebase::queryTablebaseResult {fen} {
-    # URL-encode spaces in FEN for the query string
-    # (Lichess expects standard URL encoding like %20, not underscores)
-    set urlFen [string map {" " "%20"} $fen]
-    
     # Construct the API URL (variant-aware)
-    set url "[::tablebase::getApiUrl]?fen=$urlFen"
+    set url [::tablebase::buildUrl $fen]
     
     # Try to query the tablebase
     set result ""
@@ -125,11 +123,8 @@ proc ::tablebase::lookupPosition {} {
     # Get the FEN of the current position
     set fen [sc_pos fen]
     
-    # URL-encode spaces in FEN for the query string
-    set urlFen [string map {" " "%20"} $fen]
-    
     # Construct the API URL (variant-aware)
-    set url "[::tablebase::getApiUrl]?fen=$urlFen"
+    set url [::tablebase::buildUrl $fen]
     
     # Show a temporary "Loading..." message
     set w .tablebaseResult
@@ -486,9 +481,7 @@ proc ::tablebase::window::results {} {
     $t insert end "\n [tr TBQuerying]\n"
     $t configure -state disabled
     
-    # URL-encode spaces in FEN for the query string
-    set urlFen [string map {" " "%20"} $fen]
-    set url "[::tablebase::getApiUrl]?fen=$urlFen"
+    set url [::tablebase::buildUrl $fen]
     
     # Asynchronous curl
     incr ::tablebase::window::requestCount

--- a/tcl/tools/tablebase.tcl
+++ b/tcl/tools/tablebase.tcl
@@ -125,8 +125,8 @@ proc ::tablebase::lookupPosition {} {
     # Get the FEN of the current position
     set fen [sc_pos fen]
     
-    # Convert spaces in FEN to underscores for the URL
-    set urlFen [string map {" " "_"} $fen]
+    # URL-encode spaces in FEN for the query string
+    set urlFen [string map {" " "%20"} $fen]
     
     # Construct the API URL (variant-aware)
     set url "[::tablebase::getApiUrl]?fen=$urlFen"
@@ -555,6 +555,13 @@ proc ::tablebase::window::displayResults {jsonData fen} {
         return
     }
     
+    # Guard against empty or non-JSON response
+    if {![string match "\{*" $jsonData]} {
+        $t insert end "\n [tr TBQueryError]\n"
+        $t configure -state disabled
+        return
+    }
+    
     set category ""
     regexp {"category":"([^"]+)"} $jsonData -> category
     
@@ -574,14 +581,12 @@ proc ::tablebase::window::displayResults {jsonData fen} {
             set uci ""
             set san ""
             set mcat ""
-            set wdl ""
             set dtz ""
             set dtm ""
             
             regexp {"uci":"([^"]+)"} $moveObj -> uci
             regexp {"san":"([^"]+)"} $moveObj -> san
             regexp {"category":"([^"]+)"} $moveObj -> mcat
-            regexp {"wdl":(-?\d+)} $moveObj -> wdl
             regexp {"dtz":(-?\d+)} $moveObj -> dtz
             regexp {"dtm":(-?\d+)} $moveObj -> dtm
             
@@ -593,12 +598,12 @@ proc ::tablebase::window::displayResults {jsonData fen} {
                 append displayStr [format " DTM: %-4s" [expr {abs($dtm)}]]
             }
             
-            if {$wdl > 0} {
-                lappend winMoves [list $dtz $dtm $displayStr $san]
-            } elseif {$wdl == 0} {
-                lappend drawMoves [list $dtz $dtm $displayStr $san]
-            } else {
-                lappend lossMoves [list $dtz $dtm $displayStr $san]
+            # Classify by category (the Lichess API no longer includes a wdl field)
+            switch -glob $mcat {
+                "win"  { lappend winMoves  [list $dtz $dtm $displayStr $san] }
+                "draw" { lappend drawMoves [list $dtz $dtm $displayStr $san] }
+                "loss" { lappend lossMoves [list $dtz $dtm $displayStr $san] }
+                default { lappend drawMoves [list $dtz $dtm $displayStr $san] }
             }
         }
         

--- a/tcl/tools/tablebase.tcl
+++ b/tcl/tools/tablebase.tcl
@@ -5,6 +5,18 @@
 namespace eval ::tablebase {
     # Use HTTPS for the Lichess tablebase API
     variable lichessUrl "https://tablebase.lichess.ovh/standard"
+    variable lichessChess960Url "https://tablebase.lichess.ovh/chess960"
+}
+
+# ::tablebase::getApiUrl
+#   Returns the correct Lichess tablebase API URL based on game variant.
+#
+proc ::tablebase::getApiUrl {} {
+    set gameVariant [sc_game variant]
+    if {$gameVariant eq "chess960"} {
+        return $::tablebase::lichessChess960Url
+    }
+    return $::tablebase::lichessUrl
 }
 
 # ::tablebase::countPieces
@@ -34,8 +46,8 @@ proc ::tablebase::queryTablebaseResult {fen} {
     # (Lichess expects standard URL encoding like %20, not underscores)
     set urlFen [string map {" " "%20"} $fen]
     
-    # Construct the API URL
-    set url "$::tablebase::lichessUrl?fen=$urlFen"
+    # Construct the API URL (variant-aware)
+    set url "[::tablebase::getApiUrl]?fen=$urlFen"
     
     # Try to query the tablebase
     set result ""
@@ -116,8 +128,8 @@ proc ::tablebase::lookupPosition {} {
     # Convert spaces in FEN to underscores for the URL
     set urlFen [string map {" " "_"} $fen]
     
-    # Construct the API URL
-    set url "$::tablebase::lichessUrl?fen=$urlFen"
+    # Construct the API URL (variant-aware)
+    set url "[::tablebase::getApiUrl]?fen=$urlFen"
     
     # Show a temporary "Loading..." message
     set w .tablebaseResult
@@ -476,7 +488,7 @@ proc ::tablebase::window::results {} {
     
     # URL-encode spaces in FEN for the query string
     set urlFen [string map {" " "%20"} $fen]
-    set url "$::tablebase::lichessUrl?fen=$urlFen"
+    set url "[::tablebase::getApiUrl]?fen=$urlFen"
     
     # Asynchronous curl
     incr ::tablebase::window::requestCount


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive Tablebase window showing categorized move results (win/draw/loss), clickable moves, and auto-scroll results.
  * Keyboard shortcut (Ctrl+=) and Windows menu item to open the Tablebase window.
  * Queries respect Chess960 positions and update when the current position changes.

* **Localization**
  * Added Tablebase UI translations for 30+ languages (new status, error, and training-mode messages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->