### PR TITLE
3d board

### DIFF
--- a/tcl/board3d.tcl
+++ b/tcl/board3d.tcl
@@ -1,0 +1,696 @@
+# board3d.tcl: part of Scid
+# Copyright (C) 2021-2026
+#
+# 3D perspective board renderer using software projection onto a Tk canvas.
+# Uses existing 2D piece sprites (e.g. Eboard) as images placed at
+# perspective-projected positions. No external dependencies.
+
+namespace eval ::board3d {
+  namespace export new update flip orbit zoom reset resize
+
+  # Precomputed 3D coordinates for each square (0-63)
+  variable _square3d
+  # Ordered square indices from far to near for depth sorting
+  variable _depthOrder
+
+  # Per-board state
+  variable _camera    ;# dict per board: azim elev radius focal viewW viewH
+  variable _data      ;# board position string per board
+  variable _size      ;# piece image size per board
+  variable _flip      ;# flip state per board
+  variable _marks     ;# marks per board
+  variable _showMarks ;# show marks flag per board
+
+  # Initialise the 3D square coordinates and depth ordering
+  for {set sq 0} {$sq < 64} {incr sq} {
+    set col [expr {$sq % 8}]
+    set row [expr {$sq / 8}]
+    set x [expr {$col - 3.5}]
+    set y [expr {$row - 3.5}]
+    # Square corners: bottom-left, bottom-right, top-right, top-left
+    set h 0.5
+    lappend ::board3d::_square3d($sq) \
+        [list [expr {$x-$h}] [expr {$y-$h}] 0] \
+        [list [expr {$x+$h}] [expr {$y-$h}] 0] \
+        [list [expr {$x+$h}] [expr {$y+$h}] 0] \
+        [list [expr {$x-$h}] [expr {$y+$h}] 0]
+    # Square center for piece placement:
+    lappend ::board3d::_square3d($sq) [list $x $y 0]
+  }
+
+  # Depth order: far to near. Camera behind white means white (row 0) is near, black (row 7) is far.
+  # So draw row 7 first, row 6 next, ..., row 0 last.
+  for {set row 7} {$row >= 0} {incr row -1} {
+    for {set col 0} {$col < 8} {incr col} {
+      lappend ::board3d::_depthOrder [expr {$row * 8 + $col}]
+    }
+  }
+}
+
+# ::board3d::new --
+#   Creates a new 3D board widget within the given frame.
+#   w      - parent widget path
+#   psize  - piece size (defaults to $::boardSize)
+#
+proc ::board3d::new {w {psize 40}} {
+  if {[winfo exists $w]} { return }
+
+  foreach size $::boardSizes {
+    if {$size >= $psize} { break }
+  }
+  if {![info exists size] || $size == ""} { set size $psize }
+  set psize $size
+
+  set ::board3d::_size($w) $psize
+  set ::board3d::_flip($w) 0
+  set ::board3d::_showMarks($w) 0
+  set ::board3d::_marks($w) {}
+  set ::board3d::_data($w) [sc_pos board]
+
+  # Default camera: behind white (azim=pi), 30 degree elevation, distance 10
+  # viewW/viewH are canvas dimensions; focal controls zoom
+  set cw 1040
+  set ch 1040
+  set azimVal [expr {atan2(0.0, -1.0)}]
+  set ::board3d::_camera($w) [dict create azim $azimVal elev 0.733 radius 10.0 focal [expr {$cw * 0.8}] viewW $cw viewH $ch]
+
+  ttk::frame $w -class Board3D
+  canvas $w.bd -cursor hand1 \
+      -borderwidth 0 -highlightthickness 0 \
+      -background #3e4540
+  ::applyThemeColor_background $w.bd
+  pack $w.bd -expand 1 -fill both
+
+  $w.bd create rectangle -100 -100 0 0 -tag bg -fill #3e4540 -outline ""
+
+  ::board3d::redraw3d $w
+
+  # Mouse bindings:
+  # Left-drag on empty area: orbit camera
+  # Left-drag on piece: move piece
+  # Right-click: identify square
+  # Scroll: zoom
+  bind $w.bd <ButtonPress-1>   [list ::board3d::_startClick $w %x %y]
+  bind $w.bd <B1-Motion>       [list ::board3d::_dragMotion $w %x %y]
+  bind $w.bd <ButtonRelease-1> [list ::board3d::_endClick $w %x %y]
+  bind $w.bd <MouseWheel>      { ::board3d::_onWheel %W %D }
+  bind $w.bd <Button-4>        [list ::board3d::zoom $w  0.3]
+  bind $w.bd <Button-5>        [list ::board3d::zoom $w -0.3]
+  bind $w.bd <KeyPress-r>      [list ::board3d::reset $w]
+  bind $w.bd <KeyPress-f>      [list ::board3d::flip $w]
+  bind $w.bd <ButtonPress-3>   [list ::board3d::_clickSquare $w %x %y]
+
+  return $w
+}
+
+# ::board3d::update --
+#   Updates the board display with new position data.
+#
+proc ::board3d::update {w {board ""} args} {
+  if {![winfo exists $w]} { return }
+  if {$board eq ""} {
+    set board $::board3d::_data($w)
+  } else {
+    set ::board3d::_data($w) $board
+  }
+  ::board3d::redraw3d $w
+}
+
+# ::board3d::redraw3d --
+#   Recomputes all 3D projections and redraws the entire board.
+#
+proc ::board3d::redraw3d {w} {
+  if {![winfo exists $w]} { return }
+
+  set bd $w.bd
+  set cam $::board3d::_camera($w)
+  set flip $::board3d::_flip($w)
+  set board $::board3d::_data($w)
+  set psize $::board3d::_size($w)
+
+  # Adjust depth ordering and azimuth for flip
+  if {$flip} {
+    set azim [expr {[dict get $cam azim] + 3.1415926535}]
+    set cam [dict replace $cam azim $azim]
+  }
+
+  # --- Compute projected 2D positions for all 64 squares ---
+  # For each square, project both corners and midpoint.
+  set projCorners {}    ;# list of {sq cornerlist}
+  set projCenters {}    ;# list of {sq cx cy}
+  set depths {}         ;# list of {sq depth} for sorting
+
+  for {set sq 0} {$sq < 64} {incr sq} {
+    set corners {}
+    foreach pt [lrange $::board3d::_square3d($sq) 0 3] {
+      lassign $pt px py pz
+      lassign [::board3d::_project $cam $px $py $pz] sx sy
+      lappend corners $sx $sy
+    }
+    lappend projCorners $corners
+
+    # Project center point for piece placement
+    lassign [lindex $::board3d::_square3d($sq) 4] cx cy cz
+    lassign [::board3d::_project $cam $cx $cy $cz] scx scy
+    lappend projCenters [list $scx $scy]
+
+    # Compute depth (camera-space Z) for depth sorting
+    lassign [lindex $::board3d::_square3d($sq) 4] cx cy cz
+    set depth [::board3d::_depth $cam $cx $cy $cz]
+    lappend depths $depth
+  }
+
+  # --- Determine drawing order ---
+  # Sort squares by depth: FAR squares first (drawn behind), NEAR squares last (on top)
+  set drawOrder {}
+  for {set sq 0} {$sq < 64} {incr sq} {
+    lappend drawOrder $sq
+  }
+  set drawOrder [lsort -integer -decreasing -index 0 \
+      [lmap sq $drawOrder dep $depths { list [expr {int($dep * 1000)}] $sq }]]
+  set drawOrder [lmap pair $drawOrder { lindex $pair 1 }]
+
+  # --- Compute apparent square size for piece sizing ---
+  # Use the diagonal of the nearest square to estimate a good size scale
+  set nearSq [lindex $drawOrder end]
+  set nearCorners [lindex $projCorners $nearSq]
+  lassign $nearCorners nx0 ny0 nx1 ny1 nx2 ny2 nx3 ny3
+  set nearDiag [expr {sqrt(($nx2-$nx0)*($nx2-$nx0) + ($ny2-$ny0)*($ny2-$ny0))}]
+  # Pick a "base" piece size from mid-board, not the near edge
+  set midSq 27;  # d4, near center
+  set midCorners [lindex $projCorners $midSq]
+  lassign $midCorners mx0 my0 mx1 my1 mx2 my2 mx3 my3
+  set midDiag [expr {sqrt(($mx2-$mx0)*($mx2-$mx0) + ($my2-$my0)*($my2-$my0))}]
+  set baseSize 0
+  foreach s $::boardSizes {
+    if {$s <= $midDiag && $s > $baseSize} { set baseSize $s }
+  }
+  if {$baseSize == 0} { set baseSize [lindex $::boardSizes end] }
+
+  # --- Draw ---
+  $bd delete board3d
+
+  # Draw background
+  set cw [dict get $cam viewW]
+  set ch [dict get $cam viewH]
+  $bd coords bg -100 -100 [expr {$cw + 100}] [expr {$ch + 100}]
+
+  # Draw board squares
+  foreach sq $drawOrder {
+    set corners [lindex $projCorners $sq]
+    if {[lindex $corners 0] < -10000} { continue }
+
+    # Determine color
+    set isLight [expr {($sq + ($sq / 8)) % 2}]
+    if {$flip} { set isLight [expr {!$isLight}] }
+    if {$isLight} {
+      set color $::squareColor_lite
+    } else {
+      set color $::squareColor_dark
+    }
+
+    $bd create polygon {*}$corners -fill $color -outline "" -tag board3d
+  }
+
+  # Draw pieces — size each piece to its own projected square
+  foreach sq $drawOrder {
+    set piece [string index $board $sq]
+    if {$piece eq "."} { continue }
+
+    lassign [lindex $projCenters $sq] cx cy
+    if {$cx < -10000} { continue }
+
+    # Compute piece size from this square's projected width
+    set corners [lindex $projCorners $sq]
+    lassign $corners sx0 sy0 sx1 sy1 sx2 sy2 sx3 sy3
+    set sqW [expr {abs($sx1 - $sx0) * 0.85}]
+    set pieceSize 0
+    foreach s $::boardSizes {
+      if {$s <= $sqW && $s > $pieceSize} { set pieceSize $s }
+    }
+    if {$pieceSize == 0} { set pieceSize [lindex $::boardSizes end] }
+
+    # Row-progressive y-shift: far pieces need to be pushed back into their
+    # squares to compensate for perspective foreshortening.
+    # Row 0 (nearest): 0%, row 1: 5%, ..., row 7: 35% of square height.
+    set row [expr {$sq / 8}]
+    if {$flip} { set row [expr {7 - $row}] }
+    set sqH [expr {abs($sy3 - $sy0)}]
+    set shift [expr {$row * 0.05 * $sqH}]
+    set cy [expr {$cy - $shift}]
+
+    set pieceImg $::board::letterToPiece($piece)$pieceSize
+    set tags [list board3d p$sq]
+    if {[catch { $bd create image $cx $cy -image $pieceImg -tag $tags -anchor c }]} {
+      foreach s $::boardSizes {
+        set pieceImg $::board::letterToPiece($piece)$s
+        if {![catch {image width $pieceImg}]} {
+          $bd create image $cx $cy -image $pieceImg -tag $tags -anchor c
+          break
+        }
+      }
+    }
+  }
+
+  # Draw last move highlight
+  ::board3d::_drawLastMoveHighlight $w $projCorners $projCenters
+
+  # Draw marks and arrows
+  if {$::board3d::_showMarks($w)} {
+    ::board3d::_drawMarks $w $projCorners $projCenters $drawOrder
+  }
+}
+
+# ::board3d::flip --
+#   Flips the 3D board 180 degrees.
+#
+proc ::board3d::flip {w} {
+  if {![info exists ::board3d::_flip($w)]} { return }
+  set ::board3d::_flip($w) [expr {1 - $::board3d::_flip($w)}]
+  ::board3d::redraw3d $w
+}
+
+# ::board3d::orbit --
+#   Orbits the camera by (dazim, delev) in radians.
+#
+proc ::board3d::orbit {w dazim delev} {
+  set cam $::board3d::_camera($w)
+  set azim [expr {[dict get $cam azim] + $dazim}]
+  set elev [expr {[dict get $cam elev] + $delev}]
+  # Clamp elevation
+  set maxElev 1.4
+  if {$elev > $maxElev}  { set elev $maxElev }
+  if {$elev < 0.05}      { set elev 0.05 }
+  dict set cam azim $azim
+  dict set cam elev $elev
+  set ::board3d::_camera($w) $cam
+  ::board3d::redraw3d $w
+}
+
+# ::board3d::_onWheel --
+#   Mousewheel handler. %W is the canvas; strip .bd to get the board frame.
+#   %D is the raw delta (typically ±120 per click), scaled down.
+#
+proc ::board3d::_onWheel {canvasPath rawDelta} {
+  set w [string range $canvasPath 0 end-3]
+  set delta [expr {$rawDelta / 40.0}]
+  ::board3d::zoom $w $delta
+}
+
+# ::board3d::zoom --
+#   Zooms the camera in/out.
+#
+proc ::board3d::zoom {w delta} {
+  set cam $::board3d::_camera($w)
+  set radius [expr {[dict get $cam radius] - $delta * 0.5}]
+  if {$radius < 4}  { set radius 4 }
+  if {$radius > 30} { set radius 30 }
+  dict set cam radius $radius
+  set ::board3d::_camera($w) $cam
+  ::board3d::redraw3d $w
+}
+
+# ::board3d::reset --
+#   Resets the camera to the default position.
+#
+proc ::board3d::reset {w} {
+  set cw [dict get $::board3d::_camera($w) viewW]
+  set ch [dict get $::board3d::_camera($w) viewH]
+  set azimVal [expr {atan2(0.0, -1.0)}]
+  set ::board3d::_camera($w) [dict create azim $azimVal elev 0.733 radius 10.0 focal [expr {$cw * 0.8}] viewW $cw viewH $ch]
+  ::board3d::redraw3d $w
+}
+
+# ::board3d::resize --
+#   Resizes the 3D board canvas.
+#
+proc ::board3d::resize {w neww newh} {
+  set cam $::board3d::_camera($w)
+  if {$neww < 200} { set neww 200 }
+  if {$newh < 200} { set newh 200 }
+  dict set cam viewW $neww
+  dict set cam viewH $newh
+  dict set cam focal [expr {$neww * 0.8}]
+  set ::board3d::_camera($w) $cam
+  ::board3d::redraw3d $w
+}
+
+# ::board3d::showMarks --
+#   Turns marks display on/off.
+#
+proc ::board3d::showMarks {w value} {
+  set ::board3d::_showMarks($w) $value
+}
+
+# ::board3d::setmarks --
+#   Sets marks from embedded commands.
+#
+proc ::board3d::setmarks {w cmds} {
+  set ::board3d::_marks($w) {}
+  if {$cmds eq ""} { return }
+  set ::board3d::_marks($w) [lmap elem [::board::mark::getEmbeddedCmds $cmds] {
+    lassign $elem type arg1 arg2 color
+    switch -glob $type {
+      ""     {set type [expr {[string length $arg2] ? "arrow" : "circle"}]}
+      "mark" {set type "full"}
+      ?      {set arg2 $type ; set type "text"}
+    }
+    set arg1 [::board::sq $arg1]
+    set sq2 [::board::sq $arg2]
+    if {$sq2 != -1} { set arg2 $sq2 }
+    switch -nocase $color {
+      "" - "R" {set color "#ff3030"}
+      "G"      {set color "#30c030"}
+      "Y"      {set color "#ffff30"}
+      "B"      {set color "#3030ff"}
+      "O"      {set color "#ff8030"}
+      "C"      {set color "#30ffff"}
+    }
+    list $type $arg1 $arg2 $color
+  }]
+}
+
+# ----------------------------------------------------------------------
+# Internal: Camera projection
+# ----------------------------------------------------------------------
+
+# ::board3d::_project --
+#   Projects a 3D point to 2D screen coordinates using perspective.
+#   Returns {screenX screenY} or {-10000 -10000} if behind camera.
+#
+proc ::board3d::_project {cam px py pz} {
+  set azim  [dict get $cam azim]
+  set elev  [dict get $cam elev]
+  set radius [dict get $cam radius]
+  set focal [dict get $cam focal]
+  set cw    [dict get $cam viewW]
+  set ch    [dict get $cam viewH]
+
+  # Camera position in world space
+  set cosE [expr {cos($elev)}]
+  set sinE [expr {sin($elev)}]
+  set cosA [expr {cos($azim)}]
+  set sinA [expr {sin($azim)}]
+  set camX [expr {$radius * $cosE * $sinA}]
+  set camY [expr {$radius * $cosE * $cosA}]
+  set camZ [expr {$radius * $sinE}]
+
+  # Forward vector (target - camera, normalized)
+  set fX [expr {-$camX}]
+  set fY [expr {-$camY}]
+  set fZ [expr {-$camZ}]
+  set fLen [expr {sqrt($fX*$fX + $fY*$fY + $fZ*$fZ)}]
+  if {$fLen < 0.0001} { return {-10000 -10000} }
+  set fX [expr {$fX / $fLen}]
+  set fY [expr {$fY / $fLen}]
+  set fZ [expr {$fZ / $fLen}]
+
+  # Right vector: cross(worldUp, forward)
+  # worldUp = (0,0,1) unless forward is parallel to it
+  set rX [expr {$fY}]
+  set rY [expr {-$fX}]
+  set rZ 0.0
+  set rLen [expr {sqrt($rX*$rX + $rY*$rY)}]
+  if {$rLen < 0.0001} {
+    set rX 1.0; set rY 0.0; set rZ 0.0
+  } else {
+    set rX [expr {$rX / $rLen}]
+    set rY [expr {$rY / $rLen}]
+  }
+
+  # Up' vector: cross(right, forward)
+  set uX [expr {$rY*$fZ - 0*$fY}]
+  set uY [expr {0*$fX - $rX*$fZ}]
+  set uZ [expr {$rX*$fY - $rY*$fX}]
+
+  # Transform point to camera space
+  set dx [expr {$px - $camX}]
+  set dy [expr {$py - $camY}]
+  set dz [expr {$pz - $camZ}]
+  set cx [expr {$dx*$rX + $dy*$rY + $dz*0}]
+  set cy [expr {$dx*$uX + $dy*$uY + $dz*$uZ}]
+  set cz [expr {$dx*$fX + $dy*$fY + $dz*$fZ}]
+
+  # Perspective divide
+  if {$cz <= 0.001} {
+    return {-10000 -10000}
+  }
+  set sx [expr {$focal * $cx / $cz}]
+  set sy [expr {$focal * $cy / $cz}]
+
+  # Screen coordinates
+  set screenX [expr {$cw / 2.0 + $sx}]
+  set screenY [expr {$ch / 2.0 - $sy}]
+
+  return [list $screenX $screenY]
+}
+
+# ::board3d::_depth --
+#   Returns the camera-space Z of a point (for depth sorting).
+#
+proc ::board3d::_depth {cam px py pz} {
+  set azim  [dict get $cam azim]
+  set elev  [dict get $cam elev]
+  set radius [dict get $cam radius]
+  set cosE [expr {cos($elev)}]
+  set sinE [expr {sin($elev)}]
+  set cosA [expr {cos($azim)}]
+  set sinA [expr {sin($azim)}]
+  set camX [expr {$radius * $cosE * $sinA}]
+  set camY [expr {$radius * $cosE * $cosA}]
+  set camZ [expr {$radius * $sinE}]
+
+  set dx [expr {$px - $camX}]
+  set dy [expr {$py - $camY}]
+  set dz [expr {$pz - $camZ}]
+
+  set fX [expr {-$camX}]
+  set fY [expr {-$camY}]
+  set fZ [expr {-$camZ}]
+  set fLen [expr {sqrt($fX*$fX + $fY*$fY + $fZ*$fZ)}]
+  if {$fLen < 0.0001} { return 0 }
+  set fX [expr {$fX / $fLen}]
+  set fY [expr {$fY / $fLen}]
+  set fZ [expr {$fZ / $fLen}]
+
+  return [expr {$dx*$fX + $dy*$fY + $dz*$fZ}]
+}
+
+# ----------------------------------------------------------------------
+# Internal: Mouse interaction
+# ----------------------------------------------------------------------
+
+# ::board3d::_findSquare --
+#   Returns the square number (0-63) at screen coordinates (x, y), or -1.
+#
+proc ::board3d::_findSquare {w x y} {
+  set bestDist 100000
+  set bestSq -1
+  set cam $::board3d::_camera($w)
+  for {set sq 0} {$sq < 64} {incr sq} {
+    lassign [lindex $::board3d::_square3d($sq) 4] sx sy sz
+    lassign [::board3d::_project $cam $sx $sy $sz] px py
+    set dist [expr {($x-$px)*($x-$px) + ($y-$py)*($y-$py)}]
+    if {$dist < $bestDist} {
+      set bestDist $dist
+      set bestSq $sq
+    }
+  }
+  if {$::board3d::_flip($w)} { set bestSq [expr {63 - $bestSq}] }
+  if {$bestSq < 0 || $bestSq >= 64} { return -1 }
+  return $bestSq
+}
+
+proc ::board3d::_startClick {w x y} {
+  set sq [::board3d::_findSquare $w $x $y]
+  if {$sq >= 0} {
+    set piece [string index $::board3d::_data($w) $sq]
+    if {$piece ne "."} {
+      # Start piece drag: hide the original piece on board, show a floating copy
+      set ::board3d::_dragMode($w) "piece"
+      set ::board3d::_dragOrig($w) $sq
+      set ::board3d::_dragX($w) $x
+      set ::board3d::_dragY($w) $y
+
+      $w.bd itemconfigure p$sq -state hidden
+      set psize $::board3d::_size($w)
+      set pieceImg $::board::letterToPiece($piece)$psize
+      if {[catch {image width $pieceImg}]} {
+        foreach s $::boardSizes {
+          set pieceImg $::board::letterToPiece($piece)$s
+          if {![catch {image width $pieceImg}]} { break }
+        }
+      }
+      $w.bd create image $x $y -image $pieceImg -tag floating_piece -anchor c
+      $w.bd raise floating_piece
+      return
+    }
+  }
+
+  # Otherwise: start camera orbit
+  set ::board3d::_dragMode($w) "orbit"
+  set ::board3d::_dragX($w) $x
+  set ::board3d::_dragY($w) $y
+}
+
+proc ::board3d::_dragMotion {w x y} {
+  if {![info exists ::board3d::_dragMode($w)]} { return }
+
+  if {$::board3d::_dragMode($w) eq "piece"} {
+    $w.bd coords floating_piece $x $y
+    $w.bd raise floating_piece
+    set ::board3d::_dragX($w) $x
+    set ::board3d::_dragY($w) $y
+    return
+  }
+
+  if {$::board3d::_dragMode($w) eq "orbit"} {
+    set dx [expr {$x - $::board3d::_dragX($w)}]
+    set dy [expr {$y - $::board3d::_dragY($w)}]
+    set ::board3d::_dragX($w) $x
+    set ::board3d::_dragY($w) $y
+    set sensitivity 0.005
+    ::board3d::orbit $w [expr {-$dx * $sensitivity}] [expr {$dy * $sensitivity}]
+    return
+  }
+}
+
+proc ::board3d::_endClick {w x y} {
+  if {![info exists ::board3d::_dragMode($w)]} { return }
+
+  if {$::board3d::_dragMode($w) eq "piece"} {
+    $w.bd delete floating_piece
+    set fromSq $::board3d::_dragOrig($w)
+    set toSq [::board3d::_findSquare $w $x $y]
+    if {$toSq >= 0 && $toSq != $fromSq} {
+      # Use addMove which handles promotions, variations, and follow-moves
+      addMove $toSq $fromSq
+    }
+    catch { unset ::board3d::_dragMode($w) ::board3d::_dragOrig($w) }
+    # addMove calls updateBoard internally, but also redraw for safety
+    ::board3d::redraw3d $w
+    return
+  }
+
+  catch { unset ::board3d::_dragMode($w) ::board3d::_dragOrig($w) }
+  ::board3d::redraw3d $w
+}
+
+# Approximate square click using inverse projection (right-click)
+proc ::board3d::_clickSquare {w x y} {
+  set sq [::board3d::_findSquare $w $x $y]
+  if {$sq >= 0 && $sq < 64} {
+    event generate $w.bd <<SquareClick>> -data $sq
+  }
+}
+
+# ----------------------------------------------------------------------
+# Internal: Last move highlight
+# ----------------------------------------------------------------------
+
+proc ::board3d::_drawLastMoveHighlight {w projCorners projCenters} {
+  set bd $w.bd
+  if {!$::highlightLastMove && !$::arrowLastMove} { return }
+
+  if {[catch { sc_game info previousMoveUCI } moveuci]} { return }
+  if {[string length $moveuci] < 4} { return }
+
+  set sq1 [::board::sq [string range $moveuci 0 1]]
+  set sq2 [::board::sq [string range $moveuci 2 3]]
+  if {$sq1 < 0 || $sq2 < 0} { return }
+
+  # Draw highlight rectangles
+  if {$::highlightLastMove} {
+    foreach sq [list $sq1 $sq2] {
+      set corners [lindex $projCorners $sq]
+      if {[lindex $corners 0] < -10000} { continue }
+      set pad 2
+      lassign $corners x0 y0 x1 y1 x2 y2 x3 y3
+      $bd create polygon $x0 $y0 $x1 $y1 $x2 $y2 $x3 $y3 \
+          -fill "" -outline $::highlightLastMoveColor \
+          -width $::highlightLastMoveWidth -tag board3d
+    }
+  }
+
+  # Draw arrow
+  if {$::arrowLastMove} {
+    # Recompute the arrow in 3D and project
+    set pt1 [lindex $::board3d::_square3d($sq1) 4]   ;# center of sq1
+    set pt2 [lindex $::board3d::_square3d($sq2) 4]   ;# center of sq2
+    lassign $pt1 x1 y1 z1
+    lassign $pt2 x2 y2 z2
+    set cam $::board3d::_camera($w)
+
+    # Arrow start: 80% of the way from sq1 toward sq2
+    set ax [expr {$x1 + 0.2 * ($x2 - $x1)}]
+    set ay [expr {$y1 + 0.2 * ($y2 - $y1)}]
+    set az 0.0
+    # Arrow end: at sq2
+    set bx $x2
+    set by $y2
+    set bz 0.0
+
+    lassign [::board3d::_project $cam $ax $ay $az] asx asy
+    lassign [::board3d::_project $cam $bx $by $bz] bsx bsy
+    if {$asx > -10000 && $bsx > -10000} {
+      $bd create line $asx $asy $bsx $bsy \
+          -fill $::highlightLastMoveColor -width 3 -arrow last \
+          -arrowshape {10 12 4} -tag board3d
+    }
+  }
+}
+
+# ----------------------------------------------------------------------
+# Internal: Draw marks and arrows
+# ----------------------------------------------------------------------
+
+proc ::board3d::_drawMarks {w projCorners projCenters drawOrder} {
+  set bd $w.bd
+  set cam $::board3d::_camera($w)
+
+  foreach mark $::board3d::_marks($w) {
+    lassign $mark type sq1 sq2 color
+
+    if {$type eq "full"} {
+      set corners [lindex $projCorners $sq1]
+      if {[lindex $corners 0] < -10000} { continue }
+      lassign $corners x0 y0 x1 y1 x2 y2 x3 y3
+      $bd create polygon $x0 $y0 $x1 $y1 $x2 $y2 $x3 $y3 \
+          -fill $color -stipple "" -outline "" -tag board3d
+    } elseif {$type eq "circle"} {
+      lassign [lindex $projCenters $sq1] cx cy
+      if {$cx < -10000} { continue }
+      # Estimate radius from projected square size
+      set corners [lindex $projCorners $sq1]
+      if {[lindex $corners 0] < -10000} { continue }
+      set diam [expr {abs([lindex $corners 2] - [lindex $corners 0]) * 0.8}]
+      set r [expr {$diam / 2.0}]
+      $bd create oval [expr {$cx-$r}] [expr {$cy-$r}] \
+          [expr {$cx+$r}] [expr {$cy+$r}] \
+          -fill "" -outline $color -width 3 -tag board3d
+    } elseif {$type eq "arrow"} {
+      if {$sq2 < 0} { continue }
+      set pt1 [lindex $::board3d::_square3d($sq1) 4]
+      set pt2 [lindex $::board3d::_square3d($sq2) 4]
+      lassign $pt1 x1 y1 z1
+      lassign $pt2 x2 y2 z2
+      set ax [expr {$x1 + 0.15 * ($x2 - $x1)}]
+      set ay [expr {$y1 + 0.15 * ($y2 - $y1)}]
+      set az 0.0
+      set bx [expr {$x2 - 0.15 * ($x2 - $x1)}]
+      set by [expr {$y2 - 0.15 * ($y2 - $y1)}]
+      set bz 0.0
+      lassign [::board3d::_project $cam $ax $ay $az] asx asy
+      lassign [::board3d::_project $cam $bx $by $bz] bsx bsy
+      if {$asx > -10000 && $bsx > -10000} {
+        $bd create line $asx $asy $bsx $bsy \
+            -fill $color -width 2 -arrow last \
+            -arrowshape {8 10 4} -tag board3d
+      }
+    }
+  }
+}
+
+# ----------------------------------------------------------------------
+# End of file: board3d.tcl
+# ----------------------------------------------------------------------

--- a/tcl/board3d.tcl
+++ b/tcl/board3d.tcl
@@ -195,6 +195,38 @@ proc ::board3d::redraw3d {w} {
   set ch [dict get $cam viewH]
   $bd coords bg -100 -100 [expr {$cw + 100}] [expr {$ch + 100}]
 
+  # Draw board base/thickness
+  set baseThickness 0.5
+  set baseFaces {
+    {{-4 -4 0} {4 -4 0} {4 -4 -0.5} {-4 -4 -0.5} {0 -4 -0.25}}
+    {{4 -4 0} {4 4 0} {4 4 -0.5} {4 -4 -0.5} {4 0 -0.25}}
+    {{4 4 0} {-4 4 0} {-4 4 -0.5} {4 4 -0.5} {0 4 -0.25}}
+    {{-4 4 0} {-4 -4 0} {-4 -4 -0.5} {-4 4 -0.5} {-4 0 -0.25}}
+  }
+  set faceDepths {}
+  foreach face $baseFaces {
+    lassign [lindex $face 4] cx cy cz
+    lappend faceDepths [::board3d::_depth $cam $cx $cy $cz]
+  }
+  set faceOrder {0 1 2 3}
+  set faceOrder [lsort -integer -decreasing -index 0 \
+      [lmap f $faceOrder dep $faceDepths { list [expr {int($dep * 1000)}] $f }]]
+  set faceOrder [lmap pair $faceOrder { lindex $pair 1 }]
+
+  foreach f $faceOrder {
+    set face [lindex $baseFaces $f]
+    set corners {}
+    foreach pt [lrange $face 0 3] {
+      lassign $pt px py pz
+      lassign [::board3d::_project $cam $px $py $pz] sx sy
+      lappend corners $sx $sy
+    }
+    if {[lindex $corners 0] > -10000} {
+      # Dark wood color for base
+      $bd create polygon {*}$corners -fill #2a1b14 -outline #1a0b04 -tag board3d
+    }
+  }
+
   # Draw board squares
   foreach sq $drawOrder {
     set corners [lindex $projCorners $sq]
@@ -209,7 +241,7 @@ proc ::board3d::redraw3d {w} {
       set color $::squareColor_dark
     }
 
-    $bd create polygon {*}$corners -fill $color -outline "" -tag board3d
+    $bd create polygon {*}$corners -fill $color -outline $color -tag board3d
   }
 
   # Draw pieces — size each piece to its own projected square
@@ -230,22 +262,23 @@ proc ::board3d::redraw3d {w} {
     }
     if {$pieceSize == 0} { set pieceSize [lindex $::boardSizes end] }
 
-    # Row-progressive y-shift: far pieces need to be pushed back into their
-    # squares to compensate for perspective foreshortening.
-    # Row 0 (nearest): 0%, row 1: 5%, ..., row 7: 35% of square height.
-    set row [expr {$sq / 8}]
-    if {$flip} { set row [expr {7 - $row}] }
-    set sqH [expr {abs($sy3 - $sy0)}]
-    set shift [expr {$row * 0.05 * $sqH}]
-    set cy [expr {$cy - $shift}]
+    # Draw drop shadow
+    set sw [expr {$sqW * 0.7}]
+    set sh [expr {$sw * 0.35}]
+    $bd create oval [expr {$cx - $sw/2.0}] [expr {$cy - $sh/2.0}] \
+        [expr {$cx + $sw/2.0}] [expr {$cy + $sh/2.0}] \
+        -fill #111111 -stipple gray50 -outline "" -tag board3d
 
+    # Billboarding: Anchor the bottom of the piece image to the center of the square.
+    # This keeps the pieces properly grounded regardless of perspective, eliminating
+    # the need for manual row-based y-shifts.
     set pieceImg $::board::letterToPiece($piece)$pieceSize
     set tags [list board3d p$sq]
-    if {[catch { $bd create image $cx $cy -image $pieceImg -tag $tags -anchor c }]} {
+    if {[catch { $bd create image $cx $cy -image $pieceImg -tag $tags -anchor s }]} {
       foreach s $::boardSizes {
         set pieceImg $::board::letterToPiece($piece)$s
         if {![catch {image width $pieceImg}]} {
-          $bd create image $cx $cy -image $pieceImg -tag $tags -anchor c
+          $bd create image $cx $cy -image $pieceImg -tag $tags -anchor s
           break
         }
       }

--- a/tcl/game.tcl
+++ b/tcl/game.tcl
@@ -386,6 +386,7 @@ namespace eval ::notify {
 
     ::board::setmarks .main.board [sc_pos getComment]
     ::board::update .main.board [sc_pos board] [expr {$animate ne ""}]
+    ::windows::game3d::update
 
     after cancel ::notify::privPosChanged
     if {$pgnNeedsUpdate} { after idle ::notify::privGameTextChanged }

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -1823,6 +1823,13 @@ translate J SetupBoard {Сетуп Боард}
 translate J Rotate {Ротирај}
 translate J SwitchColors {Замените боје}
 translate J FlipBoard {Флип Боард}
+translate J Board3D {3Д плоча}
+translate J Board3DReset {Ресетуј}
+translate J Board3DResetTip {Вратите камеру на подразумевани приказ}
+translate J Board3DZoomIn {Увећај}
+translate J Board3DZoomOut {Зоом Оут}
+translate J Board3DDragToRotate {Превуците да бисте ротирали}
+translate J Board3DScrollToZoom {Скролујте да бисте зумирали}
 translate J ImportPGN {Увезите ПГН игру}
 translate J ImportingFiles {Увоз ПГН датотека у}
 translate J ImportingFrom {Увоз из}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -1782,6 +1782,13 @@ translate b SetupBoard {সেটআপ বোর্ড}
 translate b Rotate {ঘোরান}
 translate b SwitchColors {রঙ পরিবর্তন করুন}
 translate b FlipBoard {ফ্লিপ বোর্ড}
+translate b Board3D {3D বোর্ড}
+translate b Board3DReset {রিসেট করুন}
+translate b Board3DResetTip {ডিফল্ট ভিউতে ক্যামেরা রিসেট করুন}
+translate b Board3DZoomIn {জুম ইন করুন}
+translate b Board3DZoomOut {জুম আউট করুন}
+translate b Board3DDragToRotate {ঘোরাতে টেনে আনুন}
+translate b Board3DScrollToZoom {জুম করতে স্ক্রোল করুন}
 translate b ImportPGN {PGN গেম ইম্পোর্ট করুন}
 translate b ImportingFiles {PGN ফাইল আমদানি করা হচ্ছে}
 translate b ImportingFrom {থেকে আমদানি করা হচ্ছে}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -1823,6 +1823,13 @@ translate g SetupBoard {Табло за настройка}
 translate g Rotate {Завъртете}
 translate g SwitchColors {Превключете цветовете}
 translate g FlipBoard {Flip Board}
+translate g Board3D {3D дъска}
+translate g Board3DReset {Нулиране}
+translate g Board3DResetTip {Нулирайте камерата към изгледа по подразбиране}
+translate g Board3DZoomIn {Увеличете}
+translate g Board3DZoomOut {Намаляване}
+translate g Board3DDragToRotate {Плъзнете, за да завъртите}
+translate g Board3DScrollToZoom {Превъртете, за да увеличите}
 translate g ImportPGN {Импортирайте PGN игра}
 translate g ImportingFiles {Импортиране на PGN файлове}
 translate g ImportingFrom {Импортиране от}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -1826,6 +1826,13 @@ translate K SetupBoard {Configura posició}
 translate K Rotate {Gira}
 translate K SwitchColors {Canvia colors}
 translate K FlipBoard {Gira tauler}
+translate K Board3D {Tauler 3D}
+translate K Board3DReset {Restableix}
+translate K Board3DResetTip {Restableix la càmera a la vista predeterminada}
+translate K Board3DZoomIn {Apropa}
+translate K Board3DZoomOut {Allunya el zoom}
+translate K Board3DDragToRotate {Arrossegueu per girar}
+translate K Board3DScrollToZoom {Desplaceu-vos per fer zoom}
 translate K ImportPGN {Importa partida en PGN}
 translate K ImportingFiles {Important fitxers PGN a}
 translate K ImportingFrom {Important des de}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1758,6 +1758,13 @@ translate M SetupBoard {设置板}
 translate M Rotate {旋转}
 translate M SwitchColors {切换颜色}
 translate M FlipBoard {翻板}
+translate M Board3D {3D板}
+translate M Board3DReset {重置}
+translate M Board3DResetTip {将相机重置为默认视图}
+translate M Board3DZoomIn {放大}
+translate M Board3DZoomOut {缩小}
+translate M Board3DDragToRotate {拖动旋转}
+translate M Board3DScrollToZoom {滚动缩放}
 translate M ImportPGN {导入PGN游戏}
 translate M ImportingFiles {将 PGN 文件导入}
 translate M ImportingFrom {导入自}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -1804,6 +1804,13 @@ translate C SetupBoard {Instalan deska}
 translate C Rotate {Stdat}
 translate C SwitchColors {Pepnout barvy}
 translate C FlipBoard {Flip Board}
+translate C Board3D {3D deska}
+translate C Board3DReset {Resetovat}
+translate C Board3DResetTip {Obnovte výchozí zobrazení fotoaparátu}
+translate C Board3DZoomIn {Přiblížit}
+translate C Board3DZoomOut {Oddálit}
+translate C Board3DDragToRotate {Přetažením otočte}
+translate C Board3DScrollToZoom {Přejděte k přiblížení}
 translate C ImportPGN {Importujte hru PGN}
 translate C ImportingFiles {Import soubor PGN do}
 translate C ImportingFrom {Import z}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -1854,6 +1854,13 @@ translate D SetupBoard {Stellung eingeben}
 translate D Rotate {Drehen}
 translate D SwitchColors {Farbe wechseln}
 translate D FlipBoard {Brett drehen}
+translate D Board3D {3D-Brett}
+translate D Board3DReset {Zurücksetzen}
+translate D Board3DResetTip {Kamera auf Standardansicht zurücksetzen}
+translate D Board3DZoomIn {Vergrößern}
+translate D Board3DZoomOut {Herauszoomen}
+translate D Board3DDragToRotate {Zum Drehen ziehen}
+translate D Board3DScrollToZoom {Zum Zoomen scrollen}
 translate D ImportPGN {Importiere PGN Partieen}
 translate D ImportingFiles {Importiere PGN Dateien nach}
 translate D ImportingFrom {Importiere von}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -1836,6 +1836,13 @@ translate E SetupBoard {Setup Board}
 translate E Rotate {Rotate}
 translate E SwitchColors {Switch colors}
 translate E FlipBoard {Flip Board}
+translate E Board3D {3D Board}
+translate E Board3DReset {Reset}
+translate E Board3DResetTip {Reset camera to default view}
+translate E Board3DZoomIn {Zoom In}
+translate E Board3DZoomOut {Zoom Out}
+translate E Board3DDragToRotate {Drag to rotate}
+translate E Board3DScrollToZoom {Scroll to zoom}
 translate E ImportPGN {Import PGN game}
 translate E ImportingFiles {Importing PGN files in}
 translate E ImportingFrom {Importing from}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -1810,6 +1810,13 @@ translate F SetupBoard {Définir la position de départ}
 translate F Rotate {Rotation}
 translate F SwitchColors {Changer de couleur}
 translate F FlipBoard {Retourner l'échiquier}
+translate F Board3D {Tableau 3D}
+translate F Board3DReset {Réinitialiser}
+translate F Board3DResetTip {Réinitialiser la caméra à la vue par défaut}
+translate F Board3DZoomIn {Zoomer}
+translate F Board3DZoomOut {Zoom arrière}
+translate F Board3DDragToRotate {Faites glisser pour faire pivoter}
+translate F Board3DScrollToZoom {Faites défiler pour zoomer}
 translate F ImportPGN {Importer un jeu PGN}
 translate F ImportingFiles {Importer des fichiers PGN dans}
 translate F ImportingFrom {Importation de}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -1831,6 +1831,13 @@ translate G SetupBoard {Πίνακας εγκατάστασης}
 translate G Rotate {Γυρίζω}
 translate G SwitchColors {Εναλλαγή χρωμάτων}
 translate G FlipBoard {Flip Board}
+translate G Board3D {3D πίνακας}
+translate G Board3DReset {Επαναφορά}
+translate G Board3DResetTip {Επαναφέρετε την κάμερα στην προεπιλεγμένη προβολή}
+translate G Board3DZoomIn {Μεγέθυνση}
+translate G Board3DZoomOut {Σμίκρυνση}
+translate G Board3DDragToRotate {Σύρετε για περιστροφή}
+translate G Board3DScrollToZoom {Κάντε κύλιση για μεγέθυνση}
 translate G ImportPGN {Εισαγωγή παιχνιδιού PGN}
 translate G ImportingFiles {Εισαγωγή αρχείων PGN σε}
 translate G ImportingFrom {Εισαγωγή από}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -1783,6 +1783,13 @@ translate V SetupBoard {לוח התקנה}
 translate V Rotate {לְסוֹבֵב}
 translate V SwitchColors {החלף צבעים}
 translate V FlipBoard {Flip Board}
+translate V Board3D {לוח תלת מימד}
+translate V Board3DReset {אִתחוּל}
+translate V Board3DResetTip {אפס את המצלמה לתצוגת ברירת המחדל}
+translate V Board3DZoomIn {לְהִתְמַקֵד}
+translate V Board3DZoomOut {זום אאוט}
+translate V Board3DDragToRotate {גרור כדי לסובב}
+translate V Board3DScrollToZoom {גלול להגדלה}
 translate V ImportPGN {ייבוא משחק PGN}
 translate V ImportingFiles {ייבוא קבצי PGN פנימה}
 translate V ImportingFrom {מייבא מ}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -1782,6 +1782,13 @@ translate h SetupBoard {सेटअप बोर्ड}
 translate h Rotate {घुमाएँ}
 translate h SwitchColors {रंग बदलें}
 translate h FlipBoard {फ्लिप बोर्ड}
+translate h Board3D {3डी बोर्ड}
+translate h Board3DReset {रीसेट करें}
+translate h Board3DResetTip {कैमरे को डिफ़ॉल्ट दृश्य पर रीसेट करें}
+translate h Board3DZoomIn {ज़ूम इन}
+translate h Board3DZoomOut {ज़ूम आउट}
+translate h Board3DDragToRotate {घुमाने के लिए खींचें}
+translate h Board3DScrollToZoom {ज़ूम करने के लिए स्क्रॉल करें}
 translate h ImportPGN {पीजीएन गेम आयात करें}
 translate h ImportingFiles {पीजीएन फ़ाइलें आयात करना}
 translate h ImportingFrom {से आयात किया जा रहा है}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -1805,6 +1805,13 @@ translate H SetupBoard {Beállítási tábla}
 translate H Rotate {Forog}
 translate H SwitchColors {Válts színeket}
 translate H FlipBoard {Flip Board}
+translate H Board3D {3D tábla}
+translate H Board3DReset {Reset}
+translate H Board3DResetTip {A kamera visszaállítása az alapértelmezett nézetre}
+translate H Board3DZoomIn {Nagyítás}
+translate H Board3DZoomOut {Kicsinyítés}
+translate H Board3DDragToRotate {Húzza az elforgatáshoz}
+translate H Board3DScrollToZoom {Görgessen a nagyításhoz}
 translate H ImportPGN {PGN játék importálása}
 translate H ImportingFiles {PGN fájlok importálása}
 translate H ImportingFrom {Importálás innen}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -1806,6 +1806,13 @@ translate I SetupBoard {Scheda di installazione}
 translate I Rotate {Ruotare}
 translate I SwitchColors {Cambia i colori}
 translate I FlipBoard {Lavagna ribaltabile}
+translate I Board3D {Scheda 3D}
+translate I Board3DReset {Reset}
+translate I Board3DResetTip {Ripristina la visualizzazione predefinita della fotocamera}
+translate I Board3DZoomIn {Ingrandisci}
+translate I Board3DZoomOut {Rimpicciolisci}
+translate I Board3DDragToRotate {Trascina per ruotare}
+translate I Board3DScrollToZoom {Scorri per ingrandire}
 translate I ImportPGN {Importa il gioco PGN}
 translate I ImportingFiles {Importazione di file PGN in}
 translate I ImportingFrom {Importazione da}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -1823,6 +1823,13 @@ translate A SetupBoard {セットアップボード}
 translate A Rotate {回転}
 translate A SwitchColors {色の切り替え}
 translate A FlipBoard {フリップボード}
+translate A Board3D {3Dボード}
+translate A Board3DReset {リセット}
+translate A Board3DResetTip {カメラをデフォルトのビューにリセット}
+translate A Board3DZoomIn {ズームイン}
+translate A Board3DZoomOut {ズームアウト}
+translate A Board3DDragToRotate {ドラッグして回転します}
+translate A Board3DScrollToZoom {スクロールしてズーム}
 translate A ImportPGN {PGN ゲームをインポートする}
 translate A ImportingFiles {PGN ファイルをインポートする}
 translate A ImportingFrom {からのインポート}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -1823,6 +1823,13 @@ translate k SetupBoard {설정 보드}
 translate k Rotate {회전}
 translate k SwitchColors {색상 전환}
 translate k FlipBoard {플립보드}
+translate k Board3D {3D 보드}
+translate k Board3DReset {다시 놓기}
+translate k Board3DResetTip {카메라를 기본 보기로 재설정}
+translate k Board3DZoomIn {확대}
+translate k Board3DZoomOut {축소}
+translate k Board3DDragToRotate {드래그하여 회전}
+translate k Board3DScrollToZoom {스크롤하여 확대/축소}
 translate k ImportPGN {PGN 게임 가져오기}
 translate k ImportingFiles {PGN 파일 가져오기}
 translate k ImportingFrom {다음에서 가져오기}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -1829,6 +1829,13 @@ translate N SetupBoard {Opstellingsbord}
 translate N Rotate {Draaien}
 translate N SwitchColors {Wissel van kleur}
 translate N FlipBoard {Flipbord}
+translate N Board3D {3D-bord}
+translate N Board3DReset {Opnieuw instellen}
+translate N Board3DResetTip {Reset de camera naar de standaardweergave}
+translate N Board3DZoomIn {Inzoomen}
+translate N Board3DZoomOut {Uitzoomen}
+translate N Board3DDragToRotate {Sleep om te roteren}
+translate N Board3DScrollToZoom {Scroll om te zoomen}
 translate N ImportPGN {PGN-spel importeren}
 translate N ImportingFiles {PGN-bestanden importeren in}
 translate N ImportingFrom {Importeren van}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -1804,6 +1804,13 @@ translate O SetupBoard {Oppsettbrett}
 translate O Rotate {Rotere}
 translate O SwitchColors {Bytt farger}
 translate O FlipBoard {Flipbrett}
+translate O Board3D {3D-brett}
+translate O Board3DReset {Tilbakestill}
+translate O Board3DResetTip {Tilbakestill kameraet til standardvisning}
+translate O Board3DZoomIn {Zoom inn}
+translate O Board3DZoomOut {Zoom ut}
+translate O Board3DDragToRotate {Dra for å rotere}
+translate O Board3DScrollToZoom {Rull for å zoome}
 translate O ImportPGN {Importer PGN-spill}
 translate O ImportingFiles {Importerer PGN-filer inn}
 translate O ImportingFrom {Importerer fra}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -1824,6 +1824,13 @@ translate P SetupBoard {Pyta konfiguracyjna}
 translate P Rotate {Obraca}
 translate P SwitchColors {Zmie kolor}
 translate P FlipBoard {Odwie tablic}
+translate P Board3D {Tablica 3D}
+translate P Board3DReset {Nastawić}
+translate P Board3DResetTip {Zresetuj kamerę do widoku domyślnego}
+translate P Board3DZoomIn {Powiększ}
+translate P Board3DZoomOut {Pomniejsz}
+translate P Board3DDragToRotate {Przeciągnij, aby obrócić}
+translate P Board3DScrollToZoom {Przewiń, aby powiększyć}
 translate P ImportPGN {Importuj gr PGN}
 translate P ImportingFiles {Importowanie plikw PGN w formacie PDF}
 translate P ImportingFrom {Importowanie z}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -1812,6 +1812,13 @@ translate B SetupBoard {Definir tabuleiro}
 translate B Rotate {Rotacionar}
 translate B SwitchColors {Trocar cores}
 translate B FlipBoard {Virar o tabuleiro}
+translate B Board3D {Quadro 3D}
+translate B Board3DReset {Reiniciar}
+translate B Board3DResetTip {Redefinir a câmera para visualização padrão}
+translate B Board3DZoomIn {Ampliar}
+translate B Board3DZoomOut {Diminuir zoom}
+translate B Board3DDragToRotate {Arraste para girar}
+translate B Board3DScrollToZoom {Role para ampliar}
 translate B ImportPGN {Importar jogo em PGN}
 translate B ImportingFiles {Importar arquivos PGN para}
 translate B ImportingFrom {Importando de}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -1823,6 +1823,13 @@ translate L SetupBoard {Placă de configurare}
 translate L Rotate {Roti}
 translate L SwitchColors {Schimbați culorile}
 translate L FlipBoard {Flip Board}
+translate L Board3D {Placă 3D}
+translate L Board3DReset {Resetați}
+translate L Board3DResetTip {Resetați camera la vizualizarea implicită}
+translate L Board3DZoomIn {Măriți}
+translate L Board3DZoomOut {Micșorați}
+translate L Board3DDragToRotate {Trageți pentru a roti}
+translate L Board3DScrollToZoom {Derulați pentru a mări}
 translate L ImportPGN {Importați jocul PGN}
 translate L ImportingFiles {Importul fișierelor PGN în}
 translate L ImportingFrom {Import de la}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -1806,6 +1806,13 @@ translate R SetupBoard {Настроить доску}
 translate R Rotate {Повернуть}
 translate R SwitchColors {Переключить цвета}
 translate R FlipBoard {Повернуть доску}
+translate R Board3D {3D доска}
+translate R Board3DReset {Перезагрузить}
+translate R Board3DResetTip {Сбросить камеру к виду по умолчанию}
+translate R Board3DZoomIn {Увеличить масштаб}
+translate R Board3DZoomOut {Уменьшить масштаб}
+translate R Board3DDragToRotate {Перетащите, чтобы повернуть}
+translate R Board3DScrollToZoom {Прокрутите, чтобы увеличить}
 translate R ImportPGN {Импортировать файл PGN}
 translate R ImportingFiles {Импортировать файлы PGN в}
 translate R ImportingFrom {Импортировать из}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -3010,6 +3010,20 @@ translate Y SwitchColors {Switch colors}
 # ====== TODO To be translated ======
 translate Y FlipBoard {Flip Board}
 # ====== TODO To be translated ======
+translate Y Board3D {3D Board}
+# ====== TODO To be translated ======
+translate Y Board3DReset {Reset}
+# ====== TODO To be translated ======
+translate Y Board3DResetTip {Reset camera to default view}
+# ====== TODO To be translated ======
+translate Y Board3DZoomIn {Zoom In}
+# ====== TODO To be translated ======
+translate Y Board3DZoomOut {Zoom Out}
+# ====== TODO To be translated ======
+translate Y Board3DDragToRotate {Drag to rotate}
+# ====== TODO To be translated ======
+translate Y Board3DScrollToZoom {Scroll to zoom}
+# ====== TODO To be translated ======
 translate Y ImportPGN {Import PGN game}
 # ====== TODO To be translated ======
 translate Y ImportingFiles {Importing PGN files in}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -1857,6 +1857,13 @@ translate S SetupBoard {Tablero de configuración}
 translate S Rotate {Girar}
 translate S SwitchColors {Cambiar colores}
 translate S FlipBoard {Tablero giratorio}
+translate S Board3D {Tablero 3D}
+translate S Board3DReset {Reiniciar}
+translate S Board3DResetTip {Restablecer la cámara a la vista predeterminada}
+translate S Board3DZoomIn {Dar un golpe de zoom}
+translate S Board3DZoomOut {Alejar}
+translate S Board3DDragToRotate {Arrastrar para rotar}
+translate S Board3DScrollToZoom {Desplácese para ampliar}
 translate S ImportPGN {Importar juego PGN}
 translate S ImportingFiles {Importar archivos PGN en}
 translate S ImportingFrom {Importando desde}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -1835,6 +1835,13 @@ translate U SetupBoard {Asennustaulu}
 translate U Rotate {Kiertää}
 translate U SwitchColors {Vaihda värejä}
 translate U FlipBoard {Flip Board}
+translate U Board3D {3D-taulu}
+translate U Board3DReset {Nollaa}
+translate U Board3DResetTip {Palauta kamera oletusnäkymään}
+translate U Board3DZoomIn {Lähennä}
+translate U Board3DZoomOut {Loitonna}
+translate U Board3DDragToRotate {Vedä kiertääksesi}
+translate U Board3DScrollToZoom {Vieritä zoomaukseen}
 translate U ImportPGN {Tuo PGN-peli}
 translate U ImportingFiles {PGN-tiedostojen tuonti sisään}
 translate U ImportingFrom {Tuodaan kohteesta}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -1782,6 +1782,13 @@ translate Z SetupBoard {Bodi ya Kuweka}
 translate Z Rotate {Zungusha}
 translate Z SwitchColors {Badilisha rangi}
 translate Z FlipBoard {Ubao Mgeuzo}
+translate Z Board3D {Bodi ya 3D}
+translate Z Board3DReset {Weka upya}
+translate Z Board3DResetTip {Weka upya kamera iwe mwonekano chaguomsingi}
+translate Z Board3DZoomIn {Kuza}
+translate Z Board3DZoomOut {Zoom Out}
+translate Z Board3DDragToRotate {Buruta ili kuzungusha}
+translate Z Board3DScrollToZoom {Sogeza ili kukuza}
 translate Z ImportPGN {Ingiza mchezo wa PGN}
 translate Z ImportingFiles {Inaleta faili za PGN ndani}
 translate Z ImportingFrom {Inaleta kutoka}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -1810,6 +1810,13 @@ translate W SetupBoard {Installationsbräda}
 translate W Rotate {Rotera}
 translate W SwitchColors {Byt färger}
 translate W FlipBoard {Blädderbräda}
+translate W Board3D {3D-bräda}
+translate W Board3DReset {Återställa}
+translate W Board3DResetTip {Återställ kameran till standardvyn}
+translate W Board3DZoomIn {Zooma in}
+translate W Board3DZoomOut {Zooma ut}
+translate W Board3DDragToRotate {Dra för att rotera}
+translate W Board3DScrollToZoom {Bläddra för att zooma}
 translate W ImportPGN {Importera PGN-spel}
 translate W ImportingFiles {Importera PGN-filer till}
 translate W ImportingFrom {Importerar från}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -1786,6 +1786,13 @@ translate T SetupBoard {Kurulum Panosu}
 translate T Rotate {Döndür}
 translate T SwitchColors {Renkleri değiştir}
 translate T FlipBoard {Çevirme Tahtası}
+translate T Board3D {3D Tahta}
+translate T Board3DReset {Sıfırla}
+translate T Board3DResetTip {Kamerayı varsayılan görünüme sıfırla}
+translate T Board3DZoomIn {Yakınlaştır}
+translate T Board3DZoomOut {Uzaklaştır}
+translate T Board3DDragToRotate {Döndürmek için sürükleyin}
+translate T Board3DScrollToZoom {Yakınlaştırmak için kaydırın}
 translate T ImportPGN {PGN oyununu içe aktar}
 translate T ImportingFiles {PGN dosyalarını içe aktarma}
 translate T ImportingFrom {Şuradan içe aktarılıyor:}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -1783,6 +1783,13 @@ translate Q SetupBoard {Налаштування дошки}
 translate Q Rotate {Обертати}
 translate Q SwitchColors {Перемикайте кольори}
 translate Q FlipBoard {Flip Board}
+translate Q Board3D {3D дошка}
+translate Q Board3DReset {Скинути}
+translate Q Board3DResetTip {Скинути камеру до стандартного вигляду}
+translate Q Board3DZoomIn {Збільшити}
+translate Q Board3DZoomOut {Зменшити}
+translate Q Board3DDragToRotate {Перетягніть, щоб повернути}
+translate Q Board3DScrollToZoom {Прокрутіть, щоб збільшити}
 translate Q ImportPGN {Імпорт гри PGN}
 translate Q ImportingFiles {Імпорт файлів PGN}
 translate Q ImportingFrom {Імпорт з}

--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -243,6 +243,7 @@ $m add checkbutton -label WindowsStats -variable ::windows::stats::isOpen -accel
 $m add checkbutton -label WindowsTree -variable treeWin -command ::tree::make -accelerator "Ctrl+T"
 $m add checkbutton -label WindowsBook -variable ::book::isOpen -command ::book::open -accelerator "F6"
 $m add checkbutton -label [tr TablebaseWindow] -variable ::tablebase::window::isOpen -command ::tablebase::window::Open -accelerator "Ctrl+="
+$m add checkbutton -label [tr Board3D] -variable ::windows::game3d::isOpen -command ::windows::game3d::toggle -accelerator "Ctrl+3"
 $m add command -label WindowsGraph -command ::tools::graphs::score::Refresh
 
 

--- a/tcl/start.tcl
+++ b/tcl/start.tcl
@@ -1007,6 +1007,8 @@ help/tips.tcl
 keyboard.tcl
 menus.tcl
 board.tcl
+board3d.tcl
+windows/game3d.tcl
 move.tcl
 main.tcl
 tools/uci.tcl

--- a/tcl/windows/game3d.tcl
+++ b/tcl/windows/game3d.tcl
@@ -1,0 +1,113 @@
+
+# game3d.tcl: part of Scid
+# Copyright (C) 2021-2026
+#
+# 3D board window wrapper using the board3d renderer.
+
+namespace eval ::windows::game3d {
+  set isOpen 0
+}
+
+# ::windows::game3d::toggle --
+#   Called from the menu checkbutton.
+#   IMPORTANT: The menu checkbutton toggles the -variable BEFORE calling -command,
+#   so this proc acts as a simple open/close switch: if window exists, destroy it;
+#   if not, create it. Same pattern as ::tree::make and ::book::open.
+#
+proc ::windows::game3d::toggle {} {
+  set w .game3dWin
+  if {[winfo exists $w]} {
+    destroy $w
+    return
+  }
+
+  if {[catch { ::windows::game3d::_create $w } err]} {
+    tk_messageBox -title ScidCommunity -type ok -icon error \
+        -message "Failed to open 3D board:\n$err\n\n$::errorInfo"
+    set ::windows::game3d::isOpen 0
+    return
+  }
+}
+
+# ::windows::game3d::Close --
+#   Closes the 3D board window explicitly.
+#
+proc ::windows::game3d::Close {} {
+  set w .game3dWin
+  if {[winfo exists $w]} {
+    destroy $w
+  }
+}
+
+# ::windows::game3d::_create --
+#   Internal: builds the window contents.
+#
+proc ::windows::game3d::_create {w} {
+  toplevel $w
+  wm title $w "Scid: [tr Board3D]"
+  wm minsize $w 400 400
+  wm geometry $w 1040x1080
+
+  bind $w <Destroy> {
+    if {[string equal %W .game3dWin]} {
+      set ::windows::game3d::isOpen 0
+    }
+  }
+
+  # Main frame
+  ttk::frame $w.f -padding 2
+  pack $w.f -expand 1 -fill both
+
+  # Create the 3D board
+  set bd $w.f.board3d
+  ::board3d::new $bd $::boardSize
+  ::board3d::showMarks $bd $::gameInfo(showMarks)
+  pack $bd -expand 1 -fill both
+
+  # --- Toolbar ---
+  set tb $w.f.toolbar
+  ttk::frame $tb
+  pack $tb -side bottom -fill x -pady {4 0}
+
+  ttk::button $tb.flip -image ::icon::tb_flip -style Toolbutton \
+      -command [list ::board3d::flip $bd]
+  ::utils::tooltip::Set $tb.flip "$::tr(FlipBoard)"
+
+  ttk::button $tb.reset -text [tr Board3DReset] -style Toolbutton \
+      -command [list ::board3d::reset $bd]
+
+  ttk::button $tb.zoomin -text "+" -style Toolbutton \
+      -command [list ::board3d::zoom $bd 1]
+
+  ttk::button $tb.zoomout -text "-" -style Toolbutton \
+      -command [list ::board3d::zoom $bd -1]
+
+  ttk::label $tb.info -text "[tr Board3DDragToRotate]  [tr Board3DScrollToZoom]"
+  pack $tb.flip $tb.reset $tb.zoomin $tb.zoomout $tb.info \
+      -side left -padx 2
+
+  # Resize binding — use the canvas's own configure event
+  bind $bd.bd <Configure> [list ::board3d::resize $bd %w %h]
+
+  # Initial position data
+  ::board3d::setmarks $bd [sc_pos getComment]
+  ::board3d::update $bd [sc_pos board]
+
+  ::update idletasks
+}
+
+# ::windows::game3d::update --
+#   Called from the position-changed notification.
+#   Safe to call even if window is not open.
+#
+proc ::windows::game3d::update {} {
+  if {!$::windows::game3d::isOpen} { return }
+  if {![winfo exists .game3dWin.f.board3d]} { return }
+  ::board3d::setmarks .game3dWin.f.board3d [sc_pos getComment]
+  ::board3d::update .game3dWin.f.board3d [sc_pos board]
+  ::update idletasks
+}
+
+# ----------------------------------------------------------------------
+# End of file: game3d.tcl
+# ----------------------------------------------------------------------


### PR DESCRIPTION
Adding a new feature to display a "pseudo-3D" board as a new option under the **Windows** menu (and Cntrl+3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive 3D chess board view with perspective rendering
  * Implemented camera controls: orbit via drag, zoom with scroll wheel, reset to default view, and board flip
  * Enabled piece dragging directly on the 3D board
  * Added Board3D menu option with keyboard shortcut (Ctrl+3)
  * Provided multilingual UI support for all 3D board controls and tooltips across 28+ languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->