### PR TITLE
Allow engine settings to be saved for Serious Game

### DIFF
--- a/tcl/tools/sergame.tcl
+++ b/tcl/tools/sergame.tcl
@@ -87,6 +87,7 @@ namespace eval sergame {
       set args [lindex $engineData 2]
       set dir [ toAbsPath [lindex $engineData 3] ]
       set options [lindex $engineData 8]
+      set ::uci::engineListIndex $index
       ::uci::uciConfig 3 [ toAbsPath $cmd ] $args [ toAbsPath $dir ] $options
     }
     pack $w.fengines.bEngineConfig -side top -pady 5 -anchor e -padx 4

--- a/tcl/tools/uci.tcl
+++ b/tcl/tools/uci.tcl
@@ -606,8 +606,8 @@ namespace eval uci {
     # will generate a list of list {{name}/value} pairs
     ################################################################################
     proc saveConfig {} {
-        global ::uci::optList ::uci::newOptions
-        set newOptions {}
+        global ::uci::optList ::uci::newOptions ::uci::engineListIndex
+        set ::uci::newOptions {}
         set w .uciConfigWin.c.f
         set optnbr 0
         
@@ -621,9 +621,16 @@ namespace eval uci {
                 set value [$w.fopt.opt$optnbr get]
             }
             if { $elt(type) != "button" } {
-                lappend newOptions [ list $elt(name)  $value ]
+                lappend ::uci::newOptions [ list $elt(name)  $value ]
             }
             incr optnbr
+        }
+        
+        if {[info exists engineListIndex]} {
+            set engineData [lindex $::engines(list) $engineListIndex]
+            lset engineData 8 $::uci::newOptions
+            lset ::engines(list) $engineListIndex $engineData
+            ::enginecfg::write
         }
     }
 

--- a/tcl/tools/uci.tcl
+++ b/tcl/tools/uci.tcl
@@ -626,7 +626,10 @@ namespace eval uci {
             incr optnbr
         }
         
-        if {[info exists engineListIndex]} {
+        if {[info exists engineListIndex] && \
+            [string is integer -strict $engineListIndex] && \
+            $engineListIndex >= 0 && \
+            $engineListIndex < [llength $::engines(list)]} {
             set engineData [lindex $::engines(list) $engineListIndex]
             lset engineData 8 $::uci::newOptions
             lset ::engines(list) $engineListIndex $engineData


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed engine selection tracking in the configuration dialog so the chosen engine is correctly applied before opening settings.
  * Improved engine settings persistence so updated options are saved back to the selected engine and stored reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->