### PR TITLE
Adopt Engine Tournament feature developed by Uwe

### DIFF
--- a/tcl/enginecomm.tcl
+++ b/tcl/enginecomm.tcl
@@ -590,8 +590,10 @@ proc ::xboard::sendGo {id msgData} {
             "movetime" { ::engine::rawsend $id "st $limit_value" }
         }
     }
-    regexp {^position(?: fen)? (.*?) moves(.*)$} $position -> fen moves
-    if {$fen eq "startpos"} {
+    set fen ""
+    set moves ""
+    regexp {^position(?: fen)? (.*?)(?:\s+moves(.*))?$} $position -> fen moves
+    if {$fen eq "" || $fen eq "startpos"} {
         set fen "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
     }
     ::engine::rawsend $id "setboard $fen"

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -153,6 +153,8 @@ menuText J GameGotoMove "Иди на премести број..." 5 \
   {Идите на одређени број потеза у тренутној игри}
 menuText J GameNovelty "Пронађите новине..." 7 \
   {Пронађите први потез ове игре који раније није игран}
+menuText J PlayTournament "Играј турнир..." 0 \
+    {Играјте моторни турнир}
 
 # Search Menu:
 menuText J Search "Тражи" 0
@@ -1421,8 +1423,106 @@ translate J RecentFilesExtra {Број недавних датотека у до
 
 # My Player Names options:
 translate J MyPlayerNamesDescription {Унесите листу жељених имена играча испод, једно име по реду. Дозвољени су џокер знакови (нпр. "?" за било који појединачни знак, "*" за било који низ знакова).
+# ====== TODO To be translated ======
+translate J configComp {Конфигуришите турнир}
+# ====== TODO To be translated ======
+translate J Tournament {Турнир}
+# ====== TODO To be translated ======
+translate J Available {Доступан}
+# ====== TODO To be translated ======
+translate J Selected {Изабрано}
+# ====== TODO To be translated ======
+translate J RoundRobin {Роунд Робин}
+# ====== TODO To be translated ======
+translate J Gauntlet {Гаунтлет}
+# ====== TODO To be translated ======
+translate J CompGameNext {Следећа утакмица:}
+# ====== TODO To be translated ======
+translate J TimeperGame {Време по игри}
+# ====== TODO To be translated ======
+translate J TimeperMove {Време по\Мове}
+# ====== TODO To be translated ======
+translate J compStoreTime {Време продавнице:}
+# ====== TODO To be translated ======
+translate J Clock {Сат}
+# ====== TODO To be translated ======
+translate J compConcurrent {Истовремене игре:}
+# ====== TODO To be translated ======
+translate J compShowBoards {Схов Боардс}
+# ====== TODO To be translated ======
+translate J compCarousel {Цароусел систем}
+# ====== TODO To be translated ======
+translate J compSaveEval {Сачувај евалуацију}
+# ====== TODO To be translated ======
+translate J compCanceledGames {Отказане или истекле игре:}
+# ====== TODO To be translated ======
+translate J Replay {Реплаи}
+# ====== TODO To be translated ======
+translate J compStart {Почни}
+# ====== TODO To be translated ======
+translate J compSave {Сачувајте после сваке утакмице}
+# ====== TODO To be translated ======
+translate J compStop {Зауставите се након завршетка чина. игра}
+# ====== TODO To be translated ======
+translate J compRunning {Турнир је у току}
+# ====== TODO To be translated ======
+translate J Restart {Поново покрени}
+# ====== TODO To be translated ======
+translate J compFinished {Турнир је завршен}
+# ====== TODO To be translated ======
+translate J compStopped {Турнир је заустављен}
 
 Сваки пут када се учита игра са играчем на листи, шаховска табла главног прозора ће се ротирати ако је потребно да се игра прикаже из перспективе тог играча.}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate J showblunderexists {показати да грешка постоји}
@@ -1797,8 +1897,8 @@ translate J TBNoMoves {Није пронађен ниједан правни п�
 translate J TBTooMany {Превише комада. Лицхесс постоље за сто подржава до 7 комада.}
 translate J TBQuerying {Querying Lichess API...}
 translate J TBError {Грешка при покретању цурл-а за упит Лицхесс-а.}
-translate J TBNotFound {Позиција није пронађена у бази табеле или грешка у АПИ-ју.}
 translate J TBQueryError {Грешка: неисправан одговор Лицхесс-а.}
+translate J TBNotFound {Позиција није пронађена у бази табеле или грешка у АПИ-ју.}
 translate J TBCategory {Категорија позиције:}
 translate J TBTrainingHidden {(Режим обуке; резултати су скривени)}
 }

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -112,6 +112,8 @@ menuText b GameGotoMove "মুভ নম্বরে যান..." 5 \
   {বর্তমান গেমে একটি নির্দিষ্ট সরানো নম্বরে যান}
 menuText b GameNovelty "নতুনত্ব খুঁজুন..." 7 \
   {এই গেমের প্রথম চালটি খুঁজুন যা আগে খেলেনি}
+menuText b PlayTournament "টুর্নামেন্ট খেলুন..." 0 \
+    {একটি ইঞ্জিন টুর্নামেন্ট খেলুন}
 
 # Search Menu:
 menuText b Search "অনুসন্ধান করুন" 0
@@ -1380,8 +1382,106 @@ translate b RecentFilesExtra {অতিরিক্ত সাবমেনুত�
 
 # My Player Names options:
 translate b MyPlayerNamesDescription {নিচে পছন্দের প্লেয়ারের নামের তালিকা লিখুন, প্রতি লাইনে একটি নাম। ওয়াইল্ডকার্ড (যেমন "?" যেকোনো একক অক্ষরের জন্য, "*" অক্ষরের যেকোনো অনুক্রমের জন্য) অনুমোদিত।
+# ====== TODO To be translated ======
+translate b configComp {টুর্নামেন্ট কনফিগার করুন}
+# ====== TODO To be translated ======
+translate b Tournament {টুর্নামেন্ট}
+# ====== TODO To be translated ======
+translate b Available {পাওয়া যায়}
+# ====== TODO To be translated ======
+translate b Selected {নির্বাচিত}
+# ====== TODO To be translated ======
+translate b RoundRobin {রাউন্ড রবিন}
+# ====== TODO To be translated ======
+translate b Gauntlet {গান্টলেট}
+# ====== TODO To be translated ======
+translate b CompGameNext {পরবর্তী খেলা:}
+# ====== TODO To be translated ======
+translate b TimeperGame {খেলা প্রতি সময়}
+# ====== TODO To be translated ======
+translate b TimeperMove {সময় প্রতি \ মুভ}
+# ====== TODO To be translated ======
+translate b compStoreTime {দোকান সময়:}
+# ====== TODO To be translated ======
+translate b Clock {ঘড়ি}
+# ====== TODO To be translated ======
+translate b compConcurrent {সমসাময়িক গেম:}
+# ====== TODO To be translated ======
+translate b compShowBoards {বোর্ড দেখান}
+# ====== TODO To be translated ======
+translate b compCarousel {ক্যারোজেল সিস্টেম}
+# ====== TODO To be translated ======
+translate b compSaveEval {মূল্যায়ন সংরক্ষণ করুন}
+# ====== TODO To be translated ======
+translate b compCanceledGames {বাতিল বা টাইম আউট গেম:}
+# ====== TODO To be translated ======
+translate b Replay {রিপ্লে}
+# ====== TODO To be translated ======
+translate b compStart {শুরু করুন}
+# ====== TODO To be translated ======
+translate b compSave {প্রতিটি খেলার পরে সংরক্ষণ করুন}
+# ====== TODO To be translated ======
+translate b compStop {কাজ শেষ হওয়ার পরে থামুন। খেলা}
+# ====== TODO To be translated ======
+translate b compRunning {টুর্নামেন্ট চলছে}
+# ====== TODO To be translated ======
+translate b Restart {রিস্টার্ট করুন}
+# ====== TODO To be translated ======
+translate b compFinished {টুর্নামেন্ট শেষ}
+# ====== TODO To be translated ======
+translate b compStopped {টুর্নামেন্ট বন্ধ}
 
 প্রতিবার তালিকার একজন খেলোয়াড়ের সাথে একটি খেলা লোড করা হলে, সেই খেলোয়াড়দের দৃষ্টিকোণ থেকে খেলাটি দেখানোর জন্য প্রয়োজনে মূল উইন্ডো চেসবোর্ডটি ঘোরানো হবে।}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate b showblunderexists {শো ভুল বিদ্যমান}
@@ -1756,6 +1856,7 @@ translate b TBNoMoves {কোন আইনি পদক্ষেপ পাওয
 translate b TBTooMany {অনেক টুকরা. লিচেস টেবিলবেস 7 টুকরা পর্যন্ত সমর্থন করে।}
 translate b TBQuerying {Lichess API জিজ্ঞাসা করা হচ্ছে...}
 translate b TBError {Lichess ক্যোয়ারী করতে কার্ল চালু করতে ত্রুটি৷}
+translate b TBQueryError {টেবিলবেস API থেকে অবৈধ প্রতিক্রিয়া।}
 translate b TBNotFound {টেবিলবেস বা API ত্রুটিতে অবস্থান পাওয়া যায়নি।}
 translate b TBCategory {অবস্থান বিভাগ:}
 translate b TBTrainingHidden {(প্রশিক্ষণ মোড; ফলাফল লুকানো আছে)}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -153,6 +153,8 @@ menuText g GameGotoMove "Към номера на преместване..." 5 \
   {Отидете до определен номер на ход в текущата игра}
 menuText g GameNovelty "Намерете новост..." 7 \
   {Намерете първия ход на тази игра, който не е игран преди}
+menuText g PlayTournament "Играйте турнир..." 0 \
+    {Играйте турнир по двигатели}
 
 # Search Menu:
 menuText g Search "Търсене" 0
@@ -1421,8 +1423,106 @@ translate g RecentFilesExtra {Брой скорошни файлове в доп
 
 # My Player Names options:
 translate g MyPlayerNamesDescription {Въведете списък с предпочитани имена на играчи по-долу, по едно име на ред. Заместващи символи (напр. „?“ за всеки отделен знак, „*“ за всяка последователност от знаци) са разрешени.
+# ====== TODO To be translated ======
+translate g configComp {Конфигуриране на турнира}
+# ====== TODO To be translated ======
+translate g Tournament {Турнир}
+# ====== TODO To be translated ======
+translate g Available {Наличен}
+# ====== TODO To be translated ======
+translate g Selected {Избрано}
+# ====== TODO To be translated ======
+translate g RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate g Gauntlet {Ръкавица}
+# ====== TODO To be translated ======
+translate g CompGameNext {Следваща игра:}
+# ====== TODO To be translated ======
+translate g TimeperGame {Време за\игра}
+# ====== TODO To be translated ======
+translate g TimeperMove {Време на ход}
+# ====== TODO To be translated ======
+translate g compStoreTime {Време за съхранение:}
+# ====== TODO To be translated ======
+translate g Clock {Часовник}
+# ====== TODO To be translated ======
+translate g compConcurrent {Едновременни игри:}
+# ====== TODO To be translated ======
+translate g compShowBoards {Показване на табла}
+# ====== TODO To be translated ======
+translate g compCarousel {Каруселна система}
+# ====== TODO To be translated ======
+translate g compSaveEval {Запазване на оценката}
+# ====== TODO To be translated ======
+translate g compCanceledGames {Отменени или изтекли игри:}
+# ====== TODO To be translated ======
+translate g Replay {Повторение}
+# ====== TODO To be translated ======
+translate g compStart {Започнете}
+# ====== TODO To be translated ======
+translate g compSave {Запазване след всяка игра}
+# ====== TODO To be translated ======
+translate g compStop {Спрете след края\на акта. игра}
+# ====== TODO To be translated ======
+translate g compRunning {Турнирът е в ход}
+# ====== TODO To be translated ======
+translate g Restart {Рестартирайте}
+# ====== TODO To be translated ======
+translate g compFinished {Турнирът приключи}
+# ====== TODO To be translated ======
+translate g compStopped {Турнирът спря}
 
 Всеки път, когато се зареди игра с играч в списъка, шахматната дъска на главния прозорец ще се завърти, ако е необходимо, за да се покаже играта от гледна точка на този играч.}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate g showblunderexists {покажете, че гафът съществува}
@@ -1797,8 +1897,8 @@ translate g TBNoMoves {Няма открити законни ходове.}
 translate g TBTooMany {Твърде много парчета. Базата за маса Lichess поддържа до 7 части.}
 translate g TBQuerying {Извършва се заявка за API на Lichess...}
 translate g TBError {Грешка при стартиране на curl за заявка на Lichess.}
-translate g TBNotFound {Позицията не е намерена в табличната база или грешка в API.}
 translate g TBQueryError {Невалиден отговор от API на табличната база.}
+translate g TBNotFound {Позицията не е намерена в табличната база или грешка в API.}
 translate g TBCategory {Категория на позицията:}
 translate g TBTrainingHidden {(Режим на обучение; резултатите са скрити)}
 }

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -120,6 +120,8 @@ menuText K GameGotoMove "Anar a la jugada número..." 6 \
   {Ves al número de jugada especificat dins la partida actual}
 menuText K GameNovelty "Trobar Novetat..." 12 \
   {Cerca la primera jugada d'aquesta partida que no s'ha jugat abans}
+menuText K PlayTournament "Juga al torneig..." 0 \
+    {Juga un torneig de motors}
 
 # Search Menu:
 menuText K Search "Cercar" 0
@@ -1423,10 +1425,108 @@ translate K RecentFilesExtra {Nombre d'arxius recents al submenú extra}
 
 # My Player Names options:
 translate K MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate K configComp {Configura el torneig}
+# ====== TODO To be translated ======
+translate K Tournament {Torneig}
+# ====== TODO To be translated ======
+translate K Available {Disponible}
+# ====== TODO To be translated ======
+translate K Selected {Seleccionat}
+# ====== TODO To be translated ======
+translate K RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate K Gauntlet {Guantlet}
+# ====== TODO To be translated ======
+translate K CompGameNext {Següent joc:}
+# ====== TODO To be translated ======
+translate K TimeperGame {Temps per\Joc}
+# ====== TODO To be translated ======
+translate K TimeperMove {Temps per\Moviment}
+# ====== TODO To be translated ======
+translate K compStoreTime {Hora de la botiga:}
+# ====== TODO To be translated ======
+translate K Clock {Rellotge}
+# ====== TODO To be translated ======
+translate K compConcurrent {Jocs simultanis:}
+# ====== TODO To be translated ======
+translate K compShowBoards {Mostra els taulers}
+# ====== TODO To be translated ======
+translate K compCarousel {Sistema de carrusel}
+# ====== TODO To be translated ======
+translate K compSaveEval {Guardar l'avaluació}
+# ====== TODO To be translated ======
+translate K compCanceledGames {Partits cancel·lats o esgotats:}
+# ====== TODO To be translated ======
+translate K Replay {Repetició}
+# ====== TODO To be translated ======
+translate K compStart {Comença}
+# ====== TODO To be translated ======
+translate K compSave {Estalvia després de cada joc}
+# ====== TODO To be translated ======
+translate K compStop {Atura després del final\de l'acte. joc}
+# ====== TODO To be translated ======
+translate K compRunning {Torneig en curs}
+# ====== TODO To be translated ======
+translate K Restart {Reinicieu}
+# ====== TODO To be translated ======
+translate K compFinished {Torneig acabat}
+# ====== TODO To be translated ======
+translate K compStopped {Torneig aturat}
 Escriu una llista de noms alternatius per jugador, un nom per cada línia. Es permeten comodins (per exemple "?" per un caracter, "*" per varis caracters).
 
 Cada cop que es carregui una partida amb un jugador de la llista es girarà l'escaquer, si fos necessari, per veure la partida des de la perspectiva del jugador.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate K showblunderexists {Mostrar ficada de pota}
@@ -1801,6 +1901,7 @@ translate K TBNoMoves {No s'han trobat moviments legals.}
 translate K TBTooMany {Massa peces. La base de taula Lichess admet fins a 7 peces.}
 translate K TBQuerying {Consultant l'API de Lichess...}
 translate K TBError {S'ha produït un error en iniciar curl per consultar Lichess.}
+translate K TBQueryError {Resposta no vàlida de l'API tablebase.}
 translate K TBNotFound {No s'ha trobat la posició a la base de taules o error de l'API.}
 translate K TBCategory {Categoria de la posició:}
 translate K TBTrainingHidden {(Mode d'entrenament; els resultats estan ocults)}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -93,6 +93,8 @@ menuText M GameDelete "删除游戏" 0 {切换删除当前游戏的标志}
 menuText M GameDeepest "识别开局" 0 {转到ECO手册中列出的最深游戏位置}
 menuText M GameGotoMove "转到着法编号..." 0 {转到当前游戏中的指定着法编号}
 menuText M GameNovelty "查找新着..." 0 {查找此游戏中之前未下过的第一步棋}
+menuText M PlayTournament "参加锦标赛..." 0 \
+    {参加引擎锦标赛}
 
 # Search Menu:
 menuText M Search "搜索" 0
@@ -1356,8 +1358,106 @@ translate M RecentFilesExtra {额外子菜单中最近文件的数量}
 
 # My Player Names options:
 translate M MyPlayerNamesDescription {在下面输入首选玩家姓名列表，每行一个姓名。允许使用通配符（例如“？”表示任何单个字符，“*”表示任何字符序列）。
+# ====== TODO To be translated ======
+translate M configComp {配置锦标赛}
+# ====== TODO To be translated ======
+translate M Tournament {比赛}
+# ====== TODO To be translated ======
+translate M Available {可用的}
+# ====== TODO To be translated ======
+translate M Selected {已选择}
+# ====== TODO To be translated ======
+translate M RoundRobin {循环赛}
+# ====== TODO To be translated ======
+translate M Gauntlet {挑战}
+# ====== TODO To be translated ======
+translate M CompGameNext {下一场比赛：}
+# ====== TODO To be translated ======
+translate M TimeperGame {每场比赛时间}
+# ====== TODO To be translated ======
+translate M TimeperMove {每次\移动时间}
+# ====== TODO To be translated ======
+translate M compStoreTime {储存时间：}
+# ====== TODO To be translated ======
+translate M Clock {钟}
+# ====== TODO To be translated ======
+translate M compConcurrent {并发游戏：}
+# ====== TODO To be translated ======
+translate M compShowBoards {显示板}
+# ====== TODO To be translated ======
+translate M compCarousel {轮播系统}
+# ====== TODO To be translated ======
+translate M compSaveEval {保存评价}
+# ====== TODO To be translated ======
+translate M compCanceledGames {取消或超时的比赛：}
+# ====== TODO To be translated ======
+translate M Replay {重播}
+# ====== TODO To be translated ======
+translate M compStart {开始}
+# ====== TODO To be translated ======
+translate M compSave {每场比赛后保存}
+# ====== TODO To be translated ======
+translate M compStop {行为结束后停止。游戏}
+# ====== TODO To be translated ======
+translate M compRunning {比赛进行中}
+# ====== TODO To be translated ======
+translate M Restart {重新启动}
+# ====== TODO To be translated ======
+translate M compFinished {比赛结束}
+# ====== TODO To be translated ======
+translate M compStopped {比赛停止}
 
 每次加载列表中包含玩家的游戏时，如有必要，主窗口棋盘都会旋转，以从该玩家的角度显示游戏。}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate M showblunderexists {显示存在错误}
@@ -1732,8 +1832,8 @@ translate M TBNoMoves {未发现合法动作。}
 translate M TBTooMany {太多了。 Lichess 桌底座最多可容纳 7 块。}
 translate M TBQuerying {正在查询 Lichess API...}
 translate M TBError {启动curl 查询Lichess 时出错。}
-translate M TBNotFound {在表库中找不到位置或 API 错误。}
 translate M TBQueryError {表库 API 的响应无效。}
+translate M TBNotFound {在表库中找不到位置或 API 错误。}
 translate M TBCategory {职位类别：}
 translate M TBTrainingHidden {（训练模式；结果隐藏）}
 }

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -115,6 +115,8 @@ menuText C GameGotoMove "Pejt na tah slo..." 10 \
   {Pejt v aktuln partii do pozice udan slem tahu}
 menuText C GameNovelty "Hledat novinku..." 0 \
   {Hledat prvn tah tto partie, kter doposud nebyl hrn}
+menuText C PlayTournament "Hrát turnaj..." 0 \
+    {Zahrajte si motorový turnaj}
 
 # Search Menu:
 menuText C Search "Hledat" 0
@@ -1401,10 +1403,108 @@ translate C RecentFilesExtra {Poet nedvnch soubor v extra podmenu}
 
 # My Player Names options:
 translate C MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate C configComp {Konfigurace turnaje}
+# ====== TODO To be translated ======
+translate C Tournament {Turnaj}
+# ====== TODO To be translated ======
+translate C Available {K dispozici}
+# ====== TODO To be translated ======
+translate C Selected {Vybraný}
+# ====== TODO To be translated ======
+translate C RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate C Gauntlet {Rukavice}
+# ====== TODO To be translated ======
+translate C CompGameNext {Další hra:}
+# ====== TODO To be translated ======
+translate C TimeperGame {Čas na\hru}
+# ====== TODO To be translated ======
+translate C TimeperMove {Čas za\tah}
+# ====== TODO To be translated ======
+translate C compStoreTime {Čas uložení:}
+# ====== TODO To be translated ======
+translate C Clock {Hodiny}
+# ====== TODO To be translated ======
+translate C compConcurrent {Souběžné hry:}
+# ====== TODO To be translated ======
+translate C compShowBoards {Zobrazit nástěnky}
+# ====== TODO To be translated ======
+translate C compCarousel {Karuselový systém}
+# ====== TODO To be translated ======
+translate C compSaveEval {Uložit hodnocení}
+# ====== TODO To be translated ======
+translate C compCanceledGames {Zrušené nebo vypršel časový limit:}
+# ====== TODO To be translated ======
+translate C Replay {Přehrát znovu}
+# ====== TODO To be translated ======
+translate C compStart {Start}
+# ====== TODO To be translated ======
+translate C compSave {Uložte po každé hře}
+# ====== TODO To be translated ======
+translate C compStop {Zastavte se po skončení akce. hra}
+# ====== TODO To be translated ======
+translate C compRunning {Turnaj probíhá}
+# ====== TODO To be translated ======
+translate C Restart {Restartujte}
+# ====== TODO To be translated ======
+translate C compFinished {Turnaj ukončen}
+# ====== TODO To be translated ======
+translate C compStopped {Turnaj zastaven}
 Oteve seznam se jmny preferovanch hr, kad jmno na jeden dek. Zstupn znaky (tj. "?" pro jakkoliv jeden znak, "*" pro jakoukoliv sekvenci znak) jsou povoleny.
 
 Vdy, kdy se nathne partie hre uvedenho v seznamu, achovnice v hlavnm okn se oto, jestlie je to nutn k zobrazen partie z perspektivy tohoto hre.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate C showblunderexists {ukzat ptomnost hrub chyby}
@@ -1779,6 +1879,7 @@ translate C TBNoMoves {Nebyly nalezeny žádné legální kroky.}
 translate C TBTooMany {Příliš mnoho kusů. Stolová podnož Lichess podporuje až 7 kusů.}
 translate C TBQuerying {Dotazování Lichess API...}
 translate C TBError {Chyba při spouštění curl pro dotaz Lichess.}
+translate C TBQueryError {Neplatná odpověď z rozhraní API tabulky.}
 translate C TBNotFound {Pozice nebyla nalezena v tabulce nebo chyba API.}
 translate C TBCategory {Kategorie pozice:}
 translate C TBTrainingHidden {(Tréninkový režim; výsledky jsou skryté)}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -136,6 +136,8 @@ menuText D GameGotoMove "Zugnummer..." 0 \
   {Zur angegebenen Zugnummer in der aktuellen Partie gehen}
 menuText D GameNovelty "Finde Neuerung..." 0 \
   {Ersten Zug dieser Partie finden, der vorher noch nie gespielt wurde}
+menuText D PlayTournament "Turnier spielen..." 0 \
+    {Spielen Sie ein Motorenturnier}
 
 # Search Menu:
 menuText D Search "Suchen" 0
@@ -1450,10 +1452,108 @@ translate D RecentFilesExtra {Anzahl letzter Dateien im Untermenü}
 
 # My Player Names options:
 translate D MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate D configComp {Turnier konfigurieren}
+# ====== TODO To be translated ======
+translate D Tournament {Turnier}
+# ====== TODO To be translated ======
+translate D Available {Verfügbar}
+# ====== TODO To be translated ======
+translate D Selected {Ausgewählt}
+# ====== TODO To be translated ======
+translate D RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate D Gauntlet {Stulpe}
+# ====== TODO To be translated ======
+translate D CompGameNext {Nächstes Spiel:}
+# ====== TODO To be translated ======
+translate D TimeperGame {Zeit pro\Spiel}
+# ====== TODO To be translated ======
+translate D TimeperMove {Zeit pro Zug}
+# ====== TODO To be translated ======
+translate D compStoreTime {Lagerzeit:}
+# ====== TODO To be translated ======
+translate D Clock {Uhr}
+# ====== TODO To be translated ======
+translate D compConcurrent {Gleichzeitige Spiele:}
+# ====== TODO To be translated ======
+translate D compShowBoards {Pinnwände anzeigen}
+# ====== TODO To be translated ======
+translate D compCarousel {Karussellsystem}
+# ====== TODO To be translated ======
+translate D compSaveEval {Auswertung speichern}
+# ====== TODO To be translated ======
+translate D compCanceledGames {Abgebrochene oder abgelaufene Spiele:}
+# ====== TODO To be translated ======
+translate D Replay {Wiederholung}
+# ====== TODO To be translated ======
+translate D compStart {Start}
+# ====== TODO To be translated ======
+translate D compSave {Speichern Sie nach jedem Spiel}
+# ====== TODO To be translated ======
+translate D compStop {Stoppen Sie nach dem Ende des Vorgangs. Spiel}
+# ====== TODO To be translated ======
+translate D compRunning {Turnier läuft}
+# ====== TODO To be translated ======
+translate D Restart {Neustart}
+# ====== TODO To be translated ======
+translate D compFinished {Turnier beendet}
+# ====== TODO To be translated ======
+translate D compStopped {Das Turnier wurde gestoppt}
 Geben Sie unten eine Liste der bevorzugten Spielernamen ein, ein Name pro Zeile. Platzhalterzeichen (z.B. "?" für ein beliebiges einzelnes Zeichen, "*" für jede beliebige Folge von Zeichen) sind erlaubt.
 
 Jedesmal, wenn ein Spiel mit einem aufgelisteten Spielernamen geladen wird, wird das Schachbrett im Hauptfenster erforderlichenfalls gedreht, um das Spiel aus der Sicht des betreffenden Spielers zu zeigen.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate D showblunderexists {Enginefehler anzeigen}
@@ -1828,6 +1928,7 @@ translate D TBNoMoves {Keine legalen Schritte gefunden.}
 translate D TBTooMany {Zu viele Stücke. Der Lichess-Tischfuß trägt bis zu 7 Teile.}
 translate D TBQuerying {Lichess-API wird abgefragt...}
 translate D TBError {Fehler beim Starten von Curl zur Abfrage von Lichess.}
+translate D TBQueryError {Ungültige Antwort von der Tablebase-API.}
 translate D TBNotFound {Position in der Tabellenbasis nicht gefunden oder API-Fehler.}
 translate D TBCategory {Positionskategorie:}
 translate D TBTrainingHidden {(Trainingsmodus; Ergebnisse werden ausgeblendet)}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -152,6 +152,8 @@ menuText E GameGotoMove "Goto Move Number..." 5 \
   {Go to a specified move number in the current game}
 menuText E GameNovelty "Find Novelty..." 7 \
   {Find the first move of this game that has not played before}
+menuText E PlayTournament "Play Tournament..." 0 \
+    {Play an engine tournament}
 
 # Search Menu:
 menuText E Search "Search" 0
@@ -1437,6 +1439,32 @@ Enter a list of preferred player names below, one name per line. Wildcards (e.g.
 
 Every time a game with a player in the list is loaded, the main window chessboard will be rotated if necessary to show the game from that players perspective.
 }
+
+# Computer Tournament:
+translate E configComp {Configure Tournament}
+translate E Tournament {Tournament}
+translate E Available {Available}
+translate E Selected {Selected}
+translate E RoundRobin {Round Robin}
+translate E Gauntlet {Gauntlet}
+translate E CompGameNext {Next game:}
+translate E TimeperGame {Time per\nGame}
+translate E TimeperMove {Time per\nMove}
+translate E compStoreTime {Store Time: }
+translate E Clock {Clock}
+translate E compConcurrent {Concurrent games: }
+translate E compShowBoards {Show Boards}
+translate E compCarousel {Carousel system}
+translate E compSaveEval {Save evaluation}
+translate E compCanceledGames {Canceled or timed out games:}
+translate E Replay {Replay}
+translate E compStart {Start}
+translate E compSave {Save after every game}
+translate E compStop {Stop after end\nof act. game}
+translate E compRunning {Tournament in progress}
+translate E Restart {Restart}
+translate E compFinished {Tournament finished}
+translate E compStopped {Tournament stopped}
 
 #Coach
 translate E showblunderexists {show blunder exists}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -117,6 +117,8 @@ menuText F GameGotoMove "Aller au coup numéro..." 14 \
   {Aller au coup spécifié dans la partie en cours}
 menuText F GameNovelty "Trouver la nouveauté..." 4 \
   {Trouver le premier coup de la partie qui n'a pas été joué auparavant}
+menuText F PlayTournament "Jouer au tournoi..." 0 \
+    {Jouez à un tournoi de moteur}
 
 # Search Menu:
 menuText F Search "Rechercher" 0
@@ -1407,10 +1409,108 @@ translate F RecentFilesExtra {Nombre de fichiers récents dans le sous-menu comp
 
 # My Player Names options:
 translate F MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate F configComp {Configurer le tournoi}
+# ====== TODO To be translated ======
+translate F Tournament {Tournoi}
+# ====== TODO To be translated ======
+translate F Available {Disponible}
+# ====== TODO To be translated ======
+translate F Selected {Choisi}
+# ====== TODO To be translated ======
+translate F RoundRobin {Tournoi à la ronde}
+# ====== TODO To be translated ======
+translate F Gauntlet {Gant}
+# ====== TODO To be translated ======
+translate F CompGameNext {Prochain jeu :}
+# ====== TODO To be translated ======
+translate F TimeperGame {Temps par\Jeu}
+# ====== TODO To be translated ======
+translate F TimeperMove {Temps par\Déplacement}
+# ====== TODO To be translated ======
+translate F compStoreTime {Heure du magasin :}
+# ====== TODO To be translated ======
+translate F Clock {Horloge}
+# ====== TODO To be translated ======
+translate F compConcurrent {Jeux simultanés :}
+# ====== TODO To be translated ======
+translate F compShowBoards {Afficher les tableaux}
+# ====== TODO To be translated ======
+translate F compCarousel {Système de carrousel}
+# ====== TODO To be translated ======
+translate F compSaveEval {Enregistrer l'évaluation}
+# ====== TODO To be translated ======
+translate F compCanceledGames {Parties annulées ou expirées :}
+# ====== TODO To be translated ======
+translate F Replay {Rejouer}
+# ====== TODO To be translated ======
+translate F compStart {Commencer}
+# ====== TODO To be translated ======
+translate F compSave {Sauvegardez après chaque partie}
+# ====== TODO To be translated ======
+translate F compStop {Arrêt après la fin de l'acte. jeu}
+# ====== TODO To be translated ======
+translate F compRunning {Tournoi en cours}
+# ====== TODO To be translated ======
+translate F Restart {Redémarrage}
+# ====== TODO To be translated ======
+translate F compFinished {Tournoi terminé}
+# ====== TODO To be translated ======
+translate F compStopped {Tournoi arrêté}
 Entrer ci-dessous une liste des noms des joueurs préférés, un nom par ligne. Les caractères spéciaux (i.e. "?" pour un seul caractère, "*" pour n'importe quelle suite de caractères) sont autorisés.
 
 Chaque fois qu'une partie avec un joueur de la liste est chargée, l'échiquier de la fenêtre principale sera tourné si nécessaire de façon à montrer la partie selon le point de vue du joueur.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate F showblunderexists {Montrer si erreur}
@@ -1785,6 +1885,7 @@ translate F TBNoMoves {Aucun mouvement légal trouvé.}
 translate F TBTooMany {Trop de pièces. La base de table Lichess prend en charge jusqu'à 7 pièces.}
 translate F TBQuerying {Interrogation de l'API Lichess...}
 translate F TBError {Erreur lors du lancement de curl pour interroger Lichess.}
+translate F TBQueryError {Réponse non valide de l'API tablebase.}
 translate F TBNotFound {Position introuvable dans la base de table ou erreur API.}
 translate F TBCategory {Catégorie de poste :}
 translate F TBTrainingHidden {(Mode Entraînement ; les résultats sont masqués)}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -144,6 +144,8 @@ menuText G GameGotoMove "Μετάβαση στην κίνηση με αριθμ�
   {Μετάβαση στην κίνηση με συγκεκριμένο αριθμό στην τρέχουσα παρτίδα}
 menuText G GameNovelty "Αναζήτηση νεοτερισμού..." 7 \
   {Βρείτε την πρώτη κίνηση αυτής της παρτίδας που δεν έχει παιχθεί ποτέ}
+menuText G PlayTournament "Παίξτε Τουρνουά..." 0 \
+    {Παίξτε ένα τουρνουά κινητήρα}
 
 # Search Menu:
 menuText G Search "Αναζήτηση" 0
@@ -1428,10 +1430,108 @@ translate G RecentFilesExtra {Πλήθος των πρόσφατων αρχεί�
 
 # My Player Names options:
 translate G MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate G configComp {Διαμόρφωση Τουρνουά}
+# ====== TODO To be translated ======
+translate G Tournament {Τουρνουά}
+# ====== TODO To be translated ======
+translate G Available {Διαθέσιμος}
+# ====== TODO To be translated ======
+translate G Selected {Επιλεγμένο}
+# ====== TODO To be translated ======
+translate G RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate G Gauntlet {Γάντι}
+# ====== TODO To be translated ======
+translate G CompGameNext {Επόμενο παιχνίδι:}
+# ====== TODO To be translated ======
+translate G TimeperGame {Χρόνος ανά\Παιχνίδι}
+# ====== TODO To be translated ======
+translate G TimeperMove {Χρόνος ανά\Μετακίνηση}
+# ====== TODO To be translated ======
+translate G compStoreTime {Ώρα καταστήματος:}
+# ====== TODO To be translated ======
+translate G Clock {Ρολόι}
+# ====== TODO To be translated ======
+translate G compConcurrent {Ταυτόχρονα παιχνίδια:}
+# ====== TODO To be translated ======
+translate G compShowBoards {Εμφάνιση πινάκων}
+# ====== TODO To be translated ======
+translate G compCarousel {Σύστημα καρουζέλ}
+# ====== TODO To be translated ======
+translate G compSaveEval {Αποθήκευση αξιολόγησης}
+# ====== TODO To be translated ======
+translate G compCanceledGames {Παιχνίδια που ακυρώθηκαν ή έληξαν:}
+# ====== TODO To be translated ======
+translate G Replay {Ξαναπαίζω}
+# ====== TODO To be translated ======
+translate G compStart {Αρχή}
+# ====== TODO To be translated ======
+translate G compSave {Αποθήκευση μετά από κάθε παιχνίδι}
+# ====== TODO To be translated ======
+translate G compStop {Διακοπή μετά το τέλος της πράξης. παιχνίδι}
+# ====== TODO To be translated ======
+translate G compRunning {Τουρνουά σε εξέλιξη}
+# ====== TODO To be translated ======
+translate G Restart {Επανεκκίνηση}
+# ====== TODO To be translated ======
+translate G compFinished {Το τουρνουά ολοκληρώθηκε}
+# ====== TODO To be translated ======
+translate G compStopped {Το τουρνουά σταμάτησε}
 Δημιουργήστε παρακάτω μια λίστα των ονομάτων των προτιμόμενων παικτών, ένα για κάθε γραμμή. Τα συμβολα μπαλαντέρ (π.χ. "?" για κάνε έναν μοναδικό χαρακτήρα, "*" για οποιαδήποτε ακολουθία χαρακτήρων) επιτρέπονται.
 
 Κάθε φορά που θα φορτώνεται μια παρτίδα με παίκτη που υπάρχειστην λίστα, αν είναι απαραίτητο η σκακιέρα του κυρίως παραθύρου θα περιστρέφεται ώστε η παρτίδα να προβάλεται από την μεριά αυτού του παίκτη.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate G showblunderexists {εμφάνιση ότι το σφάλμα υπάρχει}
@@ -1806,6 +1906,7 @@ translate G TBNoMoves {Δεν βρέθηκαν νομικές κινήσεις.}
 translate G TBTooMany {Πάρα πολλά κομμάτια. Η επιτραπέζια βάση Lichess υποστηρίζει έως και 7 κομμάτια.}
 translate G TBQuerying {Querying Lichess API...}
 translate G TBError {Σφάλμα κατά την εκκίνηση του curl στο ερώτημα Lichess.}
+translate G TBQueryError {Μη έγκυρη απάντηση από το API του tablebase.}
 translate G TBNotFound {Η θέση δεν βρέθηκε στη βάση του πίνακα ή σφάλμα API.}
 translate G TBCategory {Κατηγορία θέσης:}
 translate G TBTrainingHidden {(Λειτουργία προπόνησης, τα αποτελέσματα είναι κρυφά)}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -113,6 +113,8 @@ menuText V GameGotoMove "עבור למספר העברה..." 5 \
   {עבור למספר מהלך מוגדר במשחק הנוכחי}
 menuText V GameNovelty "מצא חידוש..." 7 \
   {מצא את המהלך הראשון של המשחק הזה שלא שיחק בעבר}
+menuText V PlayTournament "לשחק טורניר..." 0 \
+    {שחקו בטורניר מנועים}
 
 # Search Menu:
 menuText V Search "לְחַפֵּשׂ" 0
@@ -1381,8 +1383,106 @@ translate V RecentFilesExtra {מספר הקבצים האחרונים בתפרי�
 
 # My Player Names options:
 translate V MyPlayerNamesDescription {הזן רשימה של שמות שחקנים מועדפים למטה, שם אחד בכל שורה. תווים כלליים (למשל "?" עבור כל תו בודד, "*" עבור כל רצף של תווים) מותרים.
+# ====== TODO To be translated ======
+translate V configComp {הגדר את הטורניר}
+# ====== TODO To be translated ======
+translate V Tournament {טוּרנִיר}
+# ====== TODO To be translated ======
+translate V Available {זָמִין}
+# ====== TODO To be translated ======
+translate V Selected {נִבחָר}
+# ====== TODO To be translated ======
+translate V RoundRobin {רובין עגול}
+# ====== TODO To be translated ======
+translate V Gauntlet {כְּפָפַת שִׁריוֹן}
+# ====== TODO To be translated ======
+translate V CompGameNext {המשחק הבא:}
+# ====== TODO To be translated ======
+translate V TimeperGame {זמן ל\משחק}
+# ====== TODO To be translated ======
+translate V TimeperMove {זמן לכל תנועה}
+# ====== TODO To be translated ======
+translate V compStoreTime {זמן חנות:}
+# ====== TODO To be translated ======
+translate V Clock {שָׁעוֹן}
+# ====== TODO To be translated ======
+translate V compConcurrent {משחקים במקביל:}
+# ====== TODO To be translated ======
+translate V compShowBoards {הצג לוחות}
+# ====== TODO To be translated ======
+translate V compCarousel {מערכת קרוסלה}
+# ====== TODO To be translated ======
+translate V compSaveEval {שמור הערכה}
+# ====== TODO To be translated ======
+translate V compCanceledGames {משחקים שבוטלו או פג פסק זמן:}
+# ====== TODO To be translated ======
+translate V Replay {מִשְׂחָק חוֹזֵר}
+# ====== TODO To be translated ======
+translate V compStart {הַתחָלָה}
+# ====== TODO To be translated ======
+translate V compSave {שמור אחרי כל משחק}
+# ====== TODO To be translated ======
+translate V compStop {עצור לאחר סיום המעשה. מִשְׂחָק}
+# ====== TODO To be translated ======
+translate V compRunning {הטורניר בעיצומו}
+# ====== TODO To be translated ======
+translate V Restart {הפעל מחדש}
+# ====== TODO To be translated ======
+translate V compFinished {הטורניר הסתיים}
+# ====== TODO To be translated ======
+translate V compStopped {הטורניר הופסק}
 
 בכל פעם שמשחק עם שחקן ברשימה נטען, לוח השחמט של החלון הראשי יסובב במידת הצורך כדי להציג את המשחק מנקודת המבט של השחקן הזה.}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate V showblunderexists {להראות טעות קיימת}
@@ -1757,6 +1857,7 @@ translate V TBNoMoves {לא נמצאו מהלכים חוקיים.}
 translate V TBTooMany {יותר מדי חתיכות. בסיס השולחן של ליצ'ס תומך בעד 7 חלקים.}
 translate V TBQuerying {מחפש את ממשק API של Lichess...}
 translate V TBError {שגיאה בהפעלת תלתל לשאילתה של Lichess.}
+translate V TBQueryError {תגובה לא חוקית מממשק API של tablebase.}
 translate V TBNotFound {המיקום לא נמצא בבסיס הטבלה או בשגיאת API.}
 translate V TBCategory {קטגוריית תפקיד:}
 translate V TBTrainingHidden {(מצב אימון; התוצאות מוסתרות)}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -112,6 +112,8 @@ menuText h GameGotoMove "गोटो मूव नंबर..." 5 \
   {वर्तमान गेम में निर्दिष्ट चाल संख्या पर जाएँ}
 menuText h GameNovelty "नवीनता खोजें..." 7 \
   {इस खेल की पहली चाल खोजें जो पहले नहीं खेली गई हो}
+menuText h PlayTournament "टूर्नामेंट खेलें..." 0 \
+    {एक इंजन टूर्नामेंट खेलें}
 
 # Search Menu:
 menuText h Search "खोज" 0
@@ -1380,8 +1382,106 @@ translate h RecentFilesExtra {अतिरिक्त सबमेनू मे
 
 # My Player Names options:
 translate h MyPlayerNamesDescription {नीचे पसंदीदा खिलाड़ियों के नामों की सूची दर्ज करें, प्रति पंक्ति एक नाम। वाइल्डकार्ड (जैसे किसी एकल वर्ण के लिए "?", वर्णों के किसी भी क्रम के लिए "*") की अनुमति है।
+# ====== TODO To be translated ======
+translate h configComp {टूर्नामेंट कॉन्फ़िगर करें}
+# ====== TODO To be translated ======
+translate h Tournament {टूर्नामेंट}
+# ====== TODO To be translated ======
+translate h Available {उपलब्ध}
+# ====== TODO To be translated ======
+translate h Selected {चयनित}
+# ====== TODO To be translated ======
+translate h RoundRobin {राउंड रोबिन}
+# ====== TODO To be translated ======
+translate h Gauntlet {लोहे का दस्ताना}
+# ====== TODO To be translated ======
+translate h CompGameNext {अगला गेम:}
+# ====== TODO To be translated ======
+translate h TimeperGame {प्रति गेम समय}
+# ====== TODO To be translated ======
+translate h TimeperMove {प्रति चाल समय}
+# ====== TODO To be translated ======
+translate h compStoreTime {स्टोर का समय:}
+# ====== TODO To be translated ======
+translate h Clock {घड़ी}
+# ====== TODO To be translated ======
+translate h compConcurrent {समवर्ती खेल:}
+# ====== TODO To be translated ======
+translate h compShowBoards {बोर्ड दिखाएँ}
+# ====== TODO To be translated ======
+translate h compCarousel {हिंडोला प्रणाली}
+# ====== TODO To be translated ======
+translate h compSaveEval {मूल्यांकन सहेजें}
+# ====== TODO To be translated ======
+translate h compCanceledGames {रद्द किए गए या समयबद्ध खेल:}
+# ====== TODO To be translated ======
+translate h Replay {REPLAY}
+# ====== TODO To be translated ======
+translate h compStart {शुरू}
+# ====== TODO To be translated ======
+translate h compSave {प्रत्येक गेम के बाद सहेजें}
+# ====== TODO To be translated ======
+translate h compStop {कार्य समाप्ति के बाद रुकें। खेल}
+# ====== TODO To be translated ======
+translate h compRunning {टूर्नामेंट चल रहा है}
+# ====== TODO To be translated ======
+translate h Restart {पुनः आरंभ करें}
+# ====== TODO To be translated ======
+translate h compFinished {टूर्नामेंट ख़त्म}
+# ====== TODO To be translated ======
+translate h compStopped {टूर्नामेंट रुक गया}
 
 हर बार जब सूची में किसी खिलाड़ी के साथ गेम लोड किया जाता है, तो गेम को उस खिलाड़ी के दृष्टिकोण से दिखाने के लिए यदि आवश्यक हो तो मुख्य विंडो शतरंज की बिसात को घुमाया जाएगा।}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate h showblunderexists {दिखाएँ भूल मौजूद है}
@@ -1756,6 +1856,7 @@ translate h TBNoMoves {कोई कानूनी कदम नहीं म�
 translate h TBTooMany {बहुत सारे टुकड़े. लाइकेस टेबलबेस 7 टुकड़ों तक का समर्थन करता है।}
 translate h TBQuerying {लाइकेस एपीआई को क्वेरी किया जा रहा है...}
 translate h TBError {लिचेस को क्वेरी करने के लिए कर्ल लॉन्च करने में त्रुटि।}
+translate h TBQueryError {टेबलबेस एपीआई से अमान्य प्रतिक्रिया।}
 translate h TBNotFound {टेबलबेस या एपीआई त्रुटि में स्थिति नहीं मिली।}
 translate h TBCategory {पद श्रेणी:}
 translate h TBTrainingHidden {(प्रशिक्षण मोड; परिणाम छिपे हुए हैं)}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -115,6 +115,8 @@ menuText H GameGotoMove "Ugrás megadott sorszámú lépéshez..." 1 \
   {Megadott sorszámú lépéshez ugrik az aktuális játszmában.}
 menuText H GameNovelty "Újítás keresése..." 1 \
   {Megkeresi ebben a játszmában az elsõ olyan lépést, amely korábban nem fordult elõ.}
+menuText H PlayTournament "Játssz versenyt..." 0 \
+    {Játssz egy motorversenyt}
 
 # Search Menu:
 menuText H Search "Keresés" 0
@@ -1402,10 +1404,108 @@ translate H RecentFilesExtra {Az aktuális fájlok száma a kiegészítõ almen�
 
 # My Player Names options:
 translate H MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate H configComp {Verseny konfigurálása}
+# ====== TODO To be translated ======
+translate H Tournament {Verseny}
+# ====== TODO To be translated ======
+translate H Available {Elérhető}
+# ====== TODO To be translated ======
+translate H Selected {Kiválasztott}
+# ====== TODO To be translated ======
+translate H RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate H Gauntlet {Páncélkesztyű}
+# ====== TODO To be translated ======
+translate H CompGameNext {Következő meccs:}
+# ====== TODO To be translated ======
+translate H TimeperGame {Játékonkénti idő}
+# ====== TODO To be translated ======
+translate H TimeperMove {Idő per\Mozgás}
+# ====== TODO To be translated ======
+translate H compStoreTime {Tárolási idő:}
+# ====== TODO To be translated ======
+translate H Clock {Óra}
+# ====== TODO To be translated ======
+translate H compConcurrent {Párhuzamos játékok:}
+# ====== TODO To be translated ======
+translate H compShowBoards {Táblák megjelenítése}
+# ====== TODO To be translated ======
+translate H compCarousel {Körhinta rendszer}
+# ====== TODO To be translated ======
+translate H compSaveEval {Értékelés mentése}
+# ====== TODO To be translated ======
+translate H compCanceledGames {Törölt vagy lejárt játékok:}
+# ====== TODO To be translated ======
+translate H Replay {Visszajátszás}
+# ====== TODO To be translated ======
+translate H compStart {Indul}
+# ====== TODO To be translated ======
+translate H compSave {Mentés minden játék után}
+# ====== TODO To be translated ======
+translate H compStop {Az aktus vége után állj le. játék}
+# ====== TODO To be translated ======
+translate H compRunning {A torna folyamatban}
+# ====== TODO To be translated ======
+translate H Restart {Indítsa újra}
+# ====== TODO To be translated ======
+translate H compFinished {A bajnokság befejeződött}
+# ====== TODO To be translated ======
+translate H compStopped {A bajnokság leállt}
 Add meg az általad kedvelt játékosok nevét, soronként egyet. Helyettesítõ karaktereket (pl. "?" tetszõleges karakter helyett, "*" tetszõleges karaktersorozat helyett) is használhatsz.
 
 Amikor betöltöd egy a listán szereplõ játékos játszmáját, a fõablak sakktáblája szükség esetén elfordul, hogy a játszmát annak a játékosnak a szemszögébõl mutassa.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate H showblunderexists {Jelezd a durva hibát}
@@ -1780,6 +1880,7 @@ translate H TBNoMoves {Nem található törvényes lépés.}
 translate H TBTooMany {Túl sok darab. A Lichess asztallap legfeljebb 7 darabot támogat.}
 translate H TBQuerying {Lichess API lekérdezése...}
 translate H TBError {Hiba a curl indításakor a Lichess lekérdezéséhez.}
+translate H TBQueryError {Érvénytelen válasz a tablebase API-tól.}
 translate H TBNotFound {A pozíció nem található a táblázatbázisban vagy API hiba.}
 translate H TBCategory {Pozíció kategória:}
 translate H TBTrainingHidden {(edzési mód; az eredmények rejtettek)}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -119,6 +119,8 @@ menuText I GameGotoMove "Vai alla mossa numero..." 0 \
   {Va al numero di mossa specificato nella partita attuale}
 menuText I GameNovelty "Trova novità..." 0 \
   {Cerca la prima mossa mai giocata della partita corrente}
+menuText I PlayTournament "Gioca al torneo..." 0 \
+    {Gioca un torneo di motori}
 
 # Search Menu:
 menuText I Search "Cerca" 0
@@ -1402,10 +1404,108 @@ translate I RecentFilesExtra {Numero di file recentemente utilizzati nel sottome
 
 # My Player Names options:
 translate I MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate I configComp {Configura Torneo}
+# ====== TODO To be translated ======
+translate I Tournament {Torneo}
+# ====== TODO To be translated ======
+translate I Available {Disponibile}
+# ====== TODO To be translated ======
+translate I Selected {Selezionato}
+# ====== TODO To be translated ======
+translate I RoundRobin {Girotondo}
+# ====== TODO To be translated ======
+translate I Gauntlet {Guanto di sfida}
+# ====== TODO To be translated ======
+translate I CompGameNext {Prossima partita:}
+# ====== TODO To be translated ======
+translate I TimeperGame {Tempo per\Gioco}
+# ====== TODO To be translated ======
+translate I TimeperMove {Tempo per\Move}
+# ====== TODO To be translated ======
+translate I compStoreTime {Tempo di negozio:}
+# ====== TODO To be translated ======
+translate I Clock {Orologio}
+# ====== TODO To be translated ======
+translate I compConcurrent {Giochi simultanei:}
+# ====== TODO To be translated ======
+translate I compShowBoards {Mostra bacheche}
+# ====== TODO To be translated ======
+translate I compCarousel {Sistema a carosello}
+# ====== TODO To be translated ======
+translate I compSaveEval {Salva valutazione}
+# ====== TODO To be translated ======
+translate I compCanceledGames {Partite annullate o scadute:}
+# ====== TODO To be translated ======
+translate I Replay {Rigiocare}
+# ====== TODO To be translated ======
+translate I compStart {Inizio}
+# ====== TODO To be translated ======
+translate I compSave {Salva dopo ogni partita}
+# ====== TODO To be translated ======
+translate I compStop {Interruzione dopo la fine dell'atto. gioco}
+# ====== TODO To be translated ======
+translate I compRunning {Torneo in corso}
+# ====== TODO To be translated ======
+translate I Restart {Ricomincia}
+# ====== TODO To be translated ======
+translate I compFinished {Torneo finito}
+# ====== TODO To be translated ======
+translate I compStopped {Torneo interrotto}
 Inserisci sotto una lista di giocatori preferiti, un nome per linea. Caratteri jolly (p. es. "?" per ogni singolo carattere, "*" per ogni sequenza di caratteri) sono accettati.
 
 Ogni volta che viene caricata una partita con un giocatore nella lista, la finestra principale della scacchiera se necessario ruoterà e vi proporrà la partita dal punto di vista di quel giocatore.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate I showblunderexists {mostra gli errori}
@@ -1780,6 +1880,7 @@ translate I TBNoMoves {Nessuna mossa legale trovata.}
 translate I TBTooMany {Troppi pezzi. Il base tavolo Lichess supporta fino a 7 pezzi.}
 translate I TBQuerying {Interrogazione dell'API Lichess in corso...}
 translate I TBError {Errore durante l'avvio di curl per interrogare Lichess.}
+translate I TBQueryError {Risposta non valida dall'API tablebase.}
 translate I TBNotFound {Posizione non trovata nella tablebase o errore API.}
 translate I TBCategory {Categoria di posizione:}
 translate I TBTrainingHidden {(Modalità formazione; i risultati sono nascosti)}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -153,6 +153,8 @@ menuText A GameGotoMove "移動番号に移動..." 5 \
   {現在のゲームの指定された手番号に移動します}
 menuText A GameNovelty "ノベルティを見つけてください..." 7 \
   {これまでプレイしたことのないこのゲームの最初の手を見つけてください}
+menuText A PlayTournament "トーナメントをプレイ..." 0 \
+    {エンジントーナメントをプレイする}
 
 # Search Menu:
 menuText A Search "検索" 0
@@ -1421,8 +1423,106 @@ translate A RecentFilesExtra {追加のサブメニューの最近使用した�
 
 # My Player Names options:
 translate A MyPlayerNamesDescription {以下に希望するプレイヤー名のリストを 1 行に 1 つずつ入力してください。ワイルドカード (例: 単一文字の場合は「?」、一連の文字の場合は「*」) を使用できます。
+# ====== TODO To be translated ======
+translate A configComp {トーナメントの構成}
+# ====== TODO To be translated ======
+translate A Tournament {トーナメント}
+# ====== TODO To be translated ======
+translate A Available {利用可能}
+# ====== TODO To be translated ======
+translate A Selected {選択済み}
+# ====== TODO To be translated ======
+translate A RoundRobin {ラウンドロビン}
+# ====== TODO To be translated ======
+translate A Gauntlet {ガントレット}
+# ====== TODO To be translated ======
+translate A CompGameNext {次の試合:}
+# ====== TODO To be translated ======
+translate A TimeperGame {ゲームあたりの時間}
+# ====== TODO To be translated ======
+translate A TimeperMove {\移動あたりの時間}
+# ====== TODO To be translated ======
+translate A compStoreTime {ストア時間:}
+# ====== TODO To be translated ======
+translate A Clock {クロック}
+# ====== TODO To be translated ======
+translate A compConcurrent {同時進行のゲーム:}
+# ====== TODO To be translated ======
+translate A compShowBoards {ボードを表示する}
+# ====== TODO To be translated ======
+translate A compCarousel {カルーセルシステム}
+# ====== TODO To be translated ======
+translate A compSaveEval {評価を保存する}
+# ====== TODO To be translated ======
+translate A compCanceledGames {キャンセルまたはタイムアウトになったゲーム:}
+# ====== TODO To be translated ======
+translate A Replay {リプレイ}
+# ====== TODO To be translated ======
+translate A compStart {始める}
+# ====== TODO To be translated ======
+translate A compSave {ゲームごとに保存する}
+# ====== TODO To be translated ======
+translate A compStop {行為の終了後に停止します。ゲーム}
+# ====== TODO To be translated ======
+translate A compRunning {トーナメント開催中}
+# ====== TODO To be translated ======
+translate A Restart {再起動}
+# ====== TODO To be translated ======
+translate A compFinished {トーナメントが終了しました}
+# ====== TODO To be translated ======
+translate A compStopped {トーナメントは中止されました}
 
 リストにプレイヤーが含まれるゲームがロードされるたびに、必要に応じてメイン ウィンドウのチェス盤が回転し、そのプレイヤーの視点からゲームを表示します。}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate A showblunderexists {間違いが存在することを示す}
@@ -1797,6 +1897,7 @@ translate A TBNoMoves {法的な措置は見つかりませんでした。}
 translate A TBTooMany {ピースが多すぎます。 Lichess テーブルベースは最大 7 個までサポートします。}
 translate A TBQuerying {Lichess API をクエリしています...}
 translate A TBError {Lichess をクエリするためにカールを起動中にエラーが発生しました。}
+translate A TBQueryError {テーブルベース API からの応答が無効です。}
 translate A TBNotFound {テーブルベースで位置が見つからないか、API エラーです。}
 translate A TBCategory {ポジションカテゴリー:}
 translate A TBTrainingHidden {(トレーニングモード、結果は非表示)}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -153,6 +153,8 @@ menuText k GameGotoMove "이동번호로 이동..." 5 \
   {현재 게임에서 이동번호로 이동}
 menuText k GameNovelty "참신함을 찾아보세요..." 7 \
   {이전에 플레이한 적이 없는 이 게임의 첫 번째 수를 찾아보세요.}
+menuText k PlayTournament "토너먼트 플레이..." 0 \
+    {엔진 토너먼트 플레이}
 
 # Search Menu:
 menuText k Search "찾다" 0
@@ -1421,8 +1423,106 @@ translate k RecentFilesExtra {추가 하위 메뉴의 최신 파일 수}
 
 # My Player Names options:
 translate k MyPlayerNamesDescription {아래에 선호하는 플레이어 이름 목록을 한 줄에 입력하세요. 애니메이션 캐릭터(예: 단일 경우의 문자 "?", 소속의 문자의 "*")가 해당됩니다.
+# ====== TODO To be translated ======
+translate k configComp {토너먼트 구성}
+# ====== TODO To be translated ======
+translate k Tournament {토너먼트}
+# ====== TODO To be translated ======
+translate k Available {사용 가능}
+# ====== TODO To be translated ======
+translate k Selected {선택된}
+# ====== TODO To be translated ======
+translate k RoundRobin {라운드 로빈}
+# ====== TODO To be translated ======
+translate k Gauntlet {긴 장갑}
+# ====== TODO To be translated ======
+translate k CompGameNext {다음 게임:}
+# ====== TODO To be translated ======
+translate k TimeperGame {게임당 시간}
+# ====== TODO To be translated ======
+translate k TimeperMove {이동당 시간}
+# ====== TODO To be translated ======
+translate k compStoreTime {매장 시간:}
+# ====== TODO To be translated ======
+translate k Clock {시계}
+# ====== TODO To be translated ======
+translate k compConcurrent {동시 게임:}
+# ====== TODO To be translated ======
+translate k compShowBoards {보드 표시}
+# ====== TODO To be translated ======
+translate k compCarousel {캐러셀 시스템}
+# ====== TODO To be translated ======
+translate k compSaveEval {평가 저장}
+# ====== TODO To be translated ======
+translate k compCanceledGames {취소되거나 시간 초과된 게임:}
+# ====== TODO To be translated ======
+translate k Replay {다시 하다}
+# ====== TODO To be translated ======
+translate k compStart {시작}
+# ====== TODO To be translated ======
+translate k compSave {매 경기 후 저장}
+# ====== TODO To be translated ======
+translate k compStop {행위 종료 후 중지합니다. 게임}
+# ====== TODO To be translated ======
+translate k compRunning {토너먼트 진행 중}
+# ====== TODO To be translated ======
+translate k Restart {다시 시작}
+# ====== TODO To be translated ======
+translate k compFinished {토너먼트 종료}
+# ====== TODO To be translated ======
+translate k compStopped {토너먼트가 중단되었습니다}
 
 목록에 플레이어가 있는 게임이 로드될 때마다 해당 플레이어의 관점에서 게임을 표시하기 위해 필요한 경우 기본 창 체스판이 회전합니다.}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate k showblunderexists {함께가 존재함을 보여라}
@@ -1797,6 +1897,7 @@ translate k TBNoMoves {법적 움직임이 발견되지 않았습니다.}
 translate k TBTooMany {조각이 너무 많습니다. Lichess 테이블베이스는 최대 7개까지 지원합니다.}
 translate k TBQuerying {Lichess API 쿼리 중...}
 translate k TBError {Lichess를 쿼리하기 위해 컬을 실행하는 중에 오류가 발생했습니다.}
+translate k TBQueryError {테이블베이스 API의 응답이 잘못되었습니다.}
 translate k TBNotFound {테이블베이스 또는 API 오류에서 위치를 찾을 수 없습니다.}
 translate k TBCategory {직위 범주:}
 translate k TBTrainingHidden {(훈련 모드, 결과는 숨겨짐)}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -124,6 +124,8 @@ menuText N GameGotoMove "Zetnummer..." 0 \
   {Ga naar zetnummer .. in de partij}
 menuText N GameNovelty "Vind nieuwtje..." 7 \
   {Vind de eerste zet in deze partij die nog niet eerder is gespeeld}
+menuText N PlayTournament "Toernooi spelen..." 0 \
+    {Speel een motortoernooi}
 
 # Search Menu:
 menuText N Search "Selecteren" 0
@@ -1426,8 +1428,106 @@ translate N RecentFilesExtra {Aantal recente bestand in extra submenu}
 
 # My Player Names options:
 translate N MyPlayerNamesDescription {Voeg hieronder een lijst met voorkeur spelernamen in, 1 speler per regel. Jokers (bvb "?" voor elke letter, "*" voor een reeks letters) zijn toegelaten.
+# ====== TODO To be translated ======
+translate N configComp {Toernooi configureren}
+# ====== TODO To be translated ======
+translate N Tournament {Toernooi}
+# ====== TODO To be translated ======
+translate N Available {Beschikbaar}
+# ====== TODO To be translated ======
+translate N Selected {Gekozen}
+# ====== TODO To be translated ======
+translate N RoundRobin {Ronde Robin}
+# ====== TODO To be translated ======
+translate N Gauntlet {Handschoen}
+# ====== TODO To be translated ======
+translate N CompGameNext {Volgende spel:}
+# ====== TODO To be translated ======
+translate N TimeperGame {Tijd per\spel}
+# ====== TODO To be translated ======
+translate N TimeperMove {Tijd per\Verplaatsing}
+# ====== TODO To be translated ======
+translate N compStoreTime {Winkeltijd:}
+# ====== TODO To be translated ======
+translate N Clock {Klok}
+# ====== TODO To be translated ======
+translate N compConcurrent {Gelijktijdige spellen:}
+# ====== TODO To be translated ======
+translate N compShowBoards {Borden tonen}
+# ====== TODO To be translated ======
+translate N compCarousel {Carrousel systeem}
+# ====== TODO To be translated ======
+translate N compSaveEval {Evaluatie opslaan}
+# ====== TODO To be translated ======
+translate N compCanceledGames {Geannuleerde of time-out wedstrijden:}
+# ====== TODO To be translated ======
+translate N Replay {Opnieuw afspelen}
+# ====== TODO To be translated ======
+translate N compStart {Begin}
+# ====== TODO To be translated ======
+translate N compSave {Bewaar na elk spel}
+# ====== TODO To be translated ======
+translate N compStop {Stop na einde\van actie. spel}
+# ====== TODO To be translated ======
+translate N compRunning {Toernooi in uitvoering}
+# ====== TODO To be translated ======
+translate N Restart {Opnieuw opstarten}
+# ====== TODO To be translated ======
+translate N compFinished {Toernooi afgelopen}
+# ====== TODO To be translated ======
+translate N compStopped {Toernooi gestopt}
 Telkens een partij uit de lijst word geladen, zal het schaakbord worden gedraaid indien nodig om de partij vanuit die speler zijn perspektief te tonen.
 } ;
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate N showblunderexists {toon dat er een blunder is}
@@ -1802,6 +1902,7 @@ translate N TBNoMoves {Geen legale zetten gevonden.}
 translate N TBTooMany {Te veel stukken. Lichess tafelonderstel ondersteunt maximaal 7 stuks.}
 translate N TBQuerying {Lichess-API opvragen...}
 translate N TBError {Fout bij het starten van curl om Lichess te ondervragen.}
+translate N TBQueryError {Ongeldig antwoord van tablebase API.}
 translate N TBNotFound {Positie niet gevonden in tablebase of API-fout.}
 translate N TBCategory {Functiecategorie:}
 translate N TBTrainingHidden {(Trainingsmodus; resultaten zijn verborgen)}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -1403,6 +1403,12 @@ translate O RecentFilesExtra {Number of recent files in extra submenu} ;# ***
 
 # My Player Names options:
 translate O MyPlayerNamesDescription {
+Enter a list of preferred player names below, one name per line. Wildcards (e.g. "?" for any single character, "*" for any sequence of characters) are permitted.
+
+Every time a game with a player in the list is loaded, the main window chessboard will be rotated if necessary to show the game from that players perspective.
+} ;# ***
+
+# Computer Tournament:
 # ====== TODO To be translated ======
 translate O configComp {Konfigurer turnering}
 # ====== TODO To be translated ======
@@ -1451,10 +1457,6 @@ translate O Restart {Start på nytt}
 translate O compFinished {Turneringen avsluttet}
 # ====== TODO To be translated ======
 translate O compStopped {Turneringen stoppet}
-Enter a list of preferred player names below, one name per line. Wildcards (e.g. "?" for any single character, "*" for any sequence of characters) are permitted.
-
-Every time a game with a player in the list is loaded, the main window chessboard will be rotated if necessary to show the game from that players perspective.
-} ;# ***
 
 # Computer Tournament:
 # MISSING TRANSLATION for configComp:

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -117,6 +117,8 @@ menuText O GameGotoMove "Gå til trekk..." 0 \
   {Gå til et angitt trekk i dette partiet}
 menuText O GameNovelty "Finn avvik..." 0 \
   {Finn det første trekket i dette partiet som ikke har blitt spilt tidligere}
+menuText O PlayTournament "Spill turnering..." 0 \
+    {Spill en motorturnering}
 
 # Search Menu:
 menuText O Search "Søk" 0
@@ -1401,10 +1403,108 @@ translate O RecentFilesExtra {Number of recent files in extra submenu} ;# ***
 
 # My Player Names options:
 translate O MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate O configComp {Konfigurer turnering}
+# ====== TODO To be translated ======
+translate O Tournament {Turnering}
+# ====== TODO To be translated ======
+translate O Available {Tilgjengelig}
+# ====== TODO To be translated ======
+translate O Selected {Valgt}
+# ====== TODO To be translated ======
+translate O RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate O Gauntlet {Hanske}
+# ====== TODO To be translated ======
+translate O CompGameNext {Neste kamp:}
+# ====== TODO To be translated ======
+translate O TimeperGame {Tid per spill}
+# ====== TODO To be translated ======
+translate O TimeperMove {Tid per\Flytt}
+# ====== TODO To be translated ======
+translate O compStoreTime {Lagringstid:}
+# ====== TODO To be translated ======
+translate O Clock {Klokke}
+# ====== TODO To be translated ======
+translate O compConcurrent {Samtidige spill:}
+# ====== TODO To be translated ======
+translate O compShowBoards {Vis brett}
+# ====== TODO To be translated ======
+translate O compCarousel {Karusellsystem}
+# ====== TODO To be translated ======
+translate O compSaveEval {Lagre evaluering}
+# ====== TODO To be translated ======
+translate O compCanceledGames {Avlyste eller tidsavbrutt spill:}
+# ====== TODO To be translated ======
+translate O Replay {Replay}
+# ====== TODO To be translated ======
+translate O compStart {Start}
+# ====== TODO To be translated ======
+translate O compSave {Lagre etter hvert spill}
+# ====== TODO To be translated ======
+translate O compStop {Stopp etter endt handling. spill}
+# ====== TODO To be translated ======
+translate O compRunning {Turnering pågår}
+# ====== TODO To be translated ======
+translate O Restart {Start på nytt}
+# ====== TODO To be translated ======
+translate O compFinished {Turneringen avsluttet}
+# ====== TODO To be translated ======
+translate O compStopped {Turneringen stoppet}
 Enter a list of preferred player names below, one name per line. Wildcards (e.g. "?" for any single character, "*" for any sequence of characters) are permitted.
 
 Every time a game with a player in the list is loaded, the main window chessboard will be rotated if necessary to show the game from that players perspective.
 } ;# ***
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate O showblunderexists {Vis at feil eksisterer}
@@ -1779,6 +1879,7 @@ translate O TBNoMoves {Ingen lovlige trekk funnet.}
 translate O TBTooMany {For mange stykker. Lichess bordbunn støtter opptil 7 deler.}
 translate O TBQuerying {Spørrer Lichess API...}
 translate O TBError {Feil ved start av curl for å spørre Lichess.}
+translate O TBQueryError {Ugyldig svar fra tablebase API.}
 translate O TBNotFound {Finner ikke posisjon i tabellbase eller API-feil.}
 translate O TBCategory {Stillingskategori:}
 translate O TBTrainingHidden {(Opplæringsmodus; resultatene er skjult)}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -119,6 +119,8 @@ menuText P GameGotoMove "Przejd do posunicia nr..." 13 \
   {Przejd do posunicia o podanym numerze}
 menuText P GameNovelty "Znajd nowink..." 7 \
   {Znajd pierwsze posunicie partii niegrane wczeniej}
+menuText P PlayTournament "Zagraj w turnieju..." 0 \
+    {Zagraj w turnieju silnikowym}
 
 # Search Menu:
 menuText P Search "Szukaj" 0
@@ -1421,10 +1423,108 @@ translate P RecentFilesExtra {Liczba ostatnich plikw w dodatkowym podmenu}
 
 # My Player Names options:
 translate P MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate P configComp {Skonfiguruj turniej}
+# ====== TODO To be translated ======
+translate P Tournament {Turniej}
+# ====== TODO To be translated ======
+translate P Available {Dostępny}
+# ====== TODO To be translated ======
+translate P Selected {Wybrany}
+# ====== TODO To be translated ======
+translate P RoundRobin {Okrągły Robin}
+# ====== TODO To be translated ======
+translate P Gauntlet {Rękawica}
+# ====== TODO To be translated ======
+translate P CompGameNext {Następna gra:}
+# ====== TODO To be translated ======
+translate P TimeperGame {Czas na\grę}
+# ====== TODO To be translated ======
+translate P TimeperMove {Czas na\Ruch}
+# ====== TODO To be translated ======
+translate P compStoreTime {Czas przechowywania:}
+# ====== TODO To be translated ======
+translate P Clock {Zegar}
+# ====== TODO To be translated ======
+translate P compConcurrent {Równoczesne gry:}
+# ====== TODO To be translated ======
+translate P compShowBoards {Pokaż tablice}
+# ====== TODO To be translated ======
+translate P compCarousel {System karuzelowy}
+# ====== TODO To be translated ======
+translate P compSaveEval {Zapisz ocenę}
+# ====== TODO To be translated ======
+translate P compCanceledGames {Gry anulowane lub przeterminowane:}
+# ====== TODO To be translated ======
+translate P Replay {Powtórna rozgrywka}
+# ====== TODO To be translated ======
+translate P compStart {Start}
+# ====== TODO To be translated ======
+translate P compSave {Zapisz po każdej grze}
+# ====== TODO To be translated ======
+translate P compStop {Zatrzymaj się po zakończeniu aktu. gra}
+# ====== TODO To be translated ======
+translate P compRunning {Turniej w toku}
+# ====== TODO To be translated ======
+translate P Restart {Uruchom ponownie}
+# ====== TODO To be translated ======
+translate P compFinished {Turniej zakończony}
+# ====== TODO To be translated ======
+translate P compStopped {Turniej zatrzymany}
 Podaj list preferowanych nazwisk graczy, po jednym w wierszu. W nazwiskach mona stosowa znaki specjalne (np. "?" - dowolny znak, "*" - dowolna sekwencja znakw).
 
 Wszystkie partie grane przez jednego z graczy z listy bd wywietlane z jego perspektywy.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate P showblunderexists {zjawisko, e bd istnieje}
@@ -1799,6 +1899,7 @@ translate P TBNoMoves {Nie znaleziono żadnych legalnych ruchów.}
 translate P TBTooMany {Za dużo kawałków. Podstawa stołu Lichess obsługuje do 7 elementów.}
 translate P TBQuerying {Wysyłam zapytanie do API Lichess...}
 translate P TBError {Błąd podczas uruchamiania curl w celu wysłania zapytania do Lichess.}
+translate P TBQueryError {Nieprawidłowa odpowiedź z interfejsu API bazy tabel.}
 translate P TBNotFound {Nie znaleziono pozycji w bazie tabeli lub wystąpił błąd API.}
 translate P TBCategory {Kategoria stanowiska:}
 translate P TBTrainingHidden {(Tryb treningu; wyniki są ukryte)}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -116,6 +116,8 @@ menuText B GameGotoMove "Ir para o movimento número..." 5 \
   {Avança o jogo até o movimento desejado}
 menuText B GameNovelty "Pesquisa Novidade..." 7 \
   {Procura o primeiro movimento deste jogo que não tenha sido jogado antes}
+menuText B PlayTournament "Jogar torneio..." 0 \
+    {Jogue um torneio de motores}
 
 # Search Menu:
 menuText B Search "Pesquisa" 0
@@ -1409,10 +1411,108 @@ translate B RecentFilesExtra {Número de arquivos recentes no submenu extra}
 
 # My Player Names options:
 translate B MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate B configComp {Configurar torneio}
+# ====== TODO To be translated ======
+translate B Tournament {Torneio}
+# ====== TODO To be translated ======
+translate B Available {Disponível}
+# ====== TODO To be translated ======
+translate B Selected {Selecionado}
+# ====== TODO To be translated ======
+translate B RoundRobin {Rodada Robin}
+# ====== TODO To be translated ======
+translate B Gauntlet {Manopla}
+# ====== TODO To be translated ======
+translate B CompGameNext {Próximo jogo:}
+# ====== TODO To be translated ======
+translate B TimeperGame {Tempo por\Jogo}
+# ====== TODO To be translated ======
+translate B TimeperMove {Tempo por\movimento}
+# ====== TODO To be translated ======
+translate B compStoreTime {Tempo de armazenamento:}
+# ====== TODO To be translated ======
+translate B Clock {Relógio}
+# ====== TODO To be translated ======
+translate B compConcurrent {Jogos simultâneos:}
+# ====== TODO To be translated ======
+translate B compShowBoards {Mostrar painéis}
+# ====== TODO To be translated ======
+translate B compCarousel {Sistema carrossel}
+# ====== TODO To be translated ======
+translate B compSaveEval {Salvar avaliação}
+# ====== TODO To be translated ======
+translate B compCanceledGames {Jogos cancelados ou expirados:}
+# ====== TODO To be translated ======
+translate B Replay {Repetir}
+# ====== TODO To be translated ======
+translate B compStart {Começar}
+# ====== TODO To be translated ======
+translate B compSave {Salve depois de cada jogo}
+# ====== TODO To be translated ======
+translate B compStop {Pare após o fim do ato. jogo}
+# ====== TODO To be translated ======
+translate B compRunning {Torneio em andamento}
+# ====== TODO To be translated ======
+translate B Restart {Reiniciar}
+# ====== TODO To be translated ======
+translate B compFinished {Torneio terminado}
+# ====== TODO To be translated ======
+translate B compStopped {Torneio interrompido}
 Entre com uma lista dos nomes de jogadores preferidos, abaixo, um nome por linha. Substitutos (ex. "?" para qualquer caracter único, "*" para qualquer sequência de caracteres) são permitidas.
 
 Cada vez que um jogo com um jogador da lista é carregado, o tabuleiro da janela principal sofrerá rotação, se necessário, para mostrar o jogo da perspectiva desse jogador..
 } 
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate B showblunderexists {mostra que existe um erro crasso}
@@ -1787,6 +1887,7 @@ translate B TBNoMoves {Nenhum movimento legal encontrado.}
 translate B TBTooMany {Muitas peças. A base de mesa Lichess suporta até 7 peças.}
 translate B TBQuerying {Consultando API Lichess...}
 translate B TBError {Erro ao iniciar o curl para consultar o Lichess.}
+translate B TBQueryError {Resposta inválida da API tablebase.}
 translate B TBNotFound {Posição não encontrada na base de tabela ou erro de API.}
 translate B TBCategory {Categoria de posição:}
 translate B TBTrainingHidden {(Modo de treinamento; os resultados estão ocultos)}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -153,6 +153,8 @@ menuText L GameGotoMove "Du-te la Mută ​​numărul..." 5 \
   {Accesați un număr de mutare specificat în jocul curent}
 menuText L GameNovelty "Găsiți noutăți..." 7 \
   {Găsiți prima mișcare a acestui joc care nu a mai jucat înainte}
+menuText L PlayTournament "Joacă turneul..." 0 \
+    {Joacă un turneu de motoare}
 
 # Search Menu:
 menuText L Search "Căutare" 0
@@ -1421,8 +1423,106 @@ translate L RecentFilesExtra {Numărul de fișiere recente în submeniul suplime
 
 # My Player Names options:
 translate L MyPlayerNamesDescription {Introduceți mai jos o listă cu numele jucătorilor preferați, câte un nume pe linie. Caracterele metalice (de exemplu, „?” pentru orice caracter unic, „*” pentru orice secvență de caractere) sunt permise.
+# ====== TODO To be translated ======
+translate L configComp {Configurați turneul}
+# ====== TODO To be translated ======
+translate L Tournament {turneu}
+# ====== TODO To be translated ======
+translate L Available {Disponibil}
+# ====== TODO To be translated ======
+translate L Selected {Selectat}
+# ====== TODO To be translated ======
+translate L RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate L Gauntlet {Mănuşă}
+# ====== TODO To be translated ======
+translate L CompGameNext {Următorul joc:}
+# ====== TODO To be translated ======
+translate L TimeperGame {Timp per\Joc}
+# ====== TODO To be translated ======
+translate L TimeperMove {Timp per\Mutare}
+# ====== TODO To be translated ======
+translate L compStoreTime {Ora magazinului:}
+# ====== TODO To be translated ======
+translate L Clock {Ceas}
+# ====== TODO To be translated ======
+translate L compConcurrent {Jocuri concurente:}
+# ====== TODO To be translated ======
+translate L compShowBoards {Afișați panouri}
+# ====== TODO To be translated ======
+translate L compCarousel {Sistem de carusel}
+# ====== TODO To be translated ======
+translate L compSaveEval {Salvați evaluarea}
+# ====== TODO To be translated ======
+translate L compCanceledGames {Jocuri anulate sau expirate:}
+# ====== TODO To be translated ======
+translate L Replay {Reluare}
+# ====== TODO To be translated ======
+translate L compStart {Început}
+# ====== TODO To be translated ======
+translate L compSave {Economisiți după fiecare joc}
+# ====== TODO To be translated ======
+translate L compStop {Opriți după sfârșitul actului. joc}
+# ====== TODO To be translated ======
+translate L compRunning {Turneu în desfășurare}
+# ====== TODO To be translated ======
+translate L Restart {Repornire}
+# ====== TODO To be translated ======
+translate L compFinished {Turneul terminat}
+# ====== TODO To be translated ======
+translate L compStopped {Turneul s-a oprit}
 
 De fiecare dată când se încarcă un joc cu un jucător în listă, tabla de șah din fereastra principală va fi rotită dacă este necesar pentru a afișa jocul din perspectiva jucătorului respectiv.}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate L showblunderexists {arată că gafa există}
@@ -1797,6 +1897,7 @@ translate L TBNoMoves {Nu au fost găsite mișcări legale.}
 translate L TBTooMany {Prea multe piese. Baza de masă Lichess acceptă până la 7 piese.}
 translate L TBQuerying {Se interogează API-ul Lichess...}
 translate L TBError {Eroare la lansarea curl pentru a interoga Lichess.}
+translate L TBQueryError {Răspuns nevalid de la API-ul tablebase.}
 translate L TBNotFound {Poziția nu a fost găsită în baza de tabele sau eroare API.}
 translate L TBCategory {Categoria postului:}
 translate L TBTrainingHidden {(Modul de antrenament; rezultatele sunt ascunse)}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -119,6 +119,8 @@ menuText R GameGotoMove "Перейти к ходу номер..." 5 \
   {Перейти к определённому ходу текущей партии}
 menuText R GameNovelty "Найти новинку..." 2 \
   {Найти первый ход в этой партии, который раньше не применялся}
+menuText R PlayTournament "Играть в турнир..." 0 \
+    {Сыграть турнир по двигателям}
 
 # Search Menu:
 menuText R Search "Поиск" 1
@@ -1403,10 +1405,108 @@ translate R RecentFilesExtra {Число недавно загруженных �
 
 # My Player Names options:
 translate R MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate R configComp {Настроить турнир}
+# ====== TODO To be translated ======
+translate R Tournament {Турнир}
+# ====== TODO To be translated ======
+translate R Available {Доступный}
+# ====== TODO To be translated ======
+translate R Selected {Выбрано}
+# ====== TODO To be translated ======
+translate R RoundRobin {Круговая система}
+# ====== TODO To be translated ======
+translate R Gauntlet {Рукавица}
+# ====== TODO To be translated ======
+translate R CompGameNext {Следующая игра:}
+# ====== TODO To be translated ======
+translate R TimeperGame {Время за\Игру}
+# ====== TODO To be translated ======
+translate R TimeperMove {Время за\ход}
+# ====== TODO To be translated ======
+translate R compStoreTime {Время хранения:}
+# ====== TODO To be translated ======
+translate R Clock {Часы}
+# ====== TODO To be translated ======
+translate R compConcurrent {Параллельные игры:}
+# ====== TODO To be translated ======
+translate R compShowBoards {Показать доски}
+# ====== TODO To be translated ======
+translate R compCarousel {Карусельная система}
+# ====== TODO To be translated ======
+translate R compSaveEval {Сохранить оценку}
+# ====== TODO To be translated ======
+translate R compCanceledGames {Отмененные или истекшие игры:}
+# ====== TODO To be translated ======
+translate R Replay {Повтор}
+# ====== TODO To be translated ======
+translate R compStart {Начинать}
+# ====== TODO To be translated ======
+translate R compSave {Сохраняйтесь после каждой игры}
+# ====== TODO To be translated ======
+translate R compStop {Остановиться после окончания действия. игра}
+# ====== TODO To be translated ======
+translate R compRunning {Турнир в разгаре}
+# ====== TODO To be translated ======
+translate R Restart {Перезапуск}
+# ====== TODO To be translated ======
+translate R compFinished {Турнир завершен}
+# ====== TODO To be translated ======
+translate R compStopped {Турнир остановлен}
 Ввести список привилегированных имён игроков ниже, по одному имени на строку. Маски разрешены (например, "?" для любого единичного символа, "*" для любой последовательности символов)
 
 Каждый раз, когда партия с игроком в списке загружена, главное окно шахматной доски будет при необходимости поворачивается, чтобы показать партию от перспективы игрока.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate R showblunderexists {показать существующие ошибки}
@@ -1781,8 +1881,8 @@ translate R TBNoMoves {Законных ходов не обнаружено.}
 translate R TBTooMany {Слишком много кусочков. Основание стола Lichess поддерживает до 7 штук.}
 translate R TBQuerying {Запрос API Lichess...}
 translate R TBError {Ошибка при запуске Curl для запроса Lichess.}
-translate R TBNotFound {Позиция не найдена в базе таблиц или ошибка API.}
 translate R TBQueryError {Ошибка при разборе ответа API Lichess.}
+translate R TBNotFound {Позиция не найдена в базе таблиц или ошибка API.}
 translate R TBCategory {Категория позиции:}
 translate R TBTrainingHidden {(Режим обучения; результаты скрыты)}
 }

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -122,6 +122,9 @@ menuText Y GameGotoMove "Idi na potez broj..." 5 \
   {Idi na odreeni broj potez u tekuoj partiji}
 menuText Y GameNovelty "Pronai novost..." 8 \
   {Pronai prvi potez ove partije koji nije igran ranije}
+# ====== TODO To be translated ======
+menuText Y PlayTournament "Play Tournament..." 0 \
+    {Play an engine tournament}
 
 # Search Menu:
 menuText Y Search "Pretrai" 3
@@ -1716,6 +1719,54 @@ translate Y RecentFilesExtra {Number of recent files in extra submenu} ;# ***
 
 # My Player Names options:
 translate Y MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate Y configComp {Configure Tournament}
+# ====== TODO To be translated ======
+translate Y Tournament {Tournament}
+# ====== TODO To be translated ======
+translate Y Available {Available}
+# ====== TODO To be translated ======
+translate Y Selected {Selected}
+# ====== TODO To be translated ======
+translate Y RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate Y Gauntlet {Gauntlet}
+# ====== TODO To be translated ======
+translate Y CompGameNext {Next game:}
+# ====== TODO To be translated ======
+translate Y TimeperGame {Time per\nGame}
+# ====== TODO To be translated ======
+translate Y TimeperMove {Time per\nMove}
+# ====== TODO To be translated ======
+translate Y compStoreTime {Store Time: }
+# ====== TODO To be translated ======
+translate Y Clock {Clock}
+# ====== TODO To be translated ======
+translate Y compConcurrent {Concurrent games: }
+# ====== TODO To be translated ======
+translate Y compShowBoards {Show Boards}
+# ====== TODO To be translated ======
+translate Y compCarousel {Carousel system}
+# ====== TODO To be translated ======
+translate Y compSaveEval {Save evaluation}
+# ====== TODO To be translated ======
+translate Y compCanceledGames {Canceled or timed out games:}
+# ====== TODO To be translated ======
+translate Y Replay {Replay}
+# ====== TODO To be translated ======
+translate Y compStart {Start}
+# ====== TODO To be translated ======
+translate Y compSave {Save after every game}
+# ====== TODO To be translated ======
+translate Y compStop {Stop after end\nof act. game}
+# ====== TODO To be translated ======
+translate Y compRunning {Tournament in progress}
+# ====== TODO To be translated ======
+translate Y Restart {Restart}
+# ====== TODO To be translated ======
+translate Y compFinished {Tournament finished}
+# ====== TODO To be translated ======
+translate Y compStopped {Tournament stopped}
 Enter a list of preferred player names below, one name per line. Wildcards (e.g. "?" for any single character, "*" for any sequence of characters) are permitted.
 
 Every time a game with a player in the list is loaded, the main window chessboard will be rotated if necessary to show the game from that players perspective.

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -122,6 +122,8 @@ menuText S GameGotoMove "Ir al movimiento número..." 6 \
   {Ir al número de movimiento especificado en la partida actual}
 menuText S GameNovelty "Encontrar novedad..." 12 \
   {Encuentra el primer movimiento de esta partida que no se ha jugado antes}
+menuText S PlayTournament "Jugar Torneo..." 0 \
+    {Juega un torneo de motores}
 
 # Search Menu:
 menuText S Search "Buscar" 0
@@ -1454,10 +1456,108 @@ translate S RecentFilesExtra {Número de archivos recientes en submenú extra}
 
 # My Player Names options:
 translate S MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate S configComp {Configurar torneo}
+# ====== TODO To be translated ======
+translate S Tournament {Torneo}
+# ====== TODO To be translated ======
+translate S Available {Disponible}
+# ====== TODO To be translated ======
+translate S Selected {Seleccionado}
+# ====== TODO To be translated ======
+translate S RoundRobin {Ronda Robin}
+# ====== TODO To be translated ======
+translate S Gauntlet {Guantelete}
+# ====== TODO To be translated ======
+translate S CompGameNext {Próximo partido:}
+# ====== TODO To be translated ======
+translate S TimeperGame {Tiempo por\Juego}
+# ====== TODO To be translated ======
+translate S TimeperMove {Tiempo por movimiento}
+# ====== TODO To be translated ======
+translate S compStoreTime {Hora de tienda:}
+# ====== TODO To be translated ======
+translate S Clock {Reloj}
+# ====== TODO To be translated ======
+translate S compConcurrent {Juegos simultáneos:}
+# ====== TODO To be translated ======
+translate S compShowBoards {Mostrar tableros}
+# ====== TODO To be translated ======
+translate S compCarousel {Sistema carrusel}
+# ====== TODO To be translated ======
+translate S compSaveEval {Guardar evaluación}
+# ====== TODO To be translated ======
+translate S compCanceledGames {Juegos cancelados o agotados:}
+# ====== TODO To be translated ======
+translate S Replay {Repetición}
+# ====== TODO To be translated ======
+translate S compStart {Comenzar}
+# ====== TODO To be translated ======
+translate S compSave {Guardar después de cada juego}
+# ====== TODO To be translated ======
+translate S compStop {Deténgase después del final del acto. juego}
+# ====== TODO To be translated ======
+translate S compRunning {Torneo en curso}
+# ====== TODO To be translated ======
+translate S Restart {Reanudar}
+# ====== TODO To be translated ======
+translate S compFinished {Torneo terminado}
+# ====== TODO To be translated ======
+translate S compStopped {Torneo detenido}
 Escriba una lista de nombres de jugadores preferidos, un nombre por cada línea. Están permitidos los comodines (por ejemplo "?" para un sólo caracter, "*" para varios caracteres).
 
 Cada vez que carge una partida con un jugador de la lista se girará el tablero, si fuese necesario, para ver la partida desde la perspectiva del jugador.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate S showblunderexists {Mostrar metedura de pata}
@@ -1832,6 +1932,7 @@ translate S TBNoMoves {No se encontraron movimientos legales.}
 translate S TBTooMany {Demasiadas piezas. La base de mesa Lichess admite hasta 7 piezas.}
 translate S TBQuerying {Consultando la API de Lichess...}
 translate S TBError {Error al iniciar curl para consultar Lichess.}
+translate S TBQueryError {Respuesta no válida de la API de base de tabla.}
 translate S TBNotFound {Posición no encontrada en la base de tabla o error de API.}
 translate S TBCategory {Categoría de puesto:}
 translate S TBTrainingHidden {(Modo de entrenamiento; los resultados están ocultos)}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -151,6 +151,8 @@ menuText U GameGotoMove "Siirry siirtoon..." 5 \
   {Siirry määritetyn siirron kohdalle nykyisessä pelissä}
 menuText U GameNovelty "Etsi uutuus..." 0 \
   {Etsi pelin ensimmäinen ennen pelaamaton siirto}
+menuText U PlayTournament "Pelaa turnausta..." 0 \
+    {Pelaa moottoriturnausta}
 
 # Search Menu:
 menuText U Search "Etsi" 0
@@ -1432,10 +1434,108 @@ translate U RecentFilesExtra {Viimeaikaisten tiedostojen lkm extra-alivalikossa}
 
 # My Player Names options:
 translate U MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate U configComp {Määritä turnaus}
+# ====== TODO To be translated ======
+translate U Tournament {Turnaus}
+# ====== TODO To be translated ======
+translate U Available {Saatavilla}
+# ====== TODO To be translated ======
+translate U Selected {Valittu}
+# ====== TODO To be translated ======
+translate U RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate U Gauntlet {Gauntlet}
+# ====== TODO To be translated ======
+translate U CompGameNext {Seuraava peli:}
+# ====== TODO To be translated ======
+translate U TimeperGame {Aika per peli}
+# ====== TODO To be translated ======
+translate U TimeperMove {Aika per siirto}
+# ====== TODO To be translated ======
+translate U compStoreTime {Varastoaika:}
+# ====== TODO To be translated ======
+translate U Clock {Kello}
+# ====== TODO To be translated ======
+translate U compConcurrent {Samanaikaiset pelit:}
+# ====== TODO To be translated ======
+translate U compShowBoards {Näytä taulut}
+# ====== TODO To be translated ======
+translate U compCarousel {Karusellijärjestelmä}
+# ====== TODO To be translated ======
+translate U compSaveEval {Tallenna arviointi}
+# ====== TODO To be translated ======
+translate U compCanceledGames {Peruutetut tai aikakatkaistut pelit:}
+# ====== TODO To be translated ======
+translate U Replay {Uusinta}
+# ====== TODO To be translated ======
+translate U compStart {Aloita}
+# ====== TODO To be translated ======
+translate U compSave {Tallenna jokaisen pelin jälkeen}
+# ====== TODO To be translated ======
+translate U compStop {Pysäytä toiminnan päätyttyä. peli}
+# ====== TODO To be translated ======
+translate U compRunning {Turnaus käynnissä}
+# ====== TODO To be translated ======
+translate U Restart {Käynnistä uudelleen}
+# ====== TODO To be translated ======
+translate U compFinished {Turnaus päättynyt}
+# ====== TODO To be translated ======
+translate U compStopped {Turnaus pysähtyi}
 Lisää alle käyttämäsi pelaajanimet, yksi nimi per rivi. Voit käyttää villikortteja (esim. "?" korvaa yksittäisen merkin, "*" korvaa kuinka monta peräkkäistä merkkiä hyvänsä).
 
 Aina kun Scid lataa pelin, jossa on käyttämäsi pelaajanimi, peli näytetään pelaajan näkökulmasta. Tarvittaessa lauta käännetään niin, että musta pelaa alhaalta ylös.
 }
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate U showblunderexists {näytä virheet}
@@ -1810,6 +1910,7 @@ translate U TBNoMoves {Laillisia siirtoja ei löytynyt.}
 translate U TBTooMany {Liian monta kappaletta. Lichess-pöytäjalusta tukee jopa 7 osaa.}
 translate U TBQuerying {Kysellään Lichess-sovellusliittymää...}
 translate U TBError {Virhe käynnistettäessä curl-kyselyä Lichessille.}
+translate U TBQueryError {Virheellinen vastaus tablebase API:lta.}
 translate U TBNotFound {Sijaintia ei löydy taulukkokannasta tai API-virhe.}
 translate U TBCategory {Aseman luokka:}
 translate U TBTrainingHidden {(Harjoitustila; tulokset piilotetaan)}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -112,6 +112,8 @@ menuText Z GameGotoMove "Nenda kwa Hoja Nambari..." 5 \
   {Nenda kwa nambari maalum ya kusonga katika mchezo wa sasa}
 menuText Z GameNovelty "Tafuta Novelty..." 7 \
   {Tafuta hatua ya kwanza ya mchezo huu ambayo haijacheza hapo awali}
+menuText Z PlayTournament "Cheza Mashindano..." 0 \
+    {Cheza mashindano ya injini}
 
 # Search Menu:
 menuText Z Search "Tafuta" 0
@@ -1380,8 +1382,106 @@ translate Z RecentFilesExtra {Idadi ya faili za hivi majuzi katika menyu ndogo y
 
 # My Player Names options:
 translate Z MyPlayerNamesDescription {Ingiza orodha ya majina ya wachezaji unayopendelea hapa chini, jina moja kwa kila mstari. Kadi za pori (k.m. "?" kwa herufi yoyote moja, "*" kwa mfuatano wowote wa herufi) zinaruhusiwa.
+# ====== TODO To be translated ======
+translate Z configComp {Sanidi Mashindano}
+# ====== TODO To be translated ======
+translate Z Tournament {Mashindano}
+# ====== TODO To be translated ======
+translate Z Available {Inapatikana}
+# ====== TODO To be translated ======
+translate Z Selected {Imechaguliwa}
+# ====== TODO To be translated ======
+translate Z RoundRobin {Mzunguko wa Robin}
+# ====== TODO To be translated ======
+translate Z Gauntlet {Gauntlet}
+# ====== TODO To be translated ======
+translate Z CompGameNext {Mchezo unaofuata:}
+# ====== TODO To be translated ======
+translate Z TimeperGame {Muda kwa\Mchezo}
+# ====== TODO To be translated ======
+translate Z TimeperMove {Muda kwa\Hamisha}
+# ====== TODO To be translated ======
+translate Z compStoreTime {Saa ya Kuhifadhi:}
+# ====== TODO To be translated ======
+translate Z Clock {Saa}
+# ====== TODO To be translated ======
+translate Z compConcurrent {Michezo ya pamoja:}
+# ====== TODO To be translated ======
+translate Z compShowBoards {Onyesha Vibao}
+# ====== TODO To be translated ======
+translate Z compCarousel {Mfumo wa jukwa}
+# ====== TODO To be translated ======
+translate Z compSaveEval {Hifadhi tathmini}
+# ====== TODO To be translated ======
+translate Z compCanceledGames {Michezo iliyoghairiwa au kuisha muda:}
+# ====== TODO To be translated ======
+translate Z Replay {Cheza tena}
+# ====== TODO To be translated ======
+translate Z compStart {Anza}
+# ====== TODO To be translated ======
+translate Z compSave {Okoa baada ya kila mchezo}
+# ====== TODO To be translated ======
+translate Z compStop {Acha baada ya mwisho \ wa kitendo. mchezo}
+# ====== TODO To be translated ======
+translate Z compRunning {Mashindano yanaendelea}
+# ====== TODO To be translated ======
+translate Z Restart {Anzisha upya}
+# ====== TODO To be translated ======
+translate Z compFinished {Mashindano yamekamilika}
+# ====== TODO To be translated ======
+translate Z compStopped {Mashindano yamesimamishwa}
 
 Kila wakati mchezo ulio na mchezaji katika orodha unapopakiwa, dirisha kuu la chessboard litazungushwa ikiwa ni lazima ili kuonyesha mchezo kutoka kwa mtazamo huo wa wachezaji.}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate Z showblunderexists {show blunder ipo}
@@ -1756,6 +1856,7 @@ translate Z TBNoMoves {Hakuna hatua za kisheria zilizopatikana.}
 translate Z TBTooMany {Vipande vingi sana. Tablebase ya Lichess inasaidia hadi vipande 7.}
 translate Z TBQuerying {Querying Lichess API...}
 translate Z TBError {Hitilafu imetokea wakati wa kuzindua curl ili kuuliza Lichess.}
+translate Z TBQueryError {Jibu batili kutoka kwa tablebase API.}
 translate Z TBNotFound {Nafasi haipatikani kwenye msingi wa meza au hitilafu ya API.}
 translate Z TBCategory {Kitengo cha Nafasi:}
 translate Z TBTrainingHidden {(Njia ya mafunzo; matokeo yamefichwa)}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -118,6 +118,8 @@ menuText W GameGotoMove "Gå till drag nummer..." 8 \
   {Gå till ett specifikt drag i partiet}
 menuText W GameNovelty "Hitta nyhet..." 7 \
   {Hitta det första draget i partiet som inte spelats tidigare}
+menuText W PlayTournament "Spela turnering..." 0 \
+    {Spela en motorturnering}
 
 # Search Menu:
 menuText W Search "Sök" 0
@@ -1407,10 +1409,108 @@ translate W RecentFilesExtra {Antal senast öppnade filer i extra undermeny}
 
 # My Player Names options:
 translate W MyPlayerNamesDescription {
+# ====== TODO To be translated ======
+translate W configComp {Konfigurera turnering}
+# ====== TODO To be translated ======
+translate W Tournament {Turnering}
+# ====== TODO To be translated ======
+translate W Available {Tillgänglig}
+# ====== TODO To be translated ======
+translate W Selected {Vald}
+# ====== TODO To be translated ======
+translate W RoundRobin {Round Robin}
+# ====== TODO To be translated ======
+translate W Gauntlet {Gatlopp}
+# ====== TODO To be translated ======
+translate W CompGameNext {Nästa match:}
+# ====== TODO To be translated ======
+translate W TimeperGame {Tid per spel}
+# ====== TODO To be translated ======
+translate W TimeperMove {Tid per\Flytt}
+# ====== TODO To be translated ======
+translate W compStoreTime {Butikstid:}
+# ====== TODO To be translated ======
+translate W Clock {Klocka}
+# ====== TODO To be translated ======
+translate W compConcurrent {Samtidiga spel:}
+# ====== TODO To be translated ======
+translate W compShowBoards {Visa brädor}
+# ====== TODO To be translated ======
+translate W compCarousel {Karusellsystem}
+# ====== TODO To be translated ======
+translate W compSaveEval {Spara utvärdering}
+# ====== TODO To be translated ======
+translate W compCanceledGames {Inställda eller tidsgränsade spel:}
+# ====== TODO To be translated ======
+translate W Replay {Spela om}
+# ====== TODO To be translated ======
+translate W compStart {Start}
+# ====== TODO To be translated ======
+translate W compSave {Spara efter varje match}
+# ====== TODO To be translated ======
+translate W compStop {Stoppa efter aktens slut. spel}
+# ====== TODO To be translated ======
+translate W compRunning {Turneringen pågår}
+# ====== TODO To be translated ======
+translate W Restart {Starta om}
+# ====== TODO To be translated ======
+translate W compFinished {Turneringen avslutad}
+# ====== TODO To be translated ======
+translate W compStopped {Turneringen stoppas}
 Ange en lista på dina favoritspelare här nedanför. Skriv ett namn per rad. Jokertecken ("?", t ex, motsvarar ett enstaka tecken medan "*" står för flera tecken) är tillåtna.
 
 Varje gång ett parti med en spelare vars namn står i denna lista öppnas kommer brädet automatiskt att vridas så att partiet visas från spelarens perspektiv.
 } 
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate W showblunderexists {visa blunder finns}
@@ -1785,6 +1885,7 @@ translate W TBNoMoves {Inga lagliga drag hittades.}
 translate W TBTooMany {För många bitar. Lichess bordsbas stöder upp till 7 delar.}
 translate W TBQuerying {Frågar Lichess API...}
 translate W TBError {Det gick inte att starta curl för att fråga Lichess.}
+translate W TBQueryError {Ogiltigt svar från tablebase API.}
 translate W TBNotFound {Positionen hittades inte i tabellbasen eller API-fel.}
 translate W TBCategory {Positionskategori:}
 translate W TBTrainingHidden {(Träningsläge; resultaten är dolda)}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -1403,7 +1403,7 @@ translate T CompGameNext {Sonraki oyun:}
 # ====== TODO To be translated ======
 translate T TimeperGame {Oyun Başına Süre}
 # ====== TODO To be translated ======
-translate T TimeperMove {\Hareket başına süre}
+translate T TimeperMove {Hareket başına süre}
 # ====== TODO To be translated ======
 translate T compStoreTime {Mağaza Süresi:}
 # ====== TODO To be translated ======

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -116,6 +116,8 @@ menuText T GameGotoMove "Numarayı Taşı'ya Git..." 5 \
   {Mevcut oyunda belirli bir hamle numarasına git}
 menuText T GameNovelty "Yenilik Bul..." 7 \
   {Bu oyunun daha önce oynanmamış ilk hamlesini bulun}
+menuText T PlayTournament "Turnuva Oyna..." 0 \
+    {Bir motor turnuvası oynayın}
 
 # Search Menu:
 menuText T Search "Aramak" 0
@@ -1384,8 +1386,106 @@ translate T RecentFilesExtra {Ekstra alt menüdeki son dosyaların sayısı}
 
 # My Player Names options:
 translate T MyPlayerNamesDescription {Tercih ettiğiniz oyuncu adlarının listesini her satıra bir ad gelecek şekilde aşağıya girin. Joker karakterlere (örneğin herhangi bir tek karakter için "?", herhangi bir karakter dizisi için "*") izin verilir.
+# ====== TODO To be translated ======
+translate T configComp {Turnuvayı Yapılandır}
+# ====== TODO To be translated ======
+translate T Tournament {Turnuva}
+# ====== TODO To be translated ======
+translate T Available {Mevcut}
+# ====== TODO To be translated ======
+translate T Selected {Seçildi}
+# ====== TODO To be translated ======
+translate T RoundRobin {Yuvarlak Robin}
+# ====== TODO To be translated ======
+translate T Gauntlet {Eldiven}
+# ====== TODO To be translated ======
+translate T CompGameNext {Sonraki oyun:}
+# ====== TODO To be translated ======
+translate T TimeperGame {Oyun Başına Süre}
+# ====== TODO To be translated ======
+translate T TimeperMove {\Hareket başına süre}
+# ====== TODO To be translated ======
+translate T compStoreTime {Mağaza Süresi:}
+# ====== TODO To be translated ======
+translate T Clock {Saat}
+# ====== TODO To be translated ======
+translate T compConcurrent {Eşzamanlı oyunlar:}
+# ====== TODO To be translated ======
+translate T compShowBoards {Panoları Göster}
+# ====== TODO To be translated ======
+translate T compCarousel {Atlıkarınca sistemi}
+# ====== TODO To be translated ======
+translate T compSaveEval {Değerlendirmeyi kaydet}
+# ====== TODO To be translated ======
+translate T compCanceledGames {İptal edilen veya zaman aşımına uğrayan oyunlar:}
+# ====== TODO To be translated ======
+translate T Replay {Tekrar oynat}
+# ====== TODO To be translated ======
+translate T compStart {Başlangıç}
+# ====== TODO To be translated ======
+translate T compSave {Her oyundan sonra kaydet}
+# ====== TODO To be translated ======
+translate T compStop {Eylemin bitiminden sonra dur. oyun}
+# ====== TODO To be translated ======
+translate T compRunning {Turnuva devam ediyor}
+# ====== TODO To be translated ======
+translate T Restart {Tekrar başlat}
+# ====== TODO To be translated ======
+translate T compFinished {Turnuva bitti}
+# ====== TODO To be translated ======
+translate T compStopped {Turnuva durduruldu}
 
 Listede bir oyuncu bulunan bir oyun her yüklendiğinde, oyunu o oyuncunun bakış açısından göstermek için gerekirse ana pencere satranç tahtası döndürülecektir.}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate T showblunderexists {hatanın var olduğunu göster}
@@ -1760,6 +1860,7 @@ translate T TBNoMoves {Yasal hamle bulunamadı.}
 translate T TBTooMany {Çok fazla parça. Lichess masa tabanı 7 parçaya kadar destekler.}
 translate T TBQuerying {Lichess API'si sorgulanıyor...}
 translate T TBError {Lichess'i sorgulamak için curl başlatılırken hata oluştu.}
+translate T TBQueryError {Tablo tabanı API'sinden geçersiz yanıt.}
 translate T TBNotFound {Tablo tabanında konum bulunamadı veya API hatası.}
 translate T TBCategory {Pozisyon Kategorisi:}
 translate T TBTrainingHidden {(Eğitim modu; sonuçlar gizlenir)}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -113,6 +113,8 @@ menuText Q GameGotoMove "Перейти до номера переміщення
   {Перейти до вказаного номера ходу в поточній грі}
 menuText Q GameNovelty "Знайти новинку..." 7 \
   {Знайдіть перший хід цієї гри, який ще не грав}
+menuText Q PlayTournament "Грати в турнір..." 0 \
+    {Грайте в турнір двигунів}
 
 # Search Menu:
 menuText Q Search "Пошук" 0
@@ -1381,8 +1383,106 @@ translate Q RecentFilesExtra {Кількість останніх файлів �
 
 # My Player Names options:
 translate Q MyPlayerNamesDescription {Введіть список бажаних імен гравців нижче, по одному імені в рядку. Допускаються символи підстановки (наприклад, «?» для будь-якого окремого символу, «*» для будь-якої послідовності символів).
+# ====== TODO To be translated ======
+translate Q configComp {Налаштувати турнір}
+# ====== TODO To be translated ======
+translate Q Tournament {Турнір}
+# ====== TODO To be translated ======
+translate Q Available {в наявності}
+# ====== TODO To be translated ======
+translate Q Selected {Вибране}
+# ====== TODO To be translated ======
+translate Q RoundRobin {Кругова система}
+# ====== TODO To be translated ======
+translate Q Gauntlet {рукавичка}
+# ====== TODO To be translated ======
+translate Q CompGameNext {Наступна гра:}
+# ====== TODO To be translated ======
+translate Q TimeperGame {Час на\Гру}
+# ====== TODO To be translated ======
+translate Q TimeperMove {Час на\хід}
+# ====== TODO To be translated ======
+translate Q compStoreTime {Час зберігання:}
+# ====== TODO To be translated ======
+translate Q Clock {Годинник}
+# ====== TODO To be translated ======
+translate Q compConcurrent {Одночасні ігри:}
+# ====== TODO To be translated ======
+translate Q compShowBoards {Show Boards}
+# ====== TODO To be translated ======
+translate Q compCarousel {Карусельна система}
+# ====== TODO To be translated ======
+translate Q compSaveEval {Зберегти оцінку}
+# ====== TODO To be translated ======
+translate Q compCanceledGames {Скасовані або тайм-аут гри:}
+# ====== TODO To be translated ======
+translate Q Replay {Повтор}
+# ====== TODO To be translated ======
+translate Q compStart {старт}
+# ====== TODO To be translated ======
+translate Q compSave {Зберігайте після кожної гри}
+# ====== TODO To be translated ======
+translate Q compStop {Зупинка після закінчення акту. гра}
+# ====== TODO To be translated ======
+translate Q compRunning {Турнір триває}
+# ====== TODO To be translated ======
+translate Q Restart {Перезапустіть}
+# ====== TODO To be translated ======
+translate Q compFinished {Турнір завершено}
+# ====== TODO To be translated ======
+translate Q compStopped {Турнір зупинено}
 
 Кожного разу, коли завантажується гра з гравцем у списку, шахівниця головного вікна повертатиметься, якщо необхідно, щоб показати гру з точки зору цього гравця.}
+
+# Computer Tournament:
+# MISSING TRANSLATION for configComp:
+# translate E configComp {Configure Tournament}
+# MISSING TRANSLATION for Tournament:
+# translate E Tournament {Tournament}
+# MISSING TRANSLATION for Available:
+# translate E Available {Available}
+# MISSING TRANSLATION for Selected:
+# translate E Selected {Selected}
+# MISSING TRANSLATION for RoundRobin:
+# translate E RoundRobin {Round Robin}
+# MISSING TRANSLATION for Gauntlet:
+# translate E Gauntlet {Gauntlet}
+# MISSING TRANSLATION for CompGameNext:
+# translate E CompGameNext {Next game:}
+# MISSING TRANSLATION for TimeperGame:
+# translate E TimeperGame {Time per\nGame}
+# MISSING TRANSLATION for TimeperMove:
+# translate E TimeperMove {Time per\nMove}
+# MISSING TRANSLATION for compStoreTime:
+# translate E compStoreTime {Store Time: }
+# MISSING TRANSLATION for Clock:
+# translate E Clock {Clock}
+# MISSING TRANSLATION for compConcurrent:
+# translate E compConcurrent {Concurrent games: }
+# MISSING TRANSLATION for compShowBoards:
+# translate E compShowBoards {Show Boards}
+# MISSING TRANSLATION for compCarousel:
+# translate E compCarousel {Carousel system}
+# MISSING TRANSLATION for compSaveEval:
+# translate E compSaveEval {Save evaluation}
+# MISSING TRANSLATION for compCanceledGames:
+# translate E compCanceledGames {Canceled or timed out games:}
+# MISSING TRANSLATION for Replay:
+# translate E Replay {Replay}
+# MISSING TRANSLATION for compStart:
+# translate E compStart {Start}
+# MISSING TRANSLATION for compSave:
+# translate E compSave {Save after every game}
+# MISSING TRANSLATION for compStop:
+# translate E compStop {Stop after end\nof act. game}
+# MISSING TRANSLATION for compRunning:
+# translate E compRunning {Tournament in progress}
+# MISSING TRANSLATION for Restart:
+# translate E Restart {Restart}
+# MISSING TRANSLATION for compFinished:
+# translate E compFinished {Tournament finished}
+# MISSING TRANSLATION for compStopped:
+# translate E compStopped {Tournament stopped}
 
 #Coach
 translate Q showblunderexists {показати, що помилка існує}
@@ -1757,8 +1857,8 @@ translate Q TBNoMoves {Законних ходів не знайдено.}
 translate Q TBTooMany {Забагато частин. Настільна база Lichess підтримує до 7 предметів.}
 translate Q TBQuerying {Запит Lichess API...}
 translate Q TBError {Помилка запуску curl для запиту Lichess.}
-translate Q TBNotFound {Позиція не знайдена в базі таблиць або помилка API.}
 translate Q TBQueryError {Неправильна відповідь від API бази таблиць.}
+translate Q TBNotFound {Позиція не знайдена в базі таблиць або помилка API.}
 translate Q TBCategory {Категорія посади:}
 translate Q TBTrainingHidden {(Режим навчання; результати приховані)}
 }

--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -193,6 +193,8 @@ $m add command -label GameDeepest -accelerator "Ctrl+Shift+D" -command {
 }
 $m add command -label GameGotoMove -accelerator "Ctrl+U" -command ::game::GotoMoveNumber
 $m add command -label GameNovelty -accelerator "Ctrl+Shift+Y" -command findNovelty
+$m add command -label PlayTournament -command { compInit } -accelerator "Ctrl+Shift+R"
+bind . <Control-R> { compInit }
 
 
 ### Search menu:

--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -194,7 +194,7 @@ $m add command -label GameDeepest -accelerator "Ctrl+Shift+D" -command {
 $m add command -label GameGotoMove -accelerator "Ctrl+U" -command ::game::GotoMoveNumber
 $m add command -label GameNovelty -accelerator "Ctrl+Shift+Y" -command findNovelty
 $m add command -label PlayTournament -command { compInit } -accelerator "Ctrl+Shift+R"
-bind . <Control-R> { compInit }
+bind . <Control-Shift-R> { compInit }
 
 
 ### Search menu:

--- a/tcl/start.tcl
+++ b/tcl/start.tcl
@@ -972,6 +972,8 @@ tools/lichess_eval.tcl
 tools/lichess_openex.tcl
 tools/auto_comment.tcl
 tools/analysis_auto_comment.tcl
+tools/enginenowin.tcl
+tools/multicomp.tcl
 end.tcl
 tools/tacgame.tcl
 tools/sergame.tcl

--- a/tcl/tools/enginenowin.tcl
+++ b/tcl/tools/enginenowin.tcl
@@ -1,0 +1,103 @@
+###
+### enginenowin.tcl: part of Scid.
+### This file is part of Scid (Shane's Chess Information Database).
+### Copyright (C) 2025 Uwe Klimmek
+### uses code from Fulvio Benini https://github.com/benini/chess_accuracy and analysis.tcl
+##########################################################################################
+### procs for using engines without a engine window
+
+# engineNoWin will be used by annotate and finish game
+namespace eval ::engineNoWin {}
+# Open the engine and configure it
+proc ::engineNoWin::initEngine { id engine callback } {
+    if { [info exists ::enginecfg::engConfig_$id] } { return 1 }
+    set config [::enginecfg::get $engine]
+    lassign $config name cmd args wdir elo time url uci options
+    set ::enginecfg::engConfig_$id $config
+    ::engine::setLogCmd $id {}
+    ::engine::connect $id $callback $cmd $args
+    if { $options ne "" } { ::engine::send $id SetOptions $options }
+    return 1
+}
+
+proc ::engineNoWin::closeEngine { id } {
+    ::engine::close $id
+     unset -nocomplain ::enginecfg::engConfig_$id
+}
+
+proc ::engineNoWin::changeEngine {id w enginevar callback} {
+    ::engineNoWin::closeEngine $id
+    $w.text configure -state normal
+    $w.text delete 1.0 end
+    foreach wchild [winfo children $w.text] { destroy $wchild }
+    set engine [set $enginevar]
+    ::engineNoWin::initEngine $id $engine [list $callback $id $w]
+}
+
+proc ::engineNoWin::showHideOptionsFrame {id w enginevar callback col} {
+    if { [winfo ismapped $w] } { grid forget $w ; return }
+    grid $w -row 0 -column $col -rowspan 5 -sticky ne -padx 10
+    set engine [set $enginevar]
+    ::engineNoWin::initEngine $id $engine [list $callback $id $w]
+}
+
+#create frame for select and edit engine options
+#engType: all, uci or winboard
+proc ::engineNoWin::createEngineOptionsFrame {f id var col callback {engTyp "uci"}} {
+    ttk::frame $f.$id
+    set allEngList [::enginecfg::names ]
+    if { $engTyp ne "all"} {
+        set engList {}
+        foreach name $allEngList {
+            set typ [lindex [::enginecfg::get $name] 7]
+            if { $engTyp == "uci" && $typ || $engTyp == "winboard" && ! $typ } {
+                lappend engList $name
+            }
+        }
+    } else {
+        set engList $allEngList
+    }
+    if { [set $var] eq "" } { set $var [lindex $engList 0] }
+    ttk::combobox $f.$id.eng -width 20 -state readonly -values $engList -textvariable $var
+    bind $f.$id.eng <<ComboboxSelected>> "::engineNoWin::changeEngine $id $f.opts$id $var $callback"
+    ttk::button $f.$id.opts -image ::icon::filter_adv -style Toolbutton \
+        -command "::engineNoWin::showHideOptionsFrame $id $f.opts$id $var $callback $col"
+    pack $f.$id.eng $f.$id.opts -side left -padx { 0 5 }
+    ttk::labelframe $f.opts$id -text "Engine Parameter"
+    ttk::label $f.opts$id.l -textvariable $var
+    ttk::button $f.opts$id.x -image tb_close -style Toolbutton -command "grid forget $f.opts$id"
+    ttk_text $f.opts$id.text -wrap none -padx 4
+    autoscrollBars both $f.opts$id $f.opts$id.text 1
+    $f.opts$id.text configure -state normal -wrap word -width 60 -height 18
+    ttk::button $f.opts$id.save -text "Save Setup" -command "::engineNoWin::saveEngineSetup $id"
+    grid $f.opts$id.l -row 0 -column 0 -sticky w
+    grid $f.opts$id.x -row 0 -column 1 -sticky e
+    grid $f.opts$id.save -row 2 -column 0 -columnspan 2 -sticky e -pady { 5 0 }
+    bind $f.$id <Destroy> "::engineNoWin::closeEngine $id"
+}
+
+proc ::engineNoWin::initEngineOptions {id w options} {
+    upvar ::enginecfg::engConfig_$id engConfig_
+    if { ! [winfo exists $w.text.reset] } {
+        lset ::enginecfg::engConfig_$id 8 $options
+        ::enginecfg::createOptionWidgets $id $w $options
+        ::engine::replyInfoConfig $id
+    } else {
+        lset ::enginecfg::engConfig_$id 8 $options
+        ::enginecfg::updateOptionWidgets $id $w $options {}
+        $w.text configure -state disabled
+    }
+}
+
+proc ::engineNoWin::saveEngineSetup { id } {
+    upvar ::enginecfg::engConfig_$id engConfig_
+    ::enginecfg::save [set ::enginecfg::engConfig_$id]
+}
+
+proc ::engineNoWin::disconnected { id data } {
+    upvar ::enginecfg::engConfig_$id engConfig_
+    lassign $data errorMsg
+    lassign [set ::enginecfg::engConfig_$id] engine
+    if {$errorMsg eq ""} { set errorMsg "The connection with the engine $id $engine terminated unexpectedly." }
+    tk_messageBox -icon warning -type ok -parent . -message $errorMsg
+}

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -451,7 +451,7 @@ proc loadComp {} {
     ::comp::updateSelectedEngines
     compInit
     createGames $_Data(carousel)
-    destroy .comp.engines.list
+    if {[winfo exists .comp.engines.list]} { destroy .comp.engines.list }
 }
 
 proc createGames { carousel } {

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -443,7 +443,7 @@ proc loadComp {} {
     foreach e $_Data(playernames) {
         set found [lsearch -exact $engList $e]
         if { $found < 0 } {
-            tk_messageBox -type ok -title {Scid: Fehler} -message "Engine [lindex $_Data(playernames) $i] not found."
+            tk_messageBox -type ok -title {Scid: Fehler} -message "Engine $e not found."
             return
         }
     }

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -1,0 +1,1224 @@
+### Multithreaded Computer Tournament 
+###
+### multicomp.tcl: part of Scid.
+### Copyright (C) 2025- Uwe Klimmek
+
+# Credit to Fulvio for a few lines of UCI code that enabled me
+# to make this run nicely (without constantly reseting analysis),
+# and gave me impetus for a decent control structure using
+# semaphores/vwait instead of the often abused dig-deeper procedural flow 
+# sometimes evident in tcl programs.
+##################################
+
+namespace eval comp {
+    array set engine {} 
+    set cSGLock 0
+    set _Data(showscores) 1
+    set _Data(showtimes) 2
+    set _Data(base) 2
+    set _Data(processes) 3
+    set _Data(endaftergame) 0
+    set _Data(current) 1
+    set _Data(lastgame) 2
+    set _Data(games) {}
+    set _Data(showBoards) 1
+    set _Data(count) 0 ; # number of computer players
+    set _Data(start) 0 ; # "Start at position" radiobutton
+    set _Data(delta) 4000; # 4 seconds is the time
+    set _Data(tournament) "Scid Engine [tr Event]"
+    set _Data(carousel) 1
+    set _Data(site) "SCID"
+    set _Data(seconds) 0.5
+    set _Data(timecontrol) pergame ; # pergame or permove
+    set _Data(minutes) 1
+    set _Data(incr) 0.5
+    set _Data(rounds) 2
+    set _Data(firstonly) 0
+    set _Data(usebook) 0
+    set _Data(book) {}
+    set _Data(bookName) ""
+    set _Data(players) {}
+    set _Data(playernames) {}
+    set _Data(statustext) ""
+    set _Data(replaybrokengame) 1
+    set _Data(savebrokengame) 1
+    set _Data(autosave) 0
+    set _Data(engine) ""
+    set _Data(runninggames) 0
+    set _Data(paused) 0
+    set _Data(bookTyp) ""
+}
+
+# return index of actBook and a list of all books, return -1 if no books available
+proc ::comp::getBookList { actBook } {
+    set bookPath $::scidBooksDir
+    set bookList [  lsort -dictionary [ glob -nocomplain -directory $bookPath *.opn *.epd *.bin] ]
+    # No book found
+    if { [llength $bookList] == 0 } {
+        return [list -1 {}]
+    }
+    set tmp {}
+    set idx 0
+    set i 0
+    foreach file $bookList {
+        lappend tmp [ file tail $file ]
+        if {$actBook == [ file tail $file ] } {
+            set idx $i
+        }
+        incr i
+    }
+    return [list $idx $tmp]
+}
+
+
+# Convert FEN string to board representation
+# (local copy since scidCommunity lacks pgnviewer.tcl)
+proc ::comp::FENtoBoard { fen } {
+    set b ""
+    set end [string first " " $fen]
+    incr end 1
+    set m [string index $fen $end]
+    set fen "/$fen"
+    set line [string last "/" $fen]
+    while { $line >= 0 } {
+        set i [expr $line + 1]
+        set c [string index $fen $i]
+        while { $c ne "/" && $c ne " " } {
+            if { [string is digit $c] } {
+                for { set j 0 } { $j < $c } {incr j} { append b "." }
+            } else { append b $c }
+            incr i
+            set c [string index $fen $i]
+        }
+        set fen [string replace $fen $line $line " "]
+        set line [string last "/" $fen]
+    }
+    append b " $m"
+    return $b
+}
+
+proc ::comp:loadBook { bookName } {
+    global ::comp::_Data
+
+    set _Data(bookTyp) [string range $bookName end-2 end]
+    unset -nocomplain ::comp::openline
+    set _Data(maxopen) 0
+    if { $_Data(bookTyp) eq "bin" } return
+    if { $::comp::_Data(usebook) } {
+        set filename [ file join $::scidBooksDir $bookName ]
+        set infile [open $filename r]
+        set _Data(maxopen) 1
+        while { [gets $infile line] > 0 } {
+            set ::comp::openline($_Data(maxopen)) $line
+            incr _Data(maxopen)
+        }
+        close $infile
+        set ::comp::openline(0) $::comp::openline(1)
+        set ::comp::openline($_Data(maxopen)) $::comp::openline(1)
+    }
+}
+
+### Non-transient options are set in start.tcl
+proc calcGames {} {
+    global ::comp::_Data
+    set _Data(count) [llength $_Data(playernames)]
+    if { $_Data(firstonly)} {
+        set _Data(lastgame) [expr {($_Data(count)-1) * $_Data(rounds)}]
+    } else {
+        set _Data(lastgame) [expr {$_Data(count) * ($_Data(count)-1) * $_Data(rounds) / 2}]
+    }
+    return $_Data(count)
+}
+
+proc ::comp::updateSelectedEngines { {sel ""} } {
+    global ::comp::_Data
+    set j 0
+    .comp.engines.oldin.list delete [.comp.engines.oldin.list children {}]
+    foreach y $_Data(playernames) {
+        .comp.engines.oldin.list insert {} end -id $j -values [list $y]
+        incr j
+    }
+    if { $sel ne "" } { .comp.engines.oldin.list selection set $sel }
+}
+
+proc ::comp::editEngines {} {
+    global ::comp::_Data
+    set sel [.comp.engines.oldin.list selection]
+    if { [llength $sel] != 1 } return
+    set sel [lindex $sel 0]
+    set _Data(engine) [lindex $_Data(playernames) $sel]
+    ::engineNoWin::changeEngine compEngine .comp.optscompEngine ::comp::_Data(engine) ::comp::eng_messages
+}
+
+proc ::comp::addEngines {} {
+    global ::comp::_Data
+    set sel [.comp.engines.oldout.list selection]
+    lassign [::comp::getEngList] maxEng engList
+    set engList [lsort $engList]
+    foreach i $sel {
+        set name [lindex $engList $i]
+        lappend _Data(playernames) "$name"
+        set ::comp::engine($_Data(count)) $name
+    }
+    ::comp::updateSelectedEngines
+    calcGames
+    set _Data(current) 1
+}
+
+proc ::comp::removeEngines {} {
+    global ::comp::_Data
+    set sel [.comp.engines.oldin.list selection]
+    foreach i $sel {
+        set _Data(playernames) [lreplace $_Data(playernames) $i $i]
+    }
+    ::comp::updateSelectedEngines
+    calcGames
+    set _Data(current) 1
+}
+proc ::comp::updownEngines { dir } {
+    global ::comp::_Data
+    set sel [.comp.engines.oldin.list selection]
+    if { [llength $sel] != 1 } return
+    set sel [lindex $sel 0]
+    set name [lindex $_Data(playernames) $sel]
+    set _Data(playernames) [lreplace $_Data(playernames) $sel $sel]
+    incr sel $dir
+    set _Data(playernames) [linsert $_Data(playernames) $sel $name]
+    ::comp::updateSelectedEngines $sel
+}
+
+proc ::comp::configEngine { } {
+    global ::comp::_Data
+    set sel [.comp.engines.oldin.list selection]
+    if { [llength $sel] != 1 } return
+    set sel [lindex $sel 0]
+    set _Data(engine) [lindex $_Data(playernames) $sel]
+    .comp.compEngine.opts invoke
+}
+
+proc compInit { } {
+  global ::comp::_Data engines
+
+  set w .comp
+  if {[winfo exists $w]} {
+    raiseWin $w
+    return
+  }
+  win::createDialog $w
+  wm state $w withdrawn
+  wm title $w [tr configComp]
+  setWinLocation $w
+
+  grid [ttk::labelframe $w.engines -text [tr ToolsConfigureEngines]] -row 0 -column 0 -rowspan 3 -sticky nswe -padx "0 10"
+  grid [ttk::labelframe $w.tournament -text [tr Tournament]] -row 0 -column 1 -sticky nswe
+  grid [ttk::labelframe $w.time -text [tr TimeMode]] -row 1 -column 1 -sticky nswe -pady 5
+  grid [ttk::labelframe $w.config -text [tr GlistEditField]] -row 2 -column 1 -sticky nswe
+  grid [ttk::frame $w.buttons] -row 4 -column 0 -columnspan 2 -sticky we -pady "5 0"
+  grid [ttk::frame $w.games] -row 3 -column 0 -columnspan 2 -sticky nswe
+
+  ### Engines
+  lassign [::comp::getEngList] maxEng engList
+  set l $w.engines
+    foreach { i h e } [list out [tr Available] engList in [tr Selected] _Data(playernames)] {
+      ttk::frame $l.old$i
+      ttk::label $l.old$i.label -text $h -font font_Bold
+      ttk::treeview $l.old$i.list -columns {0} -show {} -selectmode extended \
+          -yscrollcommand "$l.old$i.ybar set"
+      $l.old$i.list column 0 -width 140
+      $l.old$i.list configure -height 20
+      ttk::scrollbar $l.old$i.ybar -command "$l.old$i.list yview"
+      pack $l.old$i.label -side top -anchor w
+      pack $l.old$i.ybar -side right -fill y
+      pack $l.old$i.list -side left -fill both -expand 1
+      set j 0
+      set il {}
+      set e [set $e]
+      foreach y [lsort $e] {
+          $l.old$i.list insert {} end -id $j -values [list "$y"]
+          incr j
+      }
+  }
+  ::comp::updateSelectedEngines
+
+  bind $l.oldin.list <<TreeviewSelect>> { ::comp::editEngines }
+  grid $l.oldout -row 0 -column 0
+  grid $l.oldin -row 0 -column 2
+  grid [ttk::frame $l.btlr] -row 0 -column 1
+  grid [ttk::frame $l.btud] -row 0 -column 1 -sticky s
+  ttk::button $l.btlr.l -image tb_prev -command { ::comp::removeEngines }
+  ttk::button $l.btlr.r -image tb_next -command { ::comp::addEngines }
+  ttk::button $l.btud.u -image tb_up -command { ::comp::updownEngines -1 }
+  ttk::button $l.btud.d -image tb_down -command { ::comp::updownEngines 1}
+  ttk::button $l.config -image ::icon::filter_adv -command { ::comp::configEngine }
+  grid $l.config -row 0 -column 1 -sticky n -pady 20
+  ::engineNoWin::createEngineOptionsFrame $w compEngine ::comp::_Data(engine) 7 ::comp::eng_messages
+  pack forget $w.compEngine.eng
+
+  pack $l.btlr.r $l.btlr.l -side top -padx 5
+  pack $l.btud.u $l.btud.d -side top
+
+  set _Data(endaftergame) 0
+  set _Data(countcombos) $_Data(count)
+
+  ### Config widgets
+  set row 0
+
+  ttk::label $w.tournament.eventlabel -text $::tr(Event:)
+  ttk::entry $w.tournament.evententry -width 26 -textvariable ::comp::_Data(tournament)
+
+  grid $w.tournament.eventlabel -row $row -column 0 -sticky w -pady 2
+  grid $w.tournament.evententry -row $row -column 1 -sticky we -pady 2 -columnspan 3
+
+  incr row
+  ttk::label $w.tournament.sitelabel -text $::tr(Site:)
+  ttk::entry $w.tournament.siteentry -width 26 -textvariable ::comp::_Data(site)
+  grid $w.tournament.sitelabel -row $row -column 0 -sticky w -pady 2
+  grid $w.tournament.siteentry -row $row -column 1 -sticky we -pady 2 -columnspan 3
+
+  incr row
+  ttk::frame $w.tournament.firstonlyvalue
+  ttk::label $w.tournament.firstonlyvalue.0 -text [tr FinderSortType]
+  ttk::radiobutton $w.tournament.firstonlyvalue.1 -text [tr RoundRobin] -variable ::comp::_Data(firstonly) -value 0 -command "calcGames"
+  ttk::radiobutton $w.tournament.firstonlyvalue.2 -text [tr Gauntlet] -variable ::comp::_Data(firstonly) -value 1 -command "calcGames"
+  pack $w.tournament.firstonlyvalue.0 $w.tournament.firstonlyvalue.1 $w.tournament.firstonlyvalue.2 -side left -padx "0 5" 
+  grid $w.tournament.firstonlyvalue -row $row -column 0 -pady 2 -sticky w -columnspan 4
+
+  incr row
+  ttk::label $w.tournament.roundslabel -text [tr Rounds]
+  ttk::label $w.tournament.aktlabel -text [tr CompGameNext]
+  ttk::label $w.tournament.roundsakt -textvar ::comp::_Data(current)
+  ttk::spinbox $w.tournament.roundsvalue -textvariable ::comp::_Data(rounds) -from 1 -to 10 -width 3 -command "calcGames"
+
+  grid $w.tournament.roundslabel -row $row -column 0 -sticky w -pady 2
+  grid $w.tournament.roundsvalue -row $row -column 1 -pady 2 -sticky w
+  grid $w.tournament.aktlabel -row $row -column 2 -sticky w -pady 2
+  grid $w.tournament.roundsakt -row $row -column 3 -sticky w -pady 2
+
+  incr row
+  ttk::frame $w.time.control
+  ttk::radiobutton $w.time.control.1 -variable ::comp::_Data(timecontrol) -value pergame -text [tr Game] -command checkTimeControl
+  ttk::radiobutton $w.time.control.2 -variable ::comp::_Data(timecontrol) -value permove -text [tr move] -command checkTimeControl
+
+  pack $w.time.control.1 $w.time.control.2 -side left -padx "0 5"
+  grid $w.time.control  -row $row -column 0 -columnspan 3 -sticky w -pady 2
+
+  incr row
+  ttk::frame $w.time.timegame 
+  ttk::label $w.time.timegame.label -text [tr TimeperGame]
+  ttk::spinbox $w.time.timegame.base -textvariable ::comp::_Data(base) -from 0 -to 7200 -incr 5 -width 4
+
+  ttk::label $w.time.timegame.label2 -text [tr TimeSec]
+  ttk::spinbox $w.time.timegame.incr -textvariable ::comp::_Data(incr) -from 0 -to 60 -width 4 -incr 0.1
+    ttk::label $w.time.timegame.label3 -text [tr FICSIncrement]
+
+  pack $w.time.timegame.label -side left -padx "0 5"
+  pack $w.time.timegame.base -side left
+  pack $w.time.timegame.label2 -side left -padx "0 5"
+  pack $w.time.timegame.label3 $w.time.timegame.incr -side right
+  grid $w.time.timegame -row $row -column 0 -columnspan 2 -sticky ew -pady 2
+
+  incr row
+  ttk::frame $w.time.timesecs 
+  ttk::label $w.time.timesecs.label -text [tr TimeperMove]
+  set tmp $_Data(seconds)
+  ttk::spinbox $w.time.timesecs.value -textvariable ::comp::_Data(seconds) -from 1 -to 3600 -width 4
+  set _Data(seconds) $tmp
+  ttk::label $w.time.timesecs.label2 -text [tr sec]
+
+  pack $w.time.timesecs.label -side left -padx "0 5"
+  pack $w.time.timesecs.value $w.time.timesecs.label2 -side left
+  grid $w.time.timesecs -row $row -column 0 -columnspan 2 -sticky we -pady 2
+
+  incr row
+  ttk::frame $w.time.show
+  ttk::label $w.time.show.l -text [tr compStoreTime]
+  ttk::radiobutton $w.time.show.time0 -text [tr None] -variable ::comp::_Data(showtimes) -value 0
+  ttk::radiobutton $w.time.show.time1 -text [tr Clock] -variable ::comp::_Data(showtimes) -value 1
+  ttk::radiobutton $w.time.show.time2 -text [tr move] -variable ::comp::_Data(showtimes) -value 2
+  pack $w.time.show.l -side left
+  pack $w.time.show.time0 $w.time.show.time1 $w.time.show.time2 -side left -padx "5 0"
+  grid $w.time.show -row $row -column 0 -sticky w -columnspan 3
+    
+  incr row
+  ttk::frame $w.config.multi
+  ttk::label $w.config.multi.label -text [tr compConcurrent]
+  ttk::spinbox $w.config.multi.value -textvariable ::comp::_Data(processes) -from 1 -to 8 -width 2
+  pack $w.config.multi.label $w.config.multi.value -side left
+  grid $w.config.multi -row $row -column 0 -sticky w
+  ttk::checkbutton $w.config.grafic -text [tr compShowBoards] -variable ::comp::_Data(showBoards)
+  grid $w.config.grafic -row $row -column 1 -sticky w -padx 5
+    
+  incr row
+  checkTimeControl
+
+  ttk::checkbutton $w.config.carousel -text [tr compCarousel] -variable ::comp::_Data(carousel)
+  grid $w.config.carousel -row $row -column 0 -padx 5 -sticky w
+
+  ttk::checkbutton $w.config.scorevalue -text [tr compSaveEval] -variable ::comp::_Data(showscores)
+  grid $w.config.scorevalue -row $row -column 1 -columnspan 2 -padx 5 -sticky w
+
+  incr row
+  ttk::label $w.config.0 -text [tr compCanceledGames]
+  grid $w.config.0 -row $row -column 0 -columnspan 2 -sticky w -pady "2 0"
+  incr row
+  ttk::checkbutton $w.config.replaybroken -text [tr Replay] -variable ::comp::_Data(replaybrokengame)
+  grid $w.config.replaybroken -row $row -column 0 -padx 13 -sticky w
+  ttk::checkbutton $w.config.savebroken -text [tr Save] -variable ::comp::_Data(savebrokengame)
+  grid $w.config.savebroken -row $row -column 1 -padx 8 -sticky w
+
+  incr row
+  ttk::checkbutton $w.config.autosave -text [tr compSave] -variable ::comp::_Data(autosave)
+  grid $w.config.autosave -row $row -column 0 -columnspan 2 -sticky w
+  ### Opening Book
+
+  incr row
+  ttk::frame $w.config.book
+  ttk::checkbutton $w.config.book.value -variable ::comp::_Data(usebook) -text [tr UseBook]
+  # load book names
+  lassign [::comp::getBookList $_Data(bookName)] idx tmp
+  if { $idx < 0 } {
+    $w.config.book.value configure -state disabled
+    set _Data(usebook) 0
+  }
+  if { $_Data(bookName) eq "" } { set _Data(bookName) [lindex $tmp $idx] }
+  ttk::combobox $w.config.book.combo -values $tmp -textvariable ::comp::_Data(bookName)
+  catch { $w.config.book.combo current $idx }
+
+  grid $w.config.book -row $row -column 0 -columnspan 2 -sticky w
+  pack $w.config.book.combo $w.config.book.value -side right -padx "0 5"
+
+  ttk::label $w.games.aktstart -text "[tr games] "
+  ttk::label $w.games.aktend -text " - "
+  ttk::spinbox $w.games.roundakt -textvariable ::comp::_Data(current) -from 1 -to 999 -width 3
+  ttk::spinbox $w.games.roundend -textvariable ::comp::_Data(lastgame) -from 1 -to 999 -width 4
+  pack $w.games.aktstart $w.games.roundakt $w.games.aktend $w.games.roundend -side left -pady "4 0"
+    
+  ### OK, Cancel Buttons
+
+  ttk::button $w.buttons.cancel -text $::tr(Cancel) -command compClose
+  ttk::button $w.buttons.ok -text [tr compStart] -command "startComp; compOk"
+  ttk::button $w.buttons.save -text [tr Save] -command "startComp; compSave"
+  ttk::button $w.buttons.load -text [tr GsortLoad] -command "loadComp"
+
+  focus $w.buttons.ok
+  packbuttons right $w.buttons.cancel $w.buttons.ok $w.buttons.save $w.buttons.load -anchor e
+
+  bind $w <Configure> "recordWinSize $w"
+  wm protocol $w WM_DELETE_WINDOW compClose
+  wm resizable $w 0 0
+  bind $w <Escape> compClose
+  bind $w <F1> {helpWindow Tourney}
+  update
+  wm state $w normal
+}
+
+proc checkTimeControl {} {
+  global ::comp::_Data
+  set w .comp
+  if {$_Data(timecontrol) == "permove" } {
+    foreach i [winfo children $w.time.timesecs] {
+      $i configure -state normal
+    }
+    foreach i [winfo children $w.time.timegame] {
+      $i configure -state disabled
+    }
+  } else {
+    foreach i [winfo children $w.time.timesecs] {
+      $i configure -state disabled
+    }
+    foreach i [winfo children $w.time.timegame] {
+      $i configure -state normal
+    }
+  }
+  update
+}
+proc loadComp {} {
+    global ::comp::_Data engines scidConfigDir
+    set filename ""
+    set types { {{Scid Tournament Files} {.sto}} }
+    set filename [tk_getOpenFile -initialdir $scidConfigDir -initialfile $_Data(tournament) -filetypes  $types -defaultextension ".sto"]
+    if {$filename != ""} { source $filename }
+
+    lassign [::comp::getEngList] maxEng engList
+    foreach e $_Data(playernames) {
+        set found [lsearch -exact $engList $e]
+        if { $found < 0 } {
+            tk_messageBox -type ok -title {Scid: Fehler} -message "Engine [lindex $_Data(playernames) $i] not found."
+            return
+        }
+    }
+    .comp.config.book.combo set $_Data(book)
+    ::comp::updateSelectedEngines
+    compInit
+    createGames $_Data(carousel)
+    destroy .comp.engines.list
+}
+
+proc createGames { carousel } {
+    global ::comp::_Data
+    ### Place games in cue
+    set _Data(games) {}
+    set gamesPerRound [expr int($_Data(count)/2)]
+    set even [expr ($_Data(count)+1) % 2]
+    set rounds [expr $_Data(count) -1 ]
+    set last [expr $_Data(count) -1 ]
+    set plist {}
+    set hlist {}
+    if { !$even } {
+        set last [expr $_Data(count) -2 ]
+        set rounds $_Data(count)
+    }
+    if { $carousel && ! $_Data(firstonly) } {
+        for {set k 1} {$k <= $_Data(rounds)} {incr k} {
+            for {set i 0} {$i < $_Data(count)} {incr i} {
+                lappend plist $i
+            }
+            ## Carousel or Rutschsystem
+            for {set l 1} {$l <= $rounds} {incr l} {
+                for {set i 0; set j $last } {$i < $gamesPerRound} {incr i; incr j -1 } {
+                    if { $even && [expr ($l-1) % 2] } {
+                        lappend _Data(games) [list [lindex $_Data(playernames) [lindex $plist $j]] [lindex $_Data(playernames) [lindex $plist $i]] "$k.$l"]
+                        lappend hlist [list [lindex $_Data(playernames) [lindex $plist $i]] [lindex $_Data(playernames) [lindex $plist $j]] "[expr $k+1].$l"]
+                    } else {
+                        lappend _Data(games) [list [lindex $_Data(playernames) [lindex $plist $i]] [lindex $_Data(playernames) [lindex $plist $j]] "$k.$l"]
+                        lappend hlist [list [lindex $_Data(playernames) [lindex $plist $j]] [lindex $_Data(playernames) [lindex $plist $i]] "[expr $k+1].$l"]
+                    }
+                }
+                set help [lindex $plist end];
+                set xlist [linsert $plist $even $help]
+                set plist [lreplace $xlist end end]
+            }
+            incr k
+            if { $k <= $_Data(rounds) } {
+                append _Data(games) " $hlist"
+                set hlist {}
+            }
+        }
+    } else {
+        for {set k 1} {$k <= $_Data(rounds)} {incr k} {
+            for {set i 0} {$i < $_Data(count)} {incr i} {
+                for {set j [expr $i + 1]} { $j < $_Data(count) } {incr j} {
+                    lappend _Data(games) [list [lindex $_Data(playernames) $i] [lindex $_Data(playernames) $j] $k]
+                    lappend hlist [list [lindex $_Data(playernames) $j] [lindex $_Data(playernames) $i] [expr $k+1]]
+                }
+                if {$_Data(firstonly)} {break}
+            }
+            incr k
+            if { $k <= $_Data(rounds) } {
+                append _Data(games) " $hlist"
+                set hlist {}
+            }
+        }
+    }
+}
+
+proc startComp { } {
+  global ::comp::_Data engines
+    if { ! [calcGames] } { return }
+    # make sure decimals have a leading 0
+    catch {
+        set _Data(incr) [expr $_Data(incr)]
+        set _Data(base) [expr $_Data(base)]
+        set _Data(seconds) [expr $_Data(seconds)]
+    }
+    
+    set _Data(players) {} ;# to remember which engines are selected between widget restarts
+    set _Data(book) [.comp.config.book.combo get]
+    
+    if {$_Data(timecontrol) == "permove"} {
+        set _Data(time) [expr {int($_Data(seconds) * 1000)}]
+        puts "Move delay is $_Data(time) milliseconds"
+    } 
+
+    if {$_Data(firstonly)} {
+        set _Data(firstN) [lindex $_Data(playernames) 0]
+    }
+    createGames $_Data(carousel)
+}
+
+proc  toggleEndAfterGame {} {
+    global ::comp::_Data
+    if { $_Data(endaftergame) } {
+        set _Data(endaftergame) 0
+        .comp.buttons.save state !pressed
+    } else {
+        set _Data(endaftergame) 1
+        .comp.buttons.save state pressed
+    }
+}
+
+proc ::comp::resizeBoards {x} {
+  global ::comp::_Data
+    set i $_Data(processes)
+    while { $i > 0 } {
+        ::board::resize .comp.bds.g$i $x
+        incr i -1
+    }
+}
+
+proc compOk {} {
+  global ::comp::_Data
+
+  set num_games [llength $_Data(games)]
+puts "$num_games GAMES total: $_Data(games)"
+  if { $num_games == 0 } return 
+  ## wait short for cleanup the engine analysis windows
+  set w .comp
+
+  set _Data(database) $::curr_db
+  if {[sc_base isReadOnly $_Data(database)]} {
+    set answer [tk_messageBox -title Tournanment -icon question -type okcancel \
+	-message {Database is read only. Continue ?} -parent $w]
+    if {$answer != "ok"} {return}
+  }
+  if {![sc_pos isAt end] && $_Data(start) > 0} {
+    set answer [tk_messageBox -title Tournanment -icon question -type okcancel \
+	-message {Die aktuelle Partie ist nicht am Ende der Partie. Fortfahren?} -parent $w]
+    if {$answer != "ok"} {return}
+  }
+
+  ### Reconfigure init widget for pausing
+  grid forget $w.config $w.time $w.engines $w.tournament
+
+  $w.buttons.ok configure -text "   Pause    " -command compPause -state normal
+  $w.buttons.save configure -text [tr compStop] -command "toggleEndAfterGame" -state normal
+  pack forget $w.buttons.load
+  $w.buttons.cancel configure -text [tr Cancel] -command { compAbort } -state normal
+  wm title $w "Scid [tr Engine] [tr Tournament]"
+  focus $w.buttons.ok
+
+  ttk::progressbar $w.progress -mode determinate -maximum $num_games -variable ::comp::_Data(current)
+  grid $w.progress -column 0 -row 6 -columnspan 12 -sticky we
+  ttk::label $w.status -textvariable ::comp::_Data(statustext)
+  grid $w.status -column 0 -row 7 -columnspan 2 -sticky we
+
+    if { $_Data(showBoards) } {
+        set nextrow 5
+        if { $_Data(processes) in { 5 6 } } { incr nextrow -1 }
+        ttk::button $w.games.plus -text " + " -command "::comp::resizeBoards +1; update" -state normal
+        ttk::button $w.games.minus -text " - " -command "::comp::resizeBoards -1; update" -state normal
+        pack $w.games.plus $w.games.minus -side right -pady "4 0"
+
+        ttk::frame $w.bds
+        set b $w.bds
+        set row 0
+        for {set i 1; set j 0} {$i <= $_Data(processes) } {incr i; incr j} {
+            set _Data(name,$i)(nameW) ""
+            set _Data(name,$i)(nameB) ""
+            set _Data(name,$i)(clockW) ""
+            set _Data(name,$i)(clockB) ""
+            ::board::new $b.g$i 40
+            ::board::addNamesBar $b.g$i ::comp::_Data(name,$i)
+            ::board::toggleEvalBar $b.g$i
+            ::board::toggleMaterial $b.g$i
+            if { $i == $nextrow } { set row 2; set j 0}
+            grid $b.g$i -column $j -row $row -padx 5
+            ttk::frame $b.b$i
+            ttk::button $b.b$i.w -text "1-0" -command "::comp::adjucateGame $i 1"
+            ttk::button $b.b$i.r -text " = " -command "::comp::adjucateGame $i ="
+            ttk::button $b.b$i.l -text "0-1" -command "::comp::adjucateGame $i 0"
+            pack $b.b$i.w $b.b$i.r $b.b$i.l -side left -padx 5
+            grid $b.b$i -column $j -row [expr $row +1] -padx 5 -pady {2 5}
+        }
+        grid $w.bds -column 0 -row 0
+    }
+  ### Play games
+  set game 0
+  set _Data(statustext) ""
+  set _Data(runninggames) 0
+  set _Data(paused) 0
+  ::comp:loadBook $_Data(bookName)
+  append _Data(statustext) [tr compRunning]
+  while {$_Data(runninggames) < $_Data(processes) && $_Data(current) <= $_Data(lastgame)} {
+    set thisgame [lindex $_Data(games) [expr $_Data(current) - 1]]
+    set name1 [lindex $thisgame 0]
+    set name2 [lindex $thisgame 1]
+    set k     [lindex $thisgame 2]
+    if {$name1 != {} && $name2 != {}} {
+      incr game
+puts "Start $_Data(current): $name1 - $name2"
+      after [expr {$game * 500} ] "compNM $game \"$name1\" \"$name2\" $k"
+      incr _Data(runninggames)
+      set _Data(this,$game) $thisgame
+    }
+    incr _Data(current)
+  }
+}
+
+proc ::comp::compOkEnd {game} {
+    global ::comp::_Data
+
+    incr _Data(runninggames) -1
+    set _Data(statustext) "[tr Result] [set _Data(name,$game)(nameW)] - [set _Data(name,$game)(nameB)]: $_Data(result,$game)\n"
+    ::engineNoWin::closeEngine compEnginewhite$game
+    ::engineNoWin::closeEngine compEngineblack$game
+    if { ! $_Data(endaftergame) && $_Data(current) <= $_Data(lastgame) } {
+        if { $_Data(result,$game) != "*" || !$_Data(replaybrokengame) } {
+            set thisgame [lindex $_Data(games) [expr $_Data(current) - 1]]
+            incr _Data(current)
+        } else {
+puts "replay $_Data(this,$game)"
+            set thisgame $_Data(this,$game)
+        }
+        if { $_Data(autosave) } { autocompSave }
+        set name1 [lindex $thisgame 0]
+        set name2 [lindex $thisgame 1]
+        set k     [lindex $thisgame 2]
+        if {$name1 != {} && $name2 != {}} {
+            after 500 "compNM $game \"$name1\" \"$name2\" $k"
+puts "Start $_Data(current): Slot $game $name1 - $name2"
+            incr _Data(runninggames)
+            set _Data(this,$game) $thisgame
+        }
+    }
+    if { $_Data(runninggames) > 0 } return
+    
+    if { $_Data(endaftergame) } { toggleEndAfterGame }
+
+  ### Comp over
+  if { $_Data(current) > $_Data(lastgame)} {
+      append _Data(statustext) [tr compFinished]
+      set _Data(current) $_Data(lastgame)
+      pack forget .comp.buttons.save
+  } else {
+      append _Data(statustext) [tr compStopped]
+      .comp.buttons.save configure -text [tr Continue] -state normal -command {
+          compDestroy
+          update
+          compInit
+          startComp
+          compOk
+      }
+  }
+  if {[winfo exists .comp]} {
+    # voodoo that you do
+    wm geometry .comp [wm geometry .comp]
+
+    # Hmm - if we leave this window open , and run F2 (say) the engines can sometimes stop working 
+    # So better make sure this window gets closed
+    .comp.buttons.ok configure -text [tr Restart] -command {
+       compDestroy
+       update
+       compInit
+       set _Data(current) 1
+    }
+    .comp.buttons.cancel configure -text [tr Close] -command {
+       if { $::comp::_Data(current) >= $::comp::_Data(lastgame) } { set ::comp::_Data(current) 1 }
+       compDestroy
+    }
+    raiseWin .comp
+  }
+}
+
+proc ::comp::makeBookLine {game} {
+    global ::comp::_Data
+    foreach i $_Data(moves,$game) {
+        lappend _Data(comments,$game) ""
+        lassign [::comp::compUpdateboard $_Data(board,$game) $i] res _Data(board,$game)
+    }
+    set _Data(comments,$game) [lreplace $_Data(comments,$game) end end "last move from $_Data(bookName)"]
+}
+
+#read bookline from *.bin opening book
+proc ::comp::readBookLine {game} {
+    global ::comp::_Data ::comp::cSGLock
+
+    set inbook 1
+    while { $cSGLock } {
+        puts "wait for make bookline"
+        vwait ::comp::cSGLock
+    }
+    set cSGLock 1
+    sc_game push
+    sc_game new
+    while { $inbook} {
+        set bestmove [::book::getMove $_Data(bookName) [sc_pos fen] 2]
+        if {$bestmove ne ""} {
+            if { [catch { sc_move addSan $bestmove }] } {
+                set inbook 0
+            } else {
+                sc_move forward
+            }
+        } else {
+            set inbook 0
+        }
+    }
+    set moves [sc_game UCI_currentPos]
+    set start [string first "moves " $moves]
+    incr start 6
+    set moves [string range $moves $start end]
+    sc_game pop
+    set cSGLock 0
+    return $moves
+}
+
+proc compNM {game n m k} {
+    global ::comp::_Data
+    
+    if {$_Data(timecontrol) == "pergame"} {
+        set _Data(white,$game) [expr int($_Data(base)*1000)]
+        set _Data(black,$game) [expr int($_Data(base)*1000)]
+    }
+    ## add 50ms to avoid lose on time
+    set _Data(incr50) [expr int($_Data(incr) * 1000) + 50]
+
+    update
+    set repetition {}
+    set material 0
+    set pawns ""
+    set _Data(score,$game) 0.0
+    set _Data(fen,$game) startpos
+    set _Data(moves,$game) {}
+    set _Data(comments,$game) {}
+    set _Data(board,$game) "RNBQKBNRPPPPPPPP................................pppppppprnbqkbnr"
+    if { $_Data(usebook) } {
+        switch $_Data(bookTyp) {
+            "opn" {
+                set _Data(moves,$game) $::comp::openline([expr {int( rand()*$_Data(maxopen) )}])
+                ::comp::makeBookLine $game
+            }
+            "epd" {
+                set _Data(fen,$game) $::comp::openline([expr {int( rand()*$_Data(maxopen) )}])
+                set _Data(board,$game) [::comp::FENtoBoard $_Data(fen,$game)]
+            }
+            "bin" {
+                set _Data(moves,$game) [::comp::readBookLine $game]
+                ::comp::makeBookLine $game
+            }
+        }
+    }
+    set tomove [expr { ([llength $_Data(moves,$game)] % 2) == 0 ? "white" : "black" } ]
+    set _Data(result,$game) "*"
+    set _Data(repetition,$game) {}
+    set _Data(moves50,$game) 0
+    set _Data(material,$game) {}
+    set _Data(pawns,$game) {}
+    set _Data(name,$game)(nameW) $n
+    set _Data(name,$game)(nameB) $m
+    set _Data(round,$game) $k
+    set _Data(mate,$game) 0
+    if { ! [::engineNoWin::initEngine compEnginewhite$game $n \
+                [list ::comp::eng_messages compEnginewhite$game nop]] ||
+         ! [::engineNoWin::initEngine compEngineblack$game $m \
+                [list ::comp::eng_messages compEngineblack$game nop]] } {
+        ::engineNoWin::closeEngine compEnginewhite$game
+        ::engineNoWin::closeEngine compEngineblack$game
+        return
+    }
+    set _Data(playing,$game) 1
+    after 500 "::comp::compNextMove $game $tomove 0 \"\""
+}
+
+proc ::comp::compUpdateboard {board move} {
+    set from [::board::sq [string range $move 0 1]]
+    set to [::board::sq [string range $move 2 3]]
+    set p [string index $board $from]
+#todo sollte nicht vorkommen
+    if { ! ($p in {K Q R B N P k q r b n p} ) || $from == $to } {
+        puts "wrong piece or wrong move: Piece:\($p\) Move $move $from $to $board"
+        return [list 0 $board]
+    }
+    if {$p eq "P" && $to > 55 } {
+        set p [string toupper [string index $move 4]]
+        if { $p eq "" } { set p "Q" }
+    } elseif {$p eq "p" && $to < 8  } {
+        set p [string index $move 4]
+        if { $p eq "" } { set p "q" }
+    }
+#Rochaden
+    if {[string index $board $from] == "K" } {
+        if { $from == 4 && $to == 6 } {
+            set board [string replace $board 7 7 "."]
+            set board [string replace $board 5 5 "R"]
+        } elseif { $from == 4 && $to == 2 } {
+            set board [string replace $board 0 0 "."]
+            set board [string replace $board 3 3 "R"]
+        }
+    } elseif {[string index $board $from] == "k" } {
+        if { $from == 60 && $to == 62 } {
+            set board [string replace $board 63 63 "."]
+            set board [string replace $board 61 61 "r"]
+        } elseif { $from == 60 && $to == 58 } {
+            set board [string replace $board 56 56 "."]
+            set board [string replace $board 59 59 "r"]
+        }
+    }
+#Todo enpassant
+    set board [string replace $board $to $to $p]
+    set board [string replace $board $from $from "."]
+    return [list 1 $board]
+}
+
+proc ::comp::compCheckMove { game tomove expired bestmove } {
+    global ::comp::_Data
+
+    set comment ""
+    set result 0
+#potentiel prolemeatisch Halogen blockiert alles, u.u. auch den Desktop! kovisto oder Smarthink blockieren
+    if { $bestmove eq "Time out"} {
+        lappend _Data(comments,$game) "Time out: $tomove move $bestmove ismate $_Data(mate,$game) score $_Data(score,$game)"
+    } elseif { ! [regexp {[a-h][1-8][a-h][1-8]} $bestmove] } {
+        set _Data(result,$game) [ expr { $_Data(score,$game) > 0 ? 1 : 0}]
+        if { [expr { abs($_Data(score,$game))} ] < 1 } { set _Data(result,$game) = }
+        lappend _Data(comments,$game) "Game ends: $tomove Move $bestmove ismate $_Data(mate,$game) Score $_Data(score,$game)"
+    } elseif { $_Data(mate,$game) } {
+        ### checkmate
+        set len [llength $_Data(matemoves,$game)]
+        lappend _Data(moves,$game) $_Data(matemoves,$game)
+        set _Data(result,$game) [expr { $len == 1  ? 1 : 0}]
+        if { $tomove == "black" } { set _Data(result,$game) [expr { 1 - $_Data(result,$game) }] }
+        lappend _Data(comments,$game) "Mate detected: $tomove Move $bestmove Moves to Mate: $_Data(matemoves,$game)"
+    } else {
+        lassign [::comp::compUpdateboard $_Data(board,$game) $bestmove] moveOk _Data(board,$game)
+        if { $moveOk } {
+            set result 1
+            lassign [::comp::checkRepetition $_Data(repetition,$game) $_Data(board,$game)] isRepetition _Data(repetition,$game)
+            lassign [::comp::checkfiftyMoveRule $_Data(moves50,$game) $_Data(material,$game) $_Data(pawns,$game) $_Data(board,$game)] \
+                isFifty _Data(moves50,$game) _Data(material,$game) _Data(pawns,$game)
+            if {$_Data(showscores) && $_Data(scoreIsNew,$game) } {
+                append comment "\[%eval $_Data(score,$game)\]"
+            }
+            if { $isRepetition || $isFifty } {
+                if { $isFifty } {
+                    set text [expr { $isFifty > 1 ? "50-moves rule" : "Material"}]
+                } else {
+                    set text "3-fold repetion"
+                }
+                append comment $text
+                set _Data(result,$game) "="
+                set result 0
+            }
+            if {$_Data(timecontrol) == "pergame"} {
+                set _Data($tomove,$game) [expr $_Data($tomove,$game) - $expired]
+                if { $_Data(showBoards) || $_Data(showtimes) == 1 } {
+                    set clkC [expr { $tomove == "white" ? "clockW" : "clockB" }]
+                    set sec [expr $_Data($tomove,$game) / 1000 ]
+                    set m [format "%d" [expr ($sec / 60) % 60] ]
+                    set s [format "%02d" [expr $sec % 60] ]
+                    if { $_Data(showBoards) } {
+                        set _Data(name,$game)($clkC) "$m:$s,[string range [expr $_Data($tomove,$game) % 1000 ] 0 1]"
+                    }
+                    if {$_Data(showtimes) == 1} {
+                        set h [format "%02d" [expr abs($sec) / 60 / 60] ]
+                        append comment "\[%clk $h:$m:$s\]$comment"
+                    }
+                } elseif {$_Data(showtimes) == 2} {
+                    set sec [expr $expired / 1000.0 ]
+                    append comment "\[%emt $sec\]"
+                }
+                incr _Data($tomove,$game) $_Data(incr50)
+            }
+            lappend _Data(comments,$game) $comment
+            lappend _Data(moves,$game) $bestmove
+        } elseif { $bestmove ne "a1a1" } {
+            #only debuginfo; but some engines send a1a1 for resign / end of game
+            lappend _Data(comments,$game) "Wrong Move or wrong Piece: $tomove $bestmove\n$_Data(board,$game)"
+            foreach i [array names ::comp::_Data] {
+                if { [string first ",$game" $i] > 0} {
+                    puts "::comp::_Data($i) [list $::comp::_Data($i)]"
+                }
+            }
+        }
+    }
+    return $result
+}
+
+proc ::comp::compNextMove { game tomove expired bestmove } {
+    global ::comp::_Data
+    if { $_Data(playing,$game) && $bestmove ne "" } {
+        set _Data(playing,$game) [compCheckMove $game $tomove $expired $bestmove]
+        set tomove [expr {$tomove eq "white" ? "black" : "white"}]
+        if { $_Data(showBoards) && $_Data(playing,$game) } {
+            ::board::update .comp.bds.g$game "$_Data(board,$game) $tomove" 0
+            set square1 [ ::board::sq [string range $bestmove 0 1 ] ]
+            set square2 [ ::board::sq [string range $bestmove 2 3 ] ]
+            if {$square1 ne $square2} { ::board::mark::DrawArrow .comp.bds.g$game.bd $square1 $square2 $::highlightLastMoveColor }
+            if {$_Data(scoreIsNew,$game) } { ::board::updateEvalBar .comp.bds.g$game $_Data(score,$game) }
+        }
+        while {$_Data(paused)} {
+            vwait ::comp::_Data(paused)
+        }
+    }
+    if { $_Data(playing,$game) } {
+        set bestmove ""
+        set _Data(scoreIsNew,$game) 0
+        # Automatically time-out comp in $movetime + 4 secs
+        set timeout [expr {$_Data(timecontrol) == "permove" ? $_Data(time) : $_Data($tomove,$game)}]
+        after [expr {$timeout + $_Data(delta)}] "compTimeout $game $tomove"
+        if {$_Data(timecontrol) == "pergame"} {
+            set parameter "wtime $_Data(white,$game) btime $_Data(black,$game) winc $_Data(incr50) binc $_Data(incr50)"
+        } elseif {$_Data(timecontrol) == "permove"} {
+            set parameter "movetime $_Data(time)"
+        } elseif {$_Data(timecontrol) == "depth"} {
+            set parameter "depth $_Data(fixeddepth)"
+        }
+        set _Data(lasttime,$game) [clock clicks -milli]
+        if { $_Data(fen,$game) eq "startpos"} {
+            set position "position startpos"
+        } else {
+            set position "position fen $_Data(fen,$game)"
+        }
+        if { $_Data(moves,$game) ne "" } { append position " moves $_Data(moves,$game)" }
+        ::engine::send compEngine$tomove$game Go [list $position $parameter]
+    } else {
+        ::comp::compSaveGame $game 
+puts "End $game [set _Data(name,$game)(nameW)] - [set ::comp:::_Data(name,$game)(nameB)] result: $_Data(result,$game)"
+        after 1000 "::comp::compOkEnd $game"
+    }
+}
+
+proc ::comp::adjucateGame {game result} {
+    global ::comp::_Data
+    set _Data(playing,$game) 0
+    set _Data(result,$game) $result
+    lappend _Data(comments,$game) "Game judged by user"
+}
+
+proc ::comp::compSaveGame {game} {
+    global ::comp::_Data ::comp::cSGLock
+
+    set oldCurrent $_Data(database)
+    if { $_Data(database) ne $::curr_db } {
+        set oldCurrent $::curr_db
+        sc_base switch $_Data(database)
+    }
+    while { $cSGLock } {
+        puts "wait for save"
+        vwait ::comp::cSGLock
+    }
+    set cSGLock 1
+    sc_game push
+    sc_game new
+    sc_game tags set -white [set _Data(name,$game)(nameW)]
+    sc_game tags set -black [set _Data(name,$game)(nameB)]
+    sc_game tags set -event $_Data(tournament)
+    sc_game tags set -site $_Data(site)
+    set total [expr int($_Data(base))]
+    set mins [expr $total/60]
+    set secs [expr $total%60]
+    if {$secs == 0} {
+        set timecontrol $mins
+    } else {
+        if {$secs < 10} { set secs "0$secs" }
+        set timecontrol $mins:$secs
+    }
+    set lextra [list "Time \"[clock format [clock seconds] -format %T]\"\n"]
+    lappend lextra [expr {$_Data(timecontrol) == "permove" ? "Movetime \"$_Data(seconds)\"" : "TimeControl \"$timecontrol/$_Data(incr)\""}]
+    sc_game tags set -date [::utils::date::today] -round $_Data(round,$game) -extra $lextra
+
+    if { $_Data(fen,$game) ne "startpos"} {
+        sc_game startBoard $_Data(fen,$game)
+    }
+    foreach m $_Data(moves,$game) c $_Data(comments,$game) {
+        catch { sc_move addSan $m }
+        if { $c ne "" } { sc_pos setComment $c }
+    }
+    sc_game tags set -result $_Data(result,$game)
+    if {[sc_pos moves] == {}} {
+        if {![sc_pos isCheck]} {
+            ### stalemate
+            set res =
+            sc_pos setComment [tr stalemate]
+        } else {
+            ### checkmate
+            set res [expr {[sc_pos side] == {black} ? 1 : 0}]
+        }
+        if { $_Data(result,$game) ne $res } {sc_pos setComment "[sc_pos getComment] override result $_Data(result,$game) -> $res"}
+        sc_game tags set -result $res
+        set _Data(result,$game) $res
+    } elseif { $_Data(mate,$game) } {
+        #Mate detected but pv does not go to mate
+        set _Data(result,$game) [expr { 1 - $_Data(result,$game) }]
+        sc_pos setComment "[sc_pos getComment] mate not finished result $_Data(result,$game)"
+        sc_game tags set -result $_Data(result,$game)
+    }
+    ### This game is over; Save game
+    if {![sc_base isReadOnly $_Data(database)] && ( $_Data(result,$game) != "*" || $_Data(savebrokengame) || !$_Data(replaybrokengame) )} {
+        sc_game save [sc_game number]
+    }
+    sc_game pop
+    if { $oldCurrent ne $::curr_db } { sc_base switch $oldCurrent }
+    set cSGLock 0
+    ::windows::gamelist::Refresh
+    if {[winfo exists $::crosstab::win]} { ::crosstab::Refresh }
+}
+
+proc compPause {} {
+  global ::comp::_Data engines
+  set w .comp
+  $w.buttons.ok configure -text [tr Continue] -command compResume
+  set _Data(paused) 1
+}
+
+proc compResume {} {
+  global ::comp::_Data engines
+  set w .comp
+
+  $w.buttons.ok configure -text "  Pause  " -command compPause
+  set _Data(paused) 0
+}
+
+#list of all UCI engines
+proc ::comp::getEngList {} {
+  set allEngList [::enginecfg::names ]
+  set engList {}
+  foreach name $allEngList {
+      if { [lindex [::enginecfg::get $name] 7] } {
+          lappend engList $name
+      }
+  }
+  return [list [llength $engList] $engList]
+}
+
+
+proc compTimeout {game tomove} {
+    global ::comp::_Data
+
+    puts "Timed out Game $game"
+    set expired [expr [clock clicks -milli] - $_Data(lasttime,$game)]
+    ::comp::compNextMove $game $tomove 0 "Time out"
+}
+
+proc compAbort {} {
+    # Close all games, called when game is active
+    global ::comp::_Data
+
+    if {$_Data(paused)} { compResume }
+    set i $_Data(processes)
+    while { $i > 0 } {
+        set _Data(playing,$i) 0
+        incr i -1
+    }
+    set _Data(games) {}
+    set _Data(endaftergame) 1
+}
+
+proc compClose {} {
+    global ::comp::_Data
+    if {[.comp.buttons.cancel cget -text] == {End Comp}} {
+        # comp is running. Double check before exitting
+        set msg {A Computer Tournament is running.}
+        
+        set answer [tk_dialog .unsaved "Scid: Confirm Quit" $msg question {} "   [tr FileExit]   " [tr Cancel]]
+        if {$answer != 0} {
+            return
+        }
+    }
+    compDestroy
+}
+
+proc compDestroy {} {
+    global ::comp::_Data
+
+    set _Data(games) {}
+    set _Data(playing,1) 0
+    set _Data(playing,2) 0
+    update idletasks
+    destroy .comp
+}
+
+proc compSave {} {
+    global ::comp::_Data
+    global scidConfigDir
+
+    set filename ""
+    set types { {{Scid Tournament Files} {.sto}} }
+    set filename [tk_getSaveFile -initialdir $scidConfigDir -initialfile $_Data(tournament) -filetypes  $types -defaultextension ".sto"]
+    if {$filename != ""} {
+        doCompSave $filename
+    }
+}
+proc autocompSave {} {
+    global ::comp::_Data
+    global scidConfigDir
+
+    set tname [string map { " " "" } $_Data(tournament)]
+    append tname "_autosave.sto"
+    set filename [file join $scidConfigDir $tname]
+    doCompSave $filename
+}
+
+proc doCompSave { filename } {
+    global ::comp::_Data
+    if { [catch {open $filename w} stofile]} {
+        tk_messageBox -title "Scid: Save Tournament" -type ok -icon warning -message "Unable to write tournament file:\n$filename"
+    } else {
+        puts $stofile "# Scid comptournament file"
+        puts $stofile ""
+        foreach i [array names ::comp::_Data] {
+            if { [string first "," $i] < 0 } {
+                puts $stofile "set ::comp::_Data($i) [list $::comp::_Data($i)]"
+            }
+        }
+        close $stofile
+    } 
+}
+
+proc ::comp::eng_messages {id w msg} {
+    global ::comp::_Data ::comp::options comp
+    lassign $msg msgType msgData
+    set game [string index $id end]
+    set tomove [string range $id end-5 end-1]
+    switch $msgType {
+        "InfoConfig" {
+            if { ! [winfo exists $w] } { return }
+            set msgData [lindex $msgData 2]
+            ::engineNoWin::initEngineOptions $id $w $msgData
+        }
+        "InfoPV" {
+            lassign $msgData multipv depth seldepth nodes nps hashfull tbhits time score score_type score_wdl pv
+            if { $multipv == 1 && $score ne "" } {
+                if { $score_type eq "mate" } {
+                    set _Data(score,$game) [expr { $score > 0 ? 128 : -128 }]
+                    if { [expr abs($score) ] < 2 } {
+                        set _Data(mate,$game) 1
+                        set _Data(matemoves,$game) $pv
+                    }
+                } else {
+                    set _Data(score,$game) [expr $score / 100.0]
+                    set _Data(scoreIsNew,$game) 1
+                    set _Data(mate,$game) 0
+                }
+                if {$tomove == "black"} { set _Data(score,$game) [expr 0.0 - $_Data(score,$game)] }
+            }
+        }
+        "InfoBestMove" {
+            set expired [expr [clock clicks -milli] - $_Data(lasttime,$game)]
+            after cancel "compTimeout $game $tomove"
+            lassign $msgData bestmove
+            ::comp::compNextMove $game $tomove $expired $bestmove
+        }
+        "InfoDisconnected" {
+            lassign $msgData errorMsg
+            if {$errorMsg eq ""} { set errorMsg "The connection with the engine terminated unexpectedly." }
+            set _Data(bestmove,$game) $errorMsg
+        }
+    }
+}
+
+################################################################################
+# add current position for 3fold _Data(repetition,$game) detection and returns 1 if
+# the position is a _Data(repetition,$game)
+################################################################################
+proc ::comp::checkRepetition { journal board } {
+    set isRep 0
+    # append the position only if different from the last element
+    if { $board != [ lindex $journal end ] } { lappend journal $board }
+    # 3fold repetion detected
+    if { [llength [lsearch -all $journal $board] ] >=3 } { set isRep 1 }
+    return [list $isRep $journal]
+}
+
+proc ::comp::checkfiftyMoveRule { moves prevmaterial prevpawns board} {
+    set isFiftyRule 0
+    incr moves
+    set material [string length [string map {"." ""} $board]]
+    set pawns [string map {"n" "." "b" "." "r" "." "q" "." "k" "." "N" "." "B" "." "R" "." "Q" "." "K" "." } $board]
+    if { $pawns ne $prevpawns || $material ne $prevmaterial } { set moves 0 }
+    if { $moves >= 100  } { set isFiftyRule 2 }
+    if { $material == 2 } { set isFiftyRule 1 }
+    return [list $isFiftyRule $moves $material $pawns]
+}
+###
+### End of file: multicomp.tcl
+

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -879,7 +879,8 @@ proc ::comp::compCheckMove { game tomove expired bestmove } {
         lassign [::comp::compUpdateboard $_Data(board,$game) $bestmove] moveOk _Data(board,$game)
         if { $moveOk } {
             set result 1
-            lassign [::comp::checkRepetition $_Data(repetition,$game) $_Data(board,$game)] isRepetition _Data(repetition,$game)
+            set sideToMove [expr {$tomove eq "white" ? "b" : "w"}]
+            lassign [::comp::checkRepetition $_Data(repetition,$game) "$_Data(board,$game) $sideToMove"] isRepetition _Data(repetition,$game)
             lassign [::comp::checkfiftyMoveRule $_Data(moves50,$game) $_Data(material,$game) $_Data(pawns,$game) $_Data(board,$game)] \
                 isFifty _Data(moves50,$game) _Data(material,$game) _Data(pawns,$game)
             if {$_Data(showscores) && $_Data(scoreIsNew,$game) } {
@@ -1082,9 +1083,9 @@ proc compTimeout {game tomove} {
     global ::comp::_Data
 
     puts "Timed out Game $game"
-    puts "Timed out Game $game"
-    set expired [expr {[clock clicks -milli] - $_Data(lasttime,$game)}]
-    ::comp::compNextMove $game $tomove $expired "Time out"
+    set expired [expr [clock clicks -milli] - $_Data(lasttime,$game)]
+    ::comp::compNextMove $game $tomove 0 "Time out"
+}
 
 proc compAbort {} {
     # Close all games, called when game is active

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -863,12 +863,18 @@ proc ::comp::compCheckMove { game tomove expired bestmove } {
         if { [expr { abs($_Data(score,$game))} ] < 1 } { set _Data(result,$game) = }
         lappend _Data(comments,$game) "Game ends: $tomove Move $bestmove ismate $_Data(mate,$game) Score $_Data(score,$game)"
     } elseif { $_Data(mate,$game) } {
-        ### checkmate
-        set len [llength $_Data(matemoves,$game)]
-        lappend _Data(moves,$game) $_Data(matemoves,$game)
-        set _Data(result,$game) [expr { $len == 1  ? 1 : 0}]
-        if { $tomove == "black" } { set _Data(result,$game) [expr { 1 - $_Data(result,$game) }] }
-        lappend _Data(comments,$game) "Mate detected: $tomove Move $bestmove Moves to Mate: $_Data(matemoves,$game)"
+        # Mate score means the side to move has a forced win.
+        set _Data(result,$game) [expr {$tomove eq "white" ? 1 : 0}]
+        set mateMoves $_Data(matemoves,$game)
+        foreach mv $mateMoves {
+            lappend _Data(moves,$game) $mv
+            lappend _Data(comments,$game) ""
+        }
+        if {[llength $mateMoves] > 0} {
+            set _Data(comments,$game) [lreplace $_Data(comments,$game) end end "Mate detected: $tomove PV: $mateMoves"]
+        } else {
+            lappend _Data(comments,$game) "Mate detected: $tomove"
+        }
     } else {
         lassign [::comp::compUpdateboard $_Data(board,$game) $bestmove] moveOk _Data(board,$game)
         if { $moveOk } {

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -1075,9 +1075,9 @@ proc compTimeout {game tomove} {
     global ::comp::_Data
 
     puts "Timed out Game $game"
-    set expired [expr [clock clicks -milli] - $_Data(lasttime,$game)]
-    ::comp::compNextMove $game $tomove 0 "Time out"
-}
+    puts "Timed out Game $game"
+    set expired [expr {[clock clicks -milli] - $_Data(lasttime,$game)}]
+    ::comp::compNextMove $game $tomove $expired "Time out"
 
 proc compAbort {} {
     # Close all games, called when game is active

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -567,7 +567,7 @@ puts "$num_games GAMES total: $_Data(games)"
 
   set _Data(database) $::curr_db
   if {[sc_base isReadOnly $_Data(database)]} {
-    set answer [tk_messageBox -title Tournanment -icon question -type okcancel \
+    set answer [tk_messageBox -title Tournament -icon question -type okcancel \
 	-message {Database is read only. Continue ?} -parent $w]
     if {$answer != "ok"} {return}
   }

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -206,7 +206,7 @@ proc compInit { } {
   }
   win::createDialog $w
   wm state $w withdrawn
-  wm title $w [tr configComp]
+  wm title $w "scidCommunity [tr Engine] [tr Tournament]"
   setWinLocation $w
 
   grid [ttk::labelframe $w.engines -text [tr ToolsConfigureEngines]] -row 0 -column 0 -rowspan 3 -sticky nswe -padx "0 10"
@@ -405,7 +405,7 @@ proc compInit { } {
 
   bind $w <Configure> "recordWinSize $w"
   wm protocol $w WM_DELETE_WINDOW compClose
-  wm resizable $w 0 0
+  wm resizable $w 1 1
   bind $w <Escape> compClose
   bind $w <F1> {helpWindow Tourney}
   update
@@ -584,7 +584,7 @@ puts "$num_games GAMES total: $_Data(games)"
   $w.buttons.save configure -text [tr compStop] -command "toggleEndAfterGame" -state normal
   pack forget $w.buttons.load
   $w.buttons.cancel configure -text [tr Cancel] -command { compAbort } -state normal
-  wm title $w "Scid [tr Engine] [tr Tournament]"
+  wm title $w "scidCommunity [tr Engine] [tr Tournament]"
   focus $w.buttons.ok
 
   ttk::progressbar $w.progress -mode determinate -maximum $num_games -variable ::comp::_Data(current)

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -572,7 +572,7 @@ puts "$num_games GAMES total: $_Data(games)"
     if {$answer != "ok"} {return}
   }
   if {![sc_pos isAt end] && $_Data(start) > 0} {
-    set answer [tk_messageBox -title Tournanment -icon question -type okcancel \
+    set answer [tk_messageBox -title Tournament -icon question -type okcancel \
 	-message {Die aktuelle Partie ist nicht am Ende der Partie. Fortfahren?} -parent $w]
     if {$answer != "ok"} {return}
   }

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -856,6 +856,7 @@ proc ::comp::compCheckMove { game tomove expired bestmove } {
     set result 0
 #potentiel prolemeatisch Halogen blockiert alles, u.u. auch den Desktop! kovisto oder Smarthink blockieren
     if { $bestmove eq "Time out"} {
+        set _Data(result,$game) [expr {$tomove eq "white" ? 0 : 1}]
         lappend _Data(comments,$game) "Time out: $tomove move $bestmove ismate $_Data(mate,$game) score $_Data(score,$game)"
     } elseif { ! [regexp {[a-h][1-8][a-h][1-8]} $bestmove] } {
         set _Data(result,$game) [ expr { $_Data(score,$game) > 0 ? 1 : 0}]

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -962,7 +962,7 @@ proc ::comp::compNextMove { game tomove expired bestmove } {
         ::engine::send compEngine$tomove$game Go [list $position $parameter]
     } else {
         ::comp::compSaveGame $game 
-puts "End $game [set _Data(name,$game)(nameW)] - [set ::comp:::_Data(name,$game)(nameB)] result: $_Data(result,$game)"
+puts "End $game [set _Data(name,$game)(nameW)] - [set _Data(name,$game)(nameB)] result: $_Data(result,$game)"
         after 1000 "::comp::compOkEnd $game"
     }
 }


### PR DESCRIPTION
This feature was developed by Uwe at https://codeberg.org/scid/scid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multithreaded computer tournament mode with engine management, concurrent games, opening-book support, configurable time controls, and save/load/autosave for tournament settings
  * Added a "Play Tournament" menu item and keyboard shortcuts
  * Added an engine-management UI option that runs engines without separate engine windows

* **Bug Fixes**
  * More tolerant parsing of position strings (better handling of optional moves and default start positions)

* **Translations**
  * Expanded tournament-related UI translations across many languages (placeholders for missing translations)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->