### PR TITLE
Add reverse openings and draw and resign rules to engine tournaments

### DIFF
--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -1465,6 +1465,13 @@ translate J compRunning {Турнир је у току}
 translate J Restart {Поново покрени}
 translate J compFinished {Турнир је завршен}
 translate J compStopped {Турнир је заустављен}
+translate J compForceDraw {Форце Драв}
+translate J compForceResign {Форце Ресигн}
+translate J compAfterMove {После селидбе:}
+translate J compNumMoves {Број потеза:}
+translate J compScoreLess {Резултат <:}
+translate J compScoreGreater {Резултат >:}
+translate J compRepeatReverse {Поновите обрнуто}
 
 #Coach
 translate J showblunderexists {показати да грешка постоји}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -1424,6 +1424,13 @@ translate b compRunning {টুর্নামেন্ট চলছে}
 translate b Restart {রিস্টার্ট করুন}
 translate b compFinished {টুর্নামেন্ট শেষ}
 translate b compStopped {টুর্নামেন্ট বন্ধ}
+translate b compForceDraw {ফোর্স ড্র}
+translate b compForceResign {জোর করে পদত্যাগ করুন}
+translate b compAfterMove {সরানোর পরে:}
+translate b compNumMoves {নম মুভ:}
+translate b compScoreLess {স্কোর <:}
+translate b compScoreGreater {স্কোর >:}
+translate b compRepeatReverse {বিপরীত পুনরাবৃত্তি}
 
 #Coach
 translate b showblunderexists {শো ভুল বিদ্যমান}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -1465,6 +1465,13 @@ translate g compRunning {Турнирът е в ход}
 translate g Restart {Рестартирайте}
 translate g compFinished {Турнирът приключи}
 translate g compStopped {Турнирът спря}
+translate g compForceDraw {Force Draw}
+translate g compForceResign {Принуди оставката}
+translate g compAfterMove {След преместване:}
+translate g compNumMoves {Брой ходове:}
+translate g compScoreLess {Резултат <:}
+translate g compScoreGreater {Резултат >:}
+translate g compRepeatReverse {Повторете обратно}
 
 #Coach
 translate g showblunderexists {покажете, че гафът съществува}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -1465,7 +1465,7 @@ translate g compRunning {Турнирът е в ход}
 translate g Restart {Рестартирайте}
 translate g compFinished {Турнирът приключи}
 translate g compStopped {Турнирът спря}
-translate g compForceDraw {Force Draw}
+translate g compForceDraw {Принудително равенство}
 translate g compForceResign {Принуди оставката}
 translate g compAfterMove {След преместване:}
 translate g compNumMoves {Брой ходове:}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -1468,13 +1468,13 @@ translate K compRunning {Torneig en curs}
 translate K Restart {Reinicieu}
 translate K compFinished {Torneig acabat}
 translate K compStopped {Torneig aturat}
-translate K compForceDraw {Sorteig de força}
-translate K compForceResign {Força la dimissió}
+translate K compForceDraw {Forçar empat}
+translate K compForceResign {Forçar la rendició}
 translate K compAfterMove {Després del moviment:}
-translate K compNumMoves {Núm. moviments:}
-translate K compScoreLess {Puntuació <:}
-translate K compScoreGreater {Puntuació >:}
-translate K compRepeatReverse {Repetiu el revés}
+translate K compNumMoves {Núm. de moviments:}
+translate K compScoreLess {Puntuació inferior a:}
+translate K compScoreGreater {Puntuació superior a:}
+translate K compRepeatReverse {Repetir en sentit invers}
 
 #Coach
 translate K showblunderexists {Mostrar ficada de pota}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -1468,6 +1468,13 @@ translate K compRunning {Torneig en curs}
 translate K Restart {Reinicieu}
 translate K compFinished {Torneig acabat}
 translate K compStopped {Torneig aturat}
+translate K compForceDraw {Sorteig de força}
+translate K compForceResign {Força la dimissió}
+translate K compAfterMove {Després del moviment:}
+translate K compNumMoves {Núm. moviments:}
+translate K compScoreLess {Puntuació <:}
+translate K compScoreGreater {Puntuació >:}
+translate K compRepeatReverse {Repetiu el revés}
 
 #Coach
 translate K showblunderexists {Mostrar ficada de pota}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1400,7 +1400,7 @@ translate M compRunning {比赛进行中}
 translate M Restart {重新启动}
 translate M compFinished {比赛结束}
 translate M compStopped {比赛停止}
-translate M compForceDraw {力牵引}
+translate M compForceDraw {强制和棋}
 translate M compForceResign {强制辞职}
 translate M compAfterMove {移动后：}
 translate M compNumMoves {移动次数：}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1400,6 +1400,13 @@ translate M compRunning {比赛进行中}
 translate M Restart {重新启动}
 translate M compFinished {比赛结束}
 translate M compStopped {比赛停止}
+translate M compForceDraw {力牵引}
+translate M compForceResign {强制辞职}
+translate M compAfterMove {移动后：}
+translate M compNumMoves {移动次数：}
+translate M compScoreLess {分数 <:}
+translate M compScoreGreater {分数>：}
+translate M compRepeatReverse {重复反向}
 
 #Coach
 translate M showblunderexists {显示存在错误}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -1446,7 +1446,7 @@ translate C compRunning {Turnaj probíhá}
 translate C Restart {Restartujte}
 translate C compFinished {Turnaj ukončen}
 translate C compStopped {Turnaj zastaven}
-translate C compForceDraw {Force Draw}
+translate C compForceDraw {Vynutit remízu}
 translate C compForceResign {Vynutit si rezignaci}
 translate C compAfterMove {Po přesunu:}
 translate C compNumMoves {Počet pohybů:}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -1446,6 +1446,13 @@ translate C compRunning {Turnaj probíhá}
 translate C Restart {Restartujte}
 translate C compFinished {Turnaj ukončen}
 translate C compStopped {Turnaj zastaven}
+translate C compForceDraw {Force Draw}
+translate C compForceResign {Vynutit si rezignaci}
+translate C compAfterMove {Po přesunu:}
+translate C compNumMoves {Počet pohybů:}
+translate C compScoreLess {Skóre <:}
+translate C compScoreGreater {Skóre >:}
+translate C compRepeatReverse {Opakujte obráceně}
 
 #Coach
 translate C showblunderexists {ukzat ptomnost hrub chyby}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -1496,6 +1496,13 @@ translate D compRunning {Turnier läuft}
 translate D Restart {Neustart}
 translate D compFinished {Turnier beendet}
 translate D compStopped {Das Turnier wurde gestoppt}
+translate D compForceDraw {Force Draw}
+translate D compForceResign {Rücktritt erzwingen}
+translate D compAfterMove {Nach dem Umzug:}
+translate D compNumMoves {Anzahl Züge:}
+translate D compScoreLess {Ergebnis <:}
+translate D compScoreGreater {Ergebnis >:}
+translate D compRepeatReverse {Wiederholen Sie den Vorgang umgekehrt}
 
 #Coach
 translate D showblunderexists {Enginefehler anzeigen}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -1478,6 +1478,13 @@ translate E compRunning {Tournament in progress}
 translate E Restart {Restart}
 translate E compFinished {Tournament finished}
 translate E compStopped {Tournament stopped}
+translate E compForceDraw {Force Draw}
+translate E compForceResign {Force Resign}
+translate E compAfterMove {After move:}
+translate E compNumMoves {Num Moves:}
+translate E compScoreLess {Score <:}
+translate E compScoreGreater {Score >:}
+translate E compRepeatReverse {Repeat reverse}
 
 #Coach
 translate E showblunderexists {show blunder exists}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -1452,13 +1452,13 @@ translate F compRunning {Tournoi en cours}
 translate F Restart {Redémarrage}
 translate F compFinished {Tournoi terminé}
 translate F compStopped {Tournoi arrêté}
-translate F compForceDraw {Forcer le tirage}
-translate F compForceResign {Forcer la démission}
-translate F compAfterMove {Après le déménagement :}
-translate F compNumMoves {Nombre de mouvements :}
+translate F compForceDraw {Forcer la nulle}
+translate F compForceResign {Forcer l'abandon}
+translate F compAfterMove {Après le coup :}
+translate F compNumMoves {Nombre de coups :}
 translate F compScoreLess {Score < :}
-translate F compScoreGreater {Note > :}
-translate F compRepeatReverse {Répéter l'inverse}
+translate F compScoreGreater {Score > :}
+translate F compRepeatReverse {Répéter en sens inverse}
 
 #Coach
 translate F showblunderexists {Montrer si erreur}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -1452,6 +1452,13 @@ translate F compRunning {Tournoi en cours}
 translate F Restart {Redémarrage}
 translate F compFinished {Tournoi terminé}
 translate F compStopped {Tournoi arrêté}
+translate F compForceDraw {Forcer le tirage}
+translate F compForceResign {Forcer la démission}
+translate F compAfterMove {Après le déménagement :}
+translate F compNumMoves {Nombre de mouvements :}
+translate F compScoreLess {Score < :}
+translate F compScoreGreater {Note > :}
+translate F compRepeatReverse {Répéter l'inverse}
 
 #Coach
 translate F showblunderexists {Montrer si erreur}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -1473,6 +1473,13 @@ translate G compRunning {Τουρνουά σε εξέλιξη}
 translate G Restart {Επανεκκίνηση}
 translate G compFinished {Το τουρνουά ολοκληρώθηκε}
 translate G compStopped {Το τουρνουά σταμάτησε}
+translate G compForceDraw {Force Draw}
+translate G compForceResign {Αναγκαστική παραίτηση}
+translate G compAfterMove {Μετά τη μετακίνηση:}
+translate G compNumMoves {Αριθμός κινήσεων:}
+translate G compScoreLess {Βαθμολογία <:}
+translate G compScoreGreater {Βαθμολογία >:}
+translate G compRepeatReverse {Επαναλάβετε αντίστροφα}
 
 #Coach
 translate G showblunderexists {εμφάνιση ότι το σφάλμα υπάρχει}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -1425,6 +1425,13 @@ translate V compRunning {הטורניר בעיצומו}
 translate V Restart {הפעל מחדש}
 translate V compFinished {הטורניר הסתיים}
 translate V compStopped {הטורניר הופסק}
+translate V compForceDraw {כוח ציור}
+translate V compForceResign {להכריח להתפטר}
+translate V compAfterMove {לאחר המעבר:}
+translate V compNumMoves {מספר מהלכים:}
+translate V compScoreLess {ציון <:}
+translate V compScoreGreater {ציון >:}
+translate V compRepeatReverse {חזור הפוך}
 
 #Coach
 translate V showblunderexists {להראות טעות קיימת}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -1424,6 +1424,13 @@ translate h compRunning {टूर्नामेंट चल रहा है}
 translate h Restart {पुनः आरंभ करें}
 translate h compFinished {टूर्नामेंट ख़त्म}
 translate h compStopped {टूर्नामेंट रुक गया}
+translate h compForceDraw {बलपूर्वक ड्रा}
+translate h compForceResign {जबरन इस्तीफा दें}
+translate h compAfterMove {चाल के बाद:}
+translate h compNumMoves {संख्या चालें:}
+translate h compScoreLess {स्कोर <:}
+translate h compScoreGreater {स्कोर >:}
+translate h compRepeatReverse {उलटा दोहराएँ}
 
 #Coach
 translate h showblunderexists {दिखाएँ भूल मौजूद है}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -1447,6 +1447,13 @@ translate H compRunning {A torna folyamatban}
 translate H Restart {Indítsa újra}
 translate H compFinished {A bajnokság befejeződött}
 translate H compStopped {A bajnokság leállt}
+translate H compForceDraw {Force Draw}
+translate H compForceResign {Lemondás kényszerítése}
+translate H compAfterMove {Költözés után:}
+translate H compNumMoves {Mozdulatok száma:}
+translate H compScoreLess {Pontszám <:}
+translate H compScoreGreater {Pontszám >:}
+translate H compRepeatReverse {Ismételje meg fordítva}
 
 #Coach
 translate H showblunderexists {Jelezd a durva hibát}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -1447,7 +1447,7 @@ translate H compRunning {A torna folyamatban}
 translate H Restart {Indítsa újra}
 translate H compFinished {A bajnokság befejeződött}
 translate H compStopped {A bajnokság leállt}
-translate H compForceDraw {Force Draw}
+translate H compForceDraw {Döntetlen kényszerítése}
 translate H compForceResign {Lemondás kényszerítése}
 translate H compAfterMove {Költözés után:}
 translate H compNumMoves {Mozdulatok száma:}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -1448,7 +1448,7 @@ translate I compRunning {Torneo in corso}
 translate I Restart {Ricomincia}
 translate I compFinished {Torneo finito}
 translate I compStopped {Torneo interrotto}
-translate I compForceDraw {Tiraggio della forza}
+translate I compForceDraw {Patta forzata}
 translate I compForceResign {Forza le dimissioni}
 translate I compAfterMove {Dopo lo spostamento:}
 translate I compNumMoves {Numero di mosse:}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -1448,6 +1448,13 @@ translate I compRunning {Torneo in corso}
 translate I Restart {Ricomincia}
 translate I compFinished {Torneo finito}
 translate I compStopped {Torneo interrotto}
+translate I compForceDraw {Tiraggio della forza}
+translate I compForceResign {Forza le dimissioni}
+translate I compAfterMove {Dopo lo spostamento:}
+translate I compNumMoves {Numero di mosse:}
+translate I compScoreLess {Punteggio <:}
+translate I compScoreGreater {Punteggio >:}
+translate I compRepeatReverse {Ripeti al contrario}
 
 #Coach
 translate I showblunderexists {mostra gli errori}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -1465,6 +1465,13 @@ translate A compRunning {トーナメント開催中}
 translate A Restart {再起動}
 translate A compFinished {トーナメントが終了しました}
 translate A compStopped {トーナメントは中止されました}
+translate A compForceDraw {フォースドロー}
+translate A compForceResign {強制辞任}
+translate A compAfterMove {移動後:}
+translate A compNumMoves {移動数:}
+translate A compScoreLess {スコア <:}
+translate A compScoreGreater {スコア >:}
+translate A compRepeatReverse {逆を繰り返す}
 
 #Coach
 translate A showblunderexists {間違いが存在することを示す}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -1465,6 +1465,13 @@ translate k compRunning {토너먼트 진행 중}
 translate k Restart {다시 시작}
 translate k compFinished {토너먼트 종료}
 translate k compStopped {토너먼트가 중단되었습니다}
+translate k compForceDraw {포스 드로우}
+translate k compForceResign {강제 사임}
+translate k compAfterMove {이동 후:}
+translate k compNumMoves {이동 횟수:}
+translate k compScoreLess {점수 <:}
+translate k compScoreGreater {점수 >:}
+translate k compRepeatReverse {역방향 반복}
 
 #Coach
 translate k showblunderexists {함께가 존재함을 보여라}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -1471,6 +1471,13 @@ translate N compRunning {Toernooi in uitvoering}
 translate N Restart {Opnieuw opstarten}
 translate N compFinished {Toernooi afgelopen}
 translate N compStopped {Toernooi gestopt}
+translate N compForceDraw {Forceer gelijkspel}
+translate N compForceResign {Forceer aftreden}
+translate N compAfterMove {Na verhuizing:}
+translate N compNumMoves {Aantal bewegingen:}
+translate N compScoreLess {Score <:}
+translate N compScoreGreater {Score >:}
+translate N compRepeatReverse {Herhaal omgekeerd}
 
 #Coach
 translate N showblunderexists {toon dat er een blunder is}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -1472,9 +1472,9 @@ translate N Restart {Opnieuw opstarten}
 translate N compFinished {Toernooi afgelopen}
 translate N compStopped {Toernooi gestopt}
 translate N compForceDraw {Forceer gelijkspel}
-translate N compForceResign {Forceer aftreden}
-translate N compAfterMove {Na verhuizing:}
-translate N compNumMoves {Aantal bewegingen:}
+translate N compForceResign {Forceer opgeven}
+translate N compAfterMove {Na zet:}
+translate N compNumMoves {Aantal zetten:}
 translate N compScoreLess {Score <:}
 translate N compScoreGreater {Score >:}
 translate N compRepeatReverse {Herhaal omgekeerd}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -1446,6 +1446,13 @@ translate O compRunning {Turnering pågår}
 translate O Restart {Start på nytt}
 translate O compFinished {Turneringen avsluttet}
 translate O compStopped {Turneringen stoppet}
+translate O compForceDraw {Tving uavgjort}
+translate O compForceResign {Tvinge opp}
+translate O compAfterMove {Etter flytting:}
+translate O compNumMoves {Antall trekk:}
+translate O compScoreLess {Poengsum <:}
+translate O compScoreGreater {Poengsum >:}
+translate O compRepeatReverse {Gjenta omvendt}
 
 #Coach
 translate O showblunderexists {Vis at feil eksisterer}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -1466,6 +1466,13 @@ translate P compRunning {Turniej w toku}
 translate P Restart {Uruchom ponownie}
 translate P compFinished {Turniej zakończony}
 translate P compStopped {Turniej zatrzymany}
+translate P compForceDraw {Wymuś losowanie}
+translate P compForceResign {Wymusić rezygnację}
+translate P compAfterMove {Po ruchu:}
+translate P compNumMoves {Liczba ruchów:}
+translate P compScoreLess {Wynik <:}
+translate P compScoreGreater {Wynik >:}
+translate P compRepeatReverse {Powtórz w odwrotnej kolejności}
 
 #Coach
 translate P showblunderexists {zjawisko, e bd istnieje}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -1454,13 +1454,13 @@ translate B compRunning {Torneio em andamento}
 translate B Restart {Reiniciar}
 translate B compFinished {Torneio terminado}
 translate B compStopped {Torneio interrompido}
-translate B compForceDraw {Forçar sorteio}
-translate B compForceResign {Forçar renúncia}
-translate B compAfterMove {Após a mudança:}
-translate B compNumMoves {Num Movimentos:}
+translate B compForceDraw {Forçar empate}
+translate B compForceResign {Forçar desistência}
+translate B compAfterMove {Após o movimento:}
+translate B compNumMoves {Número de movimentos:}
 translate B compScoreLess {Pontuação <:}
 translate B compScoreGreater {Pontuação >:}
-translate B compRepeatReverse {Repetir reverso}
+translate B compRepeatReverse {Repetir jogada inversa}
 
 #Coach
 translate B showblunderexists {mostra que existe um erro crasso}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -1454,6 +1454,13 @@ translate B compRunning {Torneio em andamento}
 translate B Restart {Reiniciar}
 translate B compFinished {Torneio terminado}
 translate B compStopped {Torneio interrompido}
+translate B compForceDraw {Forçar sorteio}
+translate B compForceResign {Forçar renúncia}
+translate B compAfterMove {Após a mudança:}
+translate B compNumMoves {Num Movimentos:}
+translate B compScoreLess {Pontuação <:}
+translate B compScoreGreater {Pontuação >:}
+translate B compRepeatReverse {Repetir reverso}
 
 #Coach
 translate B showblunderexists {mostra que existe um erro crasso}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -1465,6 +1465,13 @@ translate L compRunning {Turneu în desfășurare}
 translate L Restart {Repornire}
 translate L compFinished {Turneul terminat}
 translate L compStopped {Turneul s-a oprit}
+translate L compForceDraw {Remiză forțată}
+translate L compForceResign {Demisia forțată}
+translate L compAfterMove {După mutare:}
+translate L compNumMoves {Număr mișcări:}
+translate L compScoreLess {Scor <:}
+translate L compScoreGreater {Scor >:}
+translate L compRepeatReverse {Repetați invers}
 
 #Coach
 translate L showblunderexists {arată că gafa există}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -1448,6 +1448,13 @@ translate R compRunning {Турнир в разгаре}
 translate R Restart {Перезапуск}
 translate R compFinished {Турнир завершен}
 translate R compStopped {Турнир остановлен}
+translate R compForceDraw {Принудительная ничья}
+translate R compForceResign {Принудительная отставка}
+translate R compAfterMove {После переезда:}
+translate R compNumMoves {Количество ходов:}
+translate R compScoreLess {Оценка <:}
+translate R compScoreGreater {Оценка >:}
+translate R compRepeatReverse {Повторить в обратном порядке}
 
 #Coach
 translate R showblunderexists {показать существующие ошибки}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -1798,6 +1798,20 @@ translate Y Restart {Restart}
 translate Y compFinished {Tournament finished}
 # ====== TODO To be translated ======
 translate Y compStopped {Tournament stopped}
+# ====== TODO To be translated ======
+translate Y compForceDraw {Force Draw}
+# ====== TODO To be translated ======
+translate Y compForceResign {Force Resign}
+# ====== TODO To be translated ======
+translate Y compAfterMove {After move:}
+# ====== TODO To be translated ======
+translate Y compNumMoves {Num Moves:}
+# ====== TODO To be translated ======
+translate Y compScoreLess {Score <:}
+# ====== TODO To be translated ======
+translate Y compScoreGreater {Score >:}
+# ====== TODO To be translated ======
+translate Y compRepeatReverse {Repeat reverse}
 Enter a list of preferred player names below, one name per line. Wildcards (e.g. "?" for any single character, "*" for any sequence of characters) are permitted.
 
 Every time a game with a player in the list is loaded, the main window chessboard will be rotated if necessary to show the game from that players perspective.

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -1499,9 +1499,9 @@ translate S compRunning {Torneo en curso}
 translate S Restart {Reanudar}
 translate S compFinished {Torneo terminado}
 translate S compStopped {Torneo detenido}
-translate S compForceDraw {Forzar sorteo}
-translate S compForceResign {Forzar la renuncia}
-translate S compAfterMove {Después de la mudanza:}
+translate S compForceDraw {Forzar tablas}
+translate S compForceResign {Forzar abandono}
+translate S compAfterMove {Después del movimiento:}
 translate S compNumMoves {Número de movimientos:}
 translate S compScoreLess {Puntuación <:}
 translate S compScoreGreater {Puntuación >:}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -1499,6 +1499,13 @@ translate S compRunning {Torneo en curso}
 translate S Restart {Reanudar}
 translate S compFinished {Torneo terminado}
 translate S compStopped {Torneo detenido}
+translate S compForceDraw {Forzar sorteo}
+translate S compForceResign {Forzar la renuncia}
+translate S compAfterMove {Después de la mudanza:}
+translate S compNumMoves {Número de movimientos:}
+translate S compScoreLess {Puntuación <:}
+translate S compScoreGreater {Puntuación >:}
+translate S compRepeatReverse {Repetir al revés}
 
 #Coach
 translate S showblunderexists {Mostrar metedura de pata}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -1477,7 +1477,7 @@ translate U compRunning {Turnaus käynnissä}
 translate U Restart {Käynnistä uudelleen}
 translate U compFinished {Turnaus päättynyt}
 translate U compStopped {Turnaus pysähtyi}
-translate U compForceDraw {Force Draw}
+translate U compForceDraw {Pakotettu tasapeli}
 translate U compForceResign {Pakota eroamaan}
 translate U compAfterMove {Siirron jälkeen:}
 translate U compNumMoves {Liikkeiden määrä:}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -1477,6 +1477,13 @@ translate U compRunning {Turnaus käynnissä}
 translate U Restart {Käynnistä uudelleen}
 translate U compFinished {Turnaus päättynyt}
 translate U compStopped {Turnaus pysähtyi}
+translate U compForceDraw {Force Draw}
+translate U compForceResign {Pakota eroamaan}
+translate U compAfterMove {Siirron jälkeen:}
+translate U compNumMoves {Liikkeiden määrä:}
+translate U compScoreLess {Pisteet <:}
+translate U compScoreGreater {Pisteet >:}
+translate U compRepeatReverse {Toista taaksepäin}
 
 #Coach
 translate U showblunderexists {näytä virheet}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -1426,8 +1426,8 @@ translate Z compFinished {Mashindano yamekamilika}
 translate Z compStopped {Mashindano yamesimamishwa}
 translate Z compForceDraw {Lazimisha Kuteka}
 translate Z compForceResign {Lazimisha Kujiuzulu}
-translate Z compAfterMove {Baada ya kuhama:}
-translate Z compNumMoves {Nambari ya Uhamishaji:}
+translate Z compAfterMove {Baada ya mwendo:}
+translate Z compNumMoves {Idadi ya mawendo:}
 translate Z compScoreLess {Alama <:}
 translate Z compScoreGreater {Alama >:}
 translate Z compRepeatReverse {Rudia kinyume}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -1424,6 +1424,13 @@ translate Z compRunning {Mashindano yanaendelea}
 translate Z Restart {Anzisha upya}
 translate Z compFinished {Mashindano yamekamilika}
 translate Z compStopped {Mashindano yamesimamishwa}
+translate Z compForceDraw {Lazimisha Kuteka}
+translate Z compForceResign {Lazimisha Kujiuzulu}
+translate Z compAfterMove {Baada ya kuhama:}
+translate Z compNumMoves {Nambari ya Uhamishaji:}
+translate Z compScoreLess {Alama <:}
+translate Z compScoreGreater {Alama >:}
+translate Z compRepeatReverse {Rudia kinyume}
 
 #Coach
 translate Z showblunderexists {show blunder ipo}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -1452,6 +1452,13 @@ translate W compRunning {Turneringen pågår}
 translate W Restart {Starta om}
 translate W compFinished {Turneringen avslutad}
 translate W compStopped {Turneringen stoppas}
+translate W compForceDraw {Tvinga oavgjort}
+translate W compForceResign {Tvinga avgå}
+translate W compAfterMove {Efter flytt:}
+translate W compNumMoves {Antal drag:}
+translate W compScoreLess {Poäng <:}
+translate W compScoreGreater {Poäng >:}
+translate W compRepeatReverse {Upprepa omvänt}
 
 #Coach
 translate W showblunderexists {visa blunder finns}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -1428,6 +1428,13 @@ translate T compRunning {Turnuva devam ediyor}
 translate T Restart {Tekrar başlat}
 translate T compFinished {Turnuva bitti}
 translate T compStopped {Turnuva durduruldu}
+translate T compForceDraw {Çekmeye Zorla}
+translate T compForceResign {İstifaya Zorla}
+translate T compAfterMove {Taşındıktan sonra:}
+translate T compNumMoves {Hareket Sayısı:}
+translate T compScoreLess {Puan <:}
+translate T compScoreGreater {Puan >:}
+translate T compRepeatReverse {Ters yönde tekrarla}
 
 #Coach
 translate T showblunderexists {hatanın var olduğunu göster}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -1425,9 +1425,9 @@ translate Q compRunning {Турнір триває}
 translate Q Restart {Перезапустіть}
 translate Q compFinished {Турнір завершено}
 translate Q compStopped {Турнір зупинено}
-translate Q compForceDraw {Примусове малювання}
-translate Q compForceResign {Змусити подати у відставку}
-translate Q compAfterMove {Після переїзду:}
+translate Q compForceDraw {Примусова нічия}
+translate Q compForceResign {Примусово здатися}
+translate Q compAfterMove {Після ходу:}
 translate Q compNumMoves {Кількість ходів:}
 translate Q compScoreLess {Оцінка <:}
 translate Q compScoreGreater {Оцінка >:}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -1425,6 +1425,13 @@ translate Q compRunning {Турнір триває}
 translate Q Restart {Перезапустіть}
 translate Q compFinished {Турнір завершено}
 translate Q compStopped {Турнір зупинено}
+translate Q compForceDraw {Примусове малювання}
+translate Q compForceResign {Змусити подати у відставку}
+translate Q compAfterMove {Після переїзду:}
+translate Q compNumMoves {Кількість ходів:}
+translate Q compScoreLess {Оцінка <:}
+translate Q compScoreGreater {Оцінка >:}
+translate Q compRepeatReverse {Повторіть у зворотному напрямку}
 
 #Coach
 translate Q showblunderexists {показати, що помилка існує}

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -847,7 +847,9 @@ proc compNM {game n m k} {
                         ::comp::makeBookLine $game
                     }
                 }
-                set _Data(bookCache,$pairId) [list $_Data(moves,$game) $_Data(fen,$game) $_Data(board,$game)]
+                if {![info exists _Data(bookCache,$pairId)]} {
+                    set _Data(bookCache,$pairId) [list $_Data(moves,$game) $_Data(fen,$game) $_Data(board,$game)]
+                }
             }
         } else {
             switch $_Data(bookTyp) {

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -47,6 +47,14 @@ namespace eval comp {
     set _Data(runninggames) 0
     set _Data(paused) 0
     set _Data(bookTyp) ""
+    set _Data(forceDraw) 0
+    set _Data(forceDrawAfterMove) 25
+    set _Data(forceDrawNumMoves) 10
+    set _Data(forceDrawScore) 0.20
+    set _Data(forceResign) 0
+    set _Data(forceResignNumMoves) 10
+    set _Data(forceResignScore) 1.5
+    set _Data(repeatReverse) 0
 }
 
 # return index of actBook and a list of all books, return -1 if no books available
@@ -369,6 +377,31 @@ proc compInit { } {
   incr row
   ttk::checkbutton $w.config.autosave -text [tr compSave] -variable ::comp::_Data(autosave)
   grid $w.config.autosave -row $row -column 0 -columnspan 2 -sticky w
+
+  incr row
+  ttk::labelframe $w.config.forceDraw -text "Force Draw"
+  ttk::checkbutton $w.config.forceDraw.cb -variable ::comp::_Data(forceDraw)
+  ttk::label $w.config.forceDraw.afterLabel -text "After move:"
+  ttk::spinbox $w.config.forceDraw.after -textvariable ::comp::_Data(forceDrawAfterMove) -from 0 -to 999 -width 4
+  ttk::label $w.config.forceDraw.numLabel -text "Num Moves:"
+  ttk::spinbox $w.config.forceDraw.num -textvariable ::comp::_Data(forceDrawNumMoves) -from 1 -to 999 -width 4
+  ttk::label $w.config.forceDraw.scoreLabel -text "Score <:"
+  ttk::spinbox $w.config.forceDraw.score -textvariable ::comp::_Data(forceDrawScore) -from 0 -to 100 -width 5 -increment 0.01
+  pack $w.config.forceDraw.cb $w.config.forceDraw.afterLabel $w.config.forceDraw.after \
+      $w.config.forceDraw.numLabel $w.config.forceDraw.num \
+      $w.config.forceDraw.scoreLabel $w.config.forceDraw.score -side left -padx 2
+  grid $w.config.forceDraw -row $row -column 0 -columnspan 2 -sticky ew -pady 2
+
+  incr row
+  ttk::labelframe $w.config.forceResign -text "Force Resign"
+  ttk::checkbutton $w.config.forceResign.cb -variable ::comp::_Data(forceResign)
+  ttk::label $w.config.forceResign.numLabel -text "Num Moves:"
+  ttk::spinbox $w.config.forceResign.num -textvariable ::comp::_Data(forceResignNumMoves) -from 1 -to 999 -width 4
+  ttk::label $w.config.forceResign.scoreLabel -text "Score >:"
+  ttk::spinbox $w.config.forceResign.score -textvariable ::comp::_Data(forceResignScore) -from 0 -to 100 -width 5 -increment 0.1
+  pack $w.config.forceResign.cb $w.config.forceResign.numLabel $w.config.forceResign.num \
+      $w.config.forceResign.scoreLabel $w.config.forceResign.score -side left -padx 2
+  grid $w.config.forceResign -row $row -column 0 -columnspan 2 -sticky ew -pady 2
   ### Opening Book
 
   incr row
@@ -387,6 +420,11 @@ proc compInit { } {
   grid $w.config.book -row $row -column 0 -columnspan 2 -sticky w
   pack $w.config.book.combo $w.config.book.value -side right -padx "0 5"
 
+  incr row
+  ttk::checkbutton $w.config.repeatReverse -text "Repeat reverse" -variable ::comp::_Data(repeatReverse)
+  grid $w.config.repeatReverse -row $row -column 0 -padx 13 -sticky w
+
+  incr row
   ttk::label $w.games.aktstart -text "[tr games] "
   ttk::label $w.games.aktend -text " - "
   ttk::spinbox $w.games.roundakt -textvariable ::comp::_Data(current) -from 1 -to 999 -width 3
@@ -509,6 +547,16 @@ proc createGames { carousel } {
                 set hlist {}
             }
         }
+    }
+    if { $_Data(repeatReverse) } {
+        set newGames {}
+        foreach g $_Data(games) {
+            lassign $g w b r
+            lappend newGames $g
+            lappend newGames [list $b $w "$r"]
+        }
+        set _Data(games) $newGames
+        set _Data(lastgame) [llength $_Data(games)]
     }
 }
 
@@ -640,6 +688,7 @@ catch { puts "Start $_Data(current): $name1 - $name2" }
       after [expr {$game * 500} ] "compNM $game \"$name1\" \"$name2\" $k"
       incr _Data(runninggames)
       set _Data(this,$game) $thisgame
+      set _Data(currentIdx,$game) $_Data(current)
     }
     incr _Data(current)
   }
@@ -669,6 +718,7 @@ catch { puts "replay $_Data(this,$game)" }
 catch { puts "Start $_Data(current): Slot $game $name1 - $name2" }
             incr _Data(runninggames)
             set _Data(this,$game) $thisgame
+            set _Data(currentIdx,$game) $_Data(current)
         }
     }
     if { $_Data(runninggames) > 0 } return
@@ -770,20 +820,33 @@ proc compNM {game n m k} {
     set _Data(fen,$game) startpos
     set _Data(moves,$game) {}
     set _Data(comments,$game) {}
+    set _Data(scoreHistory,$game) {}
     set _Data(board,$game) "RNBQKBNRPPPPPPPP................................pppppppprnbqkbnr"
     if { $_Data(usebook) } {
-        switch $_Data(bookTyp) {
-            "opn" {
-                set _Data(moves,$game) $::comp::openline([expr {int( rand()*$_Data(maxopen) )}])
-                ::comp::makeBookLine $game
+        set isReverse [expr {$_Data(repeatReverse) && $_Data(currentIdx,$game) % 2 == 0}]
+        set pairId [expr {($_Data(currentIdx,$game) + 1) / 2}]
+        if { $isReverse && [info exists _Data(bookCache,$pairId)] } {
+            set cached $_Data(bookCache,$pairId)
+            set _Data(moves,$game) [lindex $cached 0]
+            set _Data(fen,$game) [lindex $cached 1]
+            set _Data(board,$game) [lindex $cached 2]
+        } else {
+            switch $_Data(bookTyp) {
+                "opn" {
+                    set _Data(moves,$game) $::comp::openline([expr {int( rand()*$_Data(maxopen) )}])
+                    ::comp::makeBookLine $game
+                }
+                "epd" {
+                    set _Data(fen,$game) $::comp::openline([expr {int( rand()*$_Data(maxopen) )}])
+                    set _Data(board,$game) [::comp::FENtoBoard $_Data(fen,$game)]
+                }
+                "bin" {
+                    set _Data(moves,$game) [::comp::readBookLine $game]
+                    ::comp::makeBookLine $game
+                }
             }
-            "epd" {
-                set _Data(fen,$game) $::comp::openline([expr {int( rand()*$_Data(maxopen) )}])
-                set _Data(board,$game) [::comp::FENtoBoard $_Data(fen,$game)]
-            }
-            "bin" {
-                set _Data(moves,$game) [::comp::readBookLine $game]
-                ::comp::makeBookLine $game
+            if { $_Data(repeatReverse) } {
+                set _Data(bookCache,$pairId) [list $_Data(moves,$game) $_Data(fen,$game) $_Data(board,$game)]
             }
         }
     }
@@ -943,6 +1006,9 @@ proc ::comp::compNextMove { game tomove expired bestmove } {
             if {$square1 ne $square2} { ::board::mark::DrawArrow .comp.bds.g$game.bd $square1 $square2 $::highlightLastMoveColor }
             if {$_Data(scoreIsNew,$game) } { ::board::updateEvalBar .comp.bds.g$game $_Data(score,$game) }
         }
+        if { $_Data(playing,$game) } {
+            lassign [::comp::compCheckAdjudication $game] _Data(playing,$game) _Data(result,$game)
+        }
         while {$_Data(paused)} {
             vwait ::comp::_Data(paused)
         }
@@ -980,6 +1046,89 @@ proc ::comp::adjucateGame {game result} {
     set _Data(playing,$game) 0
     set _Data(result,$game) $result
     lappend _Data(comments,$game) "Game judged by user"
+}
+
+proc ::comp::compCheckAdjudication {game} {
+    global ::comp::_Data
+
+    lappend _Data(scoreHistory,$game) $_Data(score,$game)
+    set n_moves [llength $_Data(moves,$game)]
+
+    if { $_Data(forceDraw) && $n_moves >= $_Data(forceDrawAfterMove) } {
+        set numCheck $_Data(forceDrawNumMoves)
+        set threshold $_Data(forceDrawScore)
+        set history $_Data(scoreHistory,$game)
+        set histLen [llength $history]
+        if { $histLen >= $numCheck } {
+            set recent [lrange $history end-[expr {$numCheck-1}] end]
+            set allBelow 1
+            foreach s $recent {
+                if { abs($s) >= $threshold } {
+                    set allBelow 0
+                    break
+                }
+            }
+            if { $allBelow } {
+                set txt "Force draw adjudication ($numCheck moves |score|<[format {%.2f} $threshold])"
+                set n [llength $_Data(comments,$game)]
+                if { $n > 0 } {
+                    set last [lindex $_Data(comments,$game) end]
+                    if { $last ne "" } { append last " - " }
+                    append last $txt
+                    lset _Data(comments,$game) end $last
+                }
+                return [list 0 "="]
+            }
+        }
+    }
+
+    if { $_Data(forceResign) } {
+        set numCheck $_Data(forceResignNumMoves)
+        set threshold $_Data(forceResignScore)
+        set history $_Data(scoreHistory,$game)
+        set histLen [llength $history]
+        if { $histLen >= $numCheck } {
+            set recent [lrange $history end-[expr {$numCheck-1}] end]
+            set whiteWins 1
+            foreach s $recent {
+                if { $s <= $threshold } {
+                    set whiteWins 0
+                    break
+                }
+            }
+            if { $whiteWins } {
+                set txt "Force resign adjudication: White wins ($numCheck moves score>[format {%.1f} $threshold])"
+                set n [llength $_Data(comments,$game)]
+                if { $n > 0 } {
+                    set last [lindex $_Data(comments,$game) end]
+                    if { $last ne "" } { append last " - " }
+                    append last $txt
+                    lset _Data(comments,$game) end $last
+                }
+                return [list 0 "1"]
+            }
+            set blackWins 1
+            foreach s $recent {
+                if { $s >= [expr {-$threshold}] } {
+                    set blackWins 0
+                    break
+                }
+            }
+            if { $blackWins } {
+                set txt "Force resign adjudication: Black wins ($numCheck moves score<-[format {%.1f} $threshold])"
+                set n [llength $_Data(comments,$game)]
+                if { $n > 0 } {
+                    set last [lindex $_Data(comments,$game) end]
+                    if { $last ne "" } { append last " - " }
+                    append last $txt
+                    lset _Data(comments,$game) end $last
+                }
+                return [list 0 "0"]
+            }
+        }
+    }
+
+    return [list 1 $_Data(result,$game)]
 }
 
 proc ::comp::compSaveGame {game} {

--- a/tcl/tools/multicomp.tcl
+++ b/tcl/tools/multicomp.tcl
@@ -379,13 +379,13 @@ proc compInit { } {
   grid $w.config.autosave -row $row -column 0 -columnspan 2 -sticky w
 
   incr row
-  ttk::labelframe $w.config.forceDraw -text "Force Draw"
+  ttk::labelframe $w.config.forceDraw -text [tr compForceDraw]
   ttk::checkbutton $w.config.forceDraw.cb -variable ::comp::_Data(forceDraw)
-  ttk::label $w.config.forceDraw.afterLabel -text "After move:"
+  ttk::label $w.config.forceDraw.afterLabel -text [tr compAfterMove]
   ttk::spinbox $w.config.forceDraw.after -textvariable ::comp::_Data(forceDrawAfterMove) -from 0 -to 999 -width 4
-  ttk::label $w.config.forceDraw.numLabel -text "Num Moves:"
+  ttk::label $w.config.forceDraw.numLabel -text [tr compNumMoves]
   ttk::spinbox $w.config.forceDraw.num -textvariable ::comp::_Data(forceDrawNumMoves) -from 1 -to 999 -width 4
-  ttk::label $w.config.forceDraw.scoreLabel -text "Score <:"
+  ttk::label $w.config.forceDraw.scoreLabel -text [tr compScoreLess]
   ttk::spinbox $w.config.forceDraw.score -textvariable ::comp::_Data(forceDrawScore) -from 0 -to 100 -width 5 -increment 0.01
   pack $w.config.forceDraw.cb $w.config.forceDraw.afterLabel $w.config.forceDraw.after \
       $w.config.forceDraw.numLabel $w.config.forceDraw.num \
@@ -393,11 +393,11 @@ proc compInit { } {
   grid $w.config.forceDraw -row $row -column 0 -columnspan 2 -sticky ew -pady 2
 
   incr row
-  ttk::labelframe $w.config.forceResign -text "Force Resign"
+  ttk::labelframe $w.config.forceResign -text [tr compForceResign]
   ttk::checkbutton $w.config.forceResign.cb -variable ::comp::_Data(forceResign)
-  ttk::label $w.config.forceResign.numLabel -text "Num Moves:"
+  ttk::label $w.config.forceResign.numLabel -text [tr compNumMoves]
   ttk::spinbox $w.config.forceResign.num -textvariable ::comp::_Data(forceResignNumMoves) -from 1 -to 999 -width 4
-  ttk::label $w.config.forceResign.scoreLabel -text "Score >:"
+  ttk::label $w.config.forceResign.scoreLabel -text [tr compScoreGreater]
   ttk::spinbox $w.config.forceResign.score -textvariable ::comp::_Data(forceResignScore) -from 0 -to 100 -width 5 -increment 0.1
   pack $w.config.forceResign.cb $w.config.forceResign.numLabel $w.config.forceResign.num \
       $w.config.forceResign.scoreLabel $w.config.forceResign.score -side left -padx 2
@@ -421,7 +421,7 @@ proc compInit { } {
   pack $w.config.book.combo $w.config.book.value -side right -padx "0 5"
 
   incr row
-  ttk::checkbutton $w.config.repeatReverse -text "Repeat reverse" -variable ::comp::_Data(repeatReverse)
+  ttk::checkbutton $w.config.repeatReverse -text [tr compRepeatReverse] -variable ::comp::_Data(repeatReverse)
   grid $w.config.repeatReverse -row $row -column 0 -padx 13 -sticky w
 
   incr row
@@ -676,6 +676,7 @@ catch { puts "$num_games GAMES total: $_Data(games)" }
   set _Data(runninggames) 0
   set _Data(paused) 0
   ::comp:loadBook $_Data(bookName)
+  if { $_Data(repeatReverse) } { array unset _Data {bookCache,*} }
   append _Data(statustext) [tr compRunning]
   while {$_Data(runninggames) < $_Data(processes) && $_Data(current) <= $_Data(lastgame)} {
     set thisgame [lindex $_Data(games) [expr $_Data(current) - 1]]
@@ -704,6 +705,7 @@ proc ::comp::compOkEnd {game} {
     if { ! $_Data(endaftergame) && $_Data(current) <= $_Data(lastgame) } {
         if { $_Data(result,$game) != "*" || !$_Data(replaybrokengame) } {
             set thisgame [lindex $_Data(games) [expr $_Data(current) - 1]]
+            set _Data(currentIdx,$game) $_Data(current)
             incr _Data(current)
         } else {
 catch { puts "replay $_Data(this,$game)" }
@@ -718,7 +720,6 @@ catch { puts "replay $_Data(this,$game)" }
 catch { puts "Start $_Data(current): Slot $game $name1 - $name2" }
             incr _Data(runninggames)
             set _Data(this,$game) $thisgame
-            set _Data(currentIdx,$game) $_Data(current)
         }
     }
     if { $_Data(runninggames) > 0 } return
@@ -763,10 +764,9 @@ catch { puts "Start $_Data(current): Slot $game $name1 - $name2" }
 proc ::comp::makeBookLine {game} {
     global ::comp::_Data
     foreach i $_Data(moves,$game) {
-        lappend _Data(comments,$game) ""
+        lappend _Data(comments,$game) "Book"
         lassign [::comp::compUpdateboard $_Data(board,$game) $i] res _Data(board,$game)
     }
-    set _Data(comments,$game) [lreplace $_Data(comments,$game) end end "last move from $_Data(bookName)"]
 }
 
 #read bookline from *.bin opening book
@@ -823,13 +823,32 @@ proc compNM {game n m k} {
     set _Data(scoreHistory,$game) {}
     set _Data(board,$game) "RNBQKBNRPPPPPPPP................................pppppppprnbqkbnr"
     if { $_Data(usebook) } {
-        set isReverse [expr {$_Data(repeatReverse) && $_Data(currentIdx,$game) % 2 == 0}]
-        set pairId [expr {($_Data(currentIdx,$game) + 1) / 2}]
-        if { $isReverse && [info exists _Data(bookCache,$pairId)] } {
-            set cached $_Data(bookCache,$pairId)
-            set _Data(moves,$game) [lindex $cached 0]
-            set _Data(fen,$game) [lindex $cached 1]
-            set _Data(board,$game) [lindex $cached 2]
+        if { $_Data(repeatReverse) } {
+            set pairId [expr {($_Data(currentIdx,$game) + 1) / 2}]
+            if { [info exists _Data(bookCache,$pairId)] } {
+                set cached $_Data(bookCache,$pairId)
+                set _Data(moves,$game) [lindex $cached 0]
+                set _Data(fen,$game) [lindex $cached 1]
+                set _Data(board,$game) [lindex $cached 2]
+                set _Data(comments,$game) {}
+                foreach mv $_Data(moves,$game) { lappend _Data(comments,$game) "Book" }
+            } else {
+                switch $_Data(bookTyp) {
+                    "opn" {
+                        set _Data(moves,$game) $::comp::openline([expr {int( rand()*$_Data(maxopen) )}])
+                        ::comp::makeBookLine $game
+                    }
+                    "epd" {
+                        set _Data(fen,$game) $::comp::openline([expr {int( rand()*$_Data(maxopen) )}])
+                        set _Data(board,$game) [::comp::FENtoBoard $_Data(fen,$game)]
+                    }
+                    "bin" {
+                        set _Data(moves,$game) [::comp::readBookLine $game]
+                        ::comp::makeBookLine $game
+                    }
+                }
+                set _Data(bookCache,$pairId) [list $_Data(moves,$game) $_Data(fen,$game) $_Data(board,$game)]
+            }
         } else {
             switch $_Data(bookTyp) {
                 "opn" {
@@ -844,9 +863,6 @@ proc compNM {game n m k} {
                     set _Data(moves,$game) [::comp::readBookLine $game]
                     ::comp::makeBookLine $game
                 }
-            }
-            if { $_Data(repeatReverse) } {
-                set _Data(bookCache,$pairId) [list $_Data(moves,$game) $_Data(fen,$game) $_Data(board,$game)]
             }
         }
     }
@@ -1052,15 +1068,16 @@ proc ::comp::compCheckAdjudication {game} {
     global ::comp::_Data
 
     lappend _Data(scoreHistory,$game) $_Data(score,$game)
-    set n_moves [llength $_Data(moves,$game)]
+    set n_plies [llength $_Data(moves,$game)]
+    set n_moves [expr {$n_plies / 2}]
 
     if { $_Data(forceDraw) && $n_moves >= $_Data(forceDrawAfterMove) } {
-        set numCheck $_Data(forceDrawNumMoves)
+        set numPiles [expr {$_Data(forceDrawNumMoves) * 2}]
         set threshold $_Data(forceDrawScore)
         set history $_Data(scoreHistory,$game)
         set histLen [llength $history]
-        if { $histLen >= $numCheck } {
-            set recent [lrange $history end-[expr {$numCheck-1}] end]
+        if { $histLen >= $numPiles } {
+            set recent [lrange $history end-[expr {$numPiles-1}] end]
             set allBelow 1
             foreach s $recent {
                 if { abs($s) >= $threshold } {
@@ -1069,7 +1086,7 @@ proc ::comp::compCheckAdjudication {game} {
                 }
             }
             if { $allBelow } {
-                set txt "Force draw adjudication ($numCheck moves |score|<[format {%.2f} $threshold])"
+                set txt "Force draw adjudication ($_Data(forceDrawNumMoves) moves |score|<[format {%.2f} $threshold])"
                 set n [llength $_Data(comments,$game)]
                 if { $n > 0 } {
                     set last [lindex $_Data(comments,$game) end]
@@ -1083,12 +1100,12 @@ proc ::comp::compCheckAdjudication {game} {
     }
 
     if { $_Data(forceResign) } {
-        set numCheck $_Data(forceResignNumMoves)
+        set numPiles [expr {$_Data(forceResignNumMoves) * 2}]
         set threshold $_Data(forceResignScore)
         set history $_Data(scoreHistory,$game)
         set histLen [llength $history]
-        if { $histLen >= $numCheck } {
-            set recent [lrange $history end-[expr {$numCheck-1}] end]
+        if { $histLen >= $numPiles } {
+            set recent [lrange $history end-[expr {$numPiles-1}] end]
             set whiteWins 1
             foreach s $recent {
                 if { $s <= $threshold } {
@@ -1097,7 +1114,7 @@ proc ::comp::compCheckAdjudication {game} {
                 }
             }
             if { $whiteWins } {
-                set txt "Force resign adjudication: White wins ($numCheck moves score>[format {%.1f} $threshold])"
+                set txt "Force resign adjudication: White wins ($_Data(forceResignNumMoves) moves score>[format {%.1f} $threshold])"
                 set n [llength $_Data(comments,$game)]
                 if { $n > 0 } {
                     set last [lindex $_Data(comments,$game) end]
@@ -1115,7 +1132,7 @@ proc ::comp::compCheckAdjudication {game} {
                 }
             }
             if { $blackWins } {
-                set txt "Force resign adjudication: Black wins ($numCheck moves score<-[format {%.1f} $threshold])"
+                set txt "Force resign adjudication: Black wins ($_Data(forceResignNumMoves) moves score<-[format {%.1f} $threshold])"
                 set n [llength $_Data(comments,$game)]
                 if { $n > 0 } {
                     set last [lindex $_Data(comments,$game) end]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable "force draw" and "force resign" adjudication based on recent engine scores
  * "Repeat reverse" mode that schedules reversed-color duplicate games
  * New UI controls to set adjudication thresholds, move-count windows, and enable repeat reverse

* **Localization**
  * Added Computer Tournament UI text/translations across many languages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->