### PR TITLE
refactor: allow multiple analysis windows by dynamically assigning en…

### DIFF
--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -764,6 +764,7 @@ translate J Annotate {Анотирајте}
 translate J ShowAnalysisBoard {Прикажи таблу за анализу}
 translate J ShowInfo {Прикажи информације о мотору}
 translate J FinishGame {Заврши игру}
+translate J FinishGameSlot2Warning {Слот 2 мотора је већ у употреби од стране отвореног прозора за анализу.\н\нФинисх Гаме користи слотове 1 и 2 мотора и може преузети контролу над тим мотором. Наставити?}
 translate J StopEngine {Зауставите мотор}
 translate J StartEngine {Покрените мотор}
 translate J LockEngine {Закључајте мотор у тренутни положај}

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -764,7 +764,7 @@ translate J Annotate {Анотирајте}
 translate J ShowAnalysisBoard {Прикажи таблу за анализу}
 translate J ShowInfo {Прикажи информације о мотору}
 translate J FinishGame {Заврши игру}
-translate J FinishGameSlot2Warning {Слот 2 мотора је већ у употреби од стране отвореног прозора за анализу.\н\нФинисх Гаме користи слотове 1 и 2 мотора и може преузети контролу над тим мотором. Наставити?}
+translate J FinishGameSlot2Warning {Слот 2 мотора је већ у употреби од стране отвореног прозора за анализу.\n\nФинисх Гаме користи слотове 1 и 2 мотора и може преузети контролу над тим мотором. Наставити?}
 translate J StopEngine {Зауставите мотор}
 translate J StartEngine {Покрените мотор}
 translate J LockEngine {Закључајте мотор у тренутни положај}

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -826,6 +826,7 @@ translate J EngineAddRemote {Додајте удаљени мотор}
 translate J EngineReload {Поново учитајте тренутни мотор}
 translate J EngineClone {Направите копију тренутног мотора}
 translate J EngineDelete {Избришите тренутни мотор}
+translate J EngineOpenAnalysis {Отворена анализа}
 
 # PGN window menus:
 menuText J PgnFile "Филе" 0

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -785,6 +785,7 @@ translate b EngineAddRemote {একটি দূরবর্তী ইঞ্জ�
 translate b EngineReload {বর্তমান ইঞ্জিন পুনরায় লোড করুন}
 translate b EngineClone {বর্তমান ইঞ্জিনের একটি অনুলিপি তৈরি করুন}
 translate b EngineDelete {বর্তমান ইঞ্জিন মুছুন}
+translate b EngineOpenAnalysis {খোলা বিশ্লেষণ}
 
 # PGN window menus:
 menuText b PgnFile "ফাইল" 0

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -723,6 +723,7 @@ translate b Annotate {টীকা}
 translate b ShowAnalysisBoard {বিশ্লেষণ বোর্ড দেখান}
 translate b ShowInfo {ইঞ্জিনের তথ্য দেখান}
 translate b FinishGame {খেলা শেষ করুন}
+translate b FinishGameSlot2Warning {ইঞ্জিন স্লট 2 ইতিমধ্যেই একটি খোলা বিশ্লেষণ উইন্ডো ব্যবহার করছে৷\n\nফিনিশ গেমটি ইঞ্জিন স্লট 1 এবং 2 ব্যবহার করে এবং সেই ইঞ্জিনের নিয়ন্ত্রণ নিতে পারে৷ চালিয়ে যান?}
 translate b StopEngine {ইঞ্জিন বন্ধ করুন}
 translate b StartEngine {ইঞ্জিন চালু করুন}
 translate b LockEngine {বর্তমান অবস্থানে ইঞ্জিন লক করুন}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -764,6 +764,7 @@ translate g Annotate {Анотирайте}
 translate g ShowAnalysisBoard {Показване на таблото за анализ}
 translate g ShowInfo {Показване на информация за двигателя}
 translate g FinishGame {Завършете играта}
+translate g FinishGameSlot2Warning {Слот 2 на машина вече се използва от отворен прозорец за анализ.\n\nFinish Game използва слотове 1 и 2 на машина и може да поеме контрола над тази машина. Продължаване?}
 translate g StopEngine {Спрете двигателя}
 translate g StartEngine {Стартирайте двигателя}
 translate g LockEngine {Заключете двигателя до текущата позиция}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -826,6 +826,7 @@ translate g EngineAddRemote {Добавете дистанционен двиг�
 translate g EngineReload {Презаредете текущия двигател}
 translate g EngineClone {Създайте копие на текущия двигател}
 translate g EngineDelete {Изтрийте текущия двигател}
+translate g EngineOpenAnalysis {Отворете Анализ}
 
 # PGN window menus:
 menuText g PgnFile "Файл" 0

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -811,6 +811,7 @@ translate K EngineAddRemote {Afegeix motor en remot}
 translate K EngineReload {Recarrega motor actual}
 translate K EngineClone {Crea una còpia del motor actual}
 translate K EngineDelete {Esborra el motor actual}
+translate K EngineOpenAnalysis {Anàlisi oberta}
 
 # PGN window menus:
 menuText K PgnFile "Arxiu" 0

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -749,6 +749,7 @@ translate K Annotate {Anotar}
 translate K ShowAnalysisBoard {Mostrar escaquer d'análisi}
 translate K ShowInfo {Mostra info del motor}
 translate K FinishGame {Finalitzar partida}
+translate K FinishGameSlot2Warning {L'espai de motor 2 ja està en ús per una finestra d'anàlisi oberta.\n\nFinalitza el joc utilitza els espais de motor 1 i 2 i pot prendre el control d'aquest motor. Continuar?}
 translate K StopEngine {Parar motor}
 translate K StartEngine {Iniciar motor}
 translate K LockEngine {Bloqueja motor en la posició actual}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -699,6 +699,7 @@ translate M Annotate {注释}
 translate M ShowAnalysisBoard {Show analysis board}
 translate M ShowInfo {Show engine info}
 translate M FinishGame {Finish game}
+translate M FinishGameSlot2Warning {引擎槽 2 已被打开的分析窗口使用。\n\n完成游戏使用引擎槽 1 和 2，并可能控制该引擎。继续？}
 translate M StopEngine {Stop engine}
 translate M StartEngine {Start engine}
 translate M LockEngine {Lock engine to current position}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -761,6 +761,7 @@ translate M EngineAddRemote {Add a remote engine}
 translate M EngineReload {Reload the current engine}
 translate M EngineClone {Create a copy of the current engine}
 translate M EngineDelete {Delete the current engine}
+translate M EngineOpenAnalysis {开放分析}
 
 # PGN window menus:
 menuText M PgnFile "直线" 0

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -728,6 +728,7 @@ translate C Annotate {Anotace}
 translate C ShowAnalysisBoard {Ukzat achovnici analzy}
 translate C ShowInfo {Ukzat informaci o hernm programu}
 translate C FinishGame {Ukonit partii}
+translate C FinishGameSlot2Warning {Slot motoru 2 je již používán otevřeným oknem analýzy.\n\nDokončit hru používá sloty motoru 1 a 2 a může převzít kontrolu nad tímto enginem. Pokračovat?}
 translate C StopEngine {Zastavit hern program}
 translate C StartEngine {Spustit hern program}
 translate C LockEngine {Uzamt hern program v aktuln pozici}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -790,6 +790,7 @@ translate C EngineAddRemote {Pidejte vzdlen motor}
 translate C EngineReload {Znovu natte aktuln motor}
 translate C EngineClone {Vytvote kopii aktulnho motoru}
 translate C EngineDelete {Smazat aktuln motor}
+translate C EngineOpenAnalysis {Otevřená analýza}
 
 # PGN window menus:
 menuText C PgnFile "Soubor" 0

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -825,6 +825,7 @@ translate D EngineAddRemote {Fügen Sie eine Remote-Engine hinzu}
 translate D EngineReload {Laden Sie die aktuelle Engine neu}
 translate D EngineClone {Erstellen Sie eine Kopie der aktuellen Engine}
 translate D EngineDelete {Löschen Sie die aktuelle Engine}
+translate D EngineOpenAnalysis {Offene Analyse}
 
 # PGN window menus:
 menuText D PgnFile "Datei" 0

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -763,6 +763,7 @@ translate D Annotate {Autom. kommentieren}
 translate D ShowAnalysisBoard {Analysebrett anzeigen}
 translate D ShowInfo {Engine-Information anzeigen}
 translate D FinishGame {Partie beenden}
+translate D FinishGameSlot2Warning {Engine-Slot 2 wird bereits von einem offenen Analysefenster verwendet.\n\nSpiel beenden verwendet die Engine-Slots 1 und 2 und kann die Kontrolle über diese Engine übernehmen. Weitermachen?}
 translate D StopEngine {Engine anhalten}
 translate D StartEngine {Engine starten}
 translate D LockEngine {Anbinden an aktuelle Position}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -763,6 +763,7 @@ translate E Annotate {Annotate}
 translate E ShowAnalysisBoard {Show analysis board}
 translate E ShowInfo {Show engine info}
 translate E FinishGame {Finish game}
+translate E FinishGameSlot2Warning {Engine slot 2 is already in use by an open Analysis window.\n\nFinish Game uses engine slots 1 and 2 and may take control of that engine. Continue?}
 translate E StopEngine {Stop engine}
 translate E StartEngine {Start engine}
 translate E LockEngine {Lock engine to current position}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -825,6 +825,7 @@ translate E EngineAddRemote {Add a remote engine}
 translate E EngineReload {Reload the current engine}
 translate E EngineClone {Create a copy of the current engine}
 translate E EngineDelete {Delete the current engine}
+translate E EngineOpenAnalysis {Open Analysis}
 
 # PGN window menus:
 menuText E PgnFile "File" 0

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -736,6 +736,7 @@ translate F Annotate {Annotation}
 translate F ShowAnalysisBoard {Montrer échiquier d'analyse}
 translate F ShowInfo {Montrer infos moteur}
 translate F FinishGame {Continuer la partie}
+translate F FinishGameSlot2Warning {L'emplacement de moteur 2 est déjà utilisé par une fenêtre d'analyse ouverte.\n\nFinish Game utilise les emplacements de moteur 1 et 2 et peut prendre le contrôle de ce moteur. Continuer?}
 translate F StopEngine {Arrêter le moteur}
 translate F StartEngine {Démarrer le moteur}
 translate F LockEngine {Verrouiller moteur à la position actuelle}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -736,7 +736,7 @@ translate F Annotate {Annotation}
 translate F ShowAnalysisBoard {Montrer échiquier d'analyse}
 translate F ShowInfo {Montrer infos moteur}
 translate F FinishGame {Continuer la partie}
-translate F FinishGameSlot2Warning {L'emplacement de moteur 2 est déjà utilisé par une fenêtre d'analyse ouverte.\n\nFinish Game utilise les emplacements de moteur 1 et 2 et peut prendre le contrôle de ce moteur. Continuer?}
+translate F FinishGameSlot2Warning {L'emplacement de moteur 2 est déjà utilisé par une fenêtre d'analyse ouverte.\n\nContinuer la partie utilise les emplacements de moteur 1 et 2 et peut prendre le contrôle de ce moteur. Continuer ?}
 translate F StopEngine {Arrêter le moteur}
 translate F StartEngine {Démarrer le moteur}
 translate F LockEngine {Verrouiller moteur à la position actuelle}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -798,6 +798,7 @@ translate F EngineAddRemote {Ajouter un moteur distant}
 translate F EngineReload {Recharger le moteur actuel}
 translate F EngineClone {Créer une copie du moteur actuel}
 translate F EngineDelete {Supprimer le moteur actuel}
+translate F EngineOpenAnalysis {Open Analysis}
 
 # PGN window menus:
 menuText F PgnFile "Fichier" 0

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -817,6 +817,7 @@ translate G EngineAddRemote {Προσθέστε έναν απομακρυσμέ�
 translate G EngineReload {Φορτώστε ξανά τον τρέχοντα κινητήρα}
 translate G EngineClone {Δημιουργήστε ένα αντίγραφο του τρέχοντος κινητήρα}
 translate G EngineDelete {Διαγράψτε τον τρέχοντα κινητήρα}
+translate G EngineOpenAnalysis {Ανοιχτή Ανάλυση}
 
 # PGN window menus:
 menuText G PgnFile "Αρχείο" 0

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -755,6 +755,7 @@ translate G Annotate {Υπομνηματισμός}
 translate G ShowAnalysisBoard {Εμφάνισης της σκακιέρας ανάλυσης}
 translate G ShowInfo {Εμφάνιση πληροφοριών μηχανής}
 translate G FinishGame {Ολοκλήρωση παρτίδας}
+translate G FinishGameSlot2Warning {Η υποδοχή 2 του κινητήρα χρησιμοποιείται ήδη από ένα ανοιχτό παράθυρο ανάλυσης.\n\nΤο Finish Game χρησιμοποιεί τις υποδοχές 1 και 2 του κινητήρα και μπορεί να αναλάβει τον έλεγχο αυτού του κινητήρα. Συνεχίζω;}
 translate G StopEngine {Διακοπή μηχανής}
 translate G StartEngine {Εκκίνηση μηχανής}
 translate G LockEngine {Κλείδωμα της μηχανής στην τρέχουσα θέση}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -724,6 +724,7 @@ translate V Annotate {הערה}
 translate V ShowAnalysisBoard {הצג לוח ניתוח}
 translate V ShowInfo {הצג מידע על מנוע}
 translate V FinishGame {סיים משחק}
+translate V FinishGameSlot2Warning {חריץ מנוע 2 כבר נמצא בשימוש על ידי חלון ניתוח פתוח.\n\nFinish Game משתמש בחריצי מנוע 1 ו-2 ועשוי להשתלט על המנוע הזה. לְהַמשִׁיך?}
 translate V StopEngine {עצור מנוע}
 translate V StartEngine {הפעל מנוע}
 translate V LockEngine {נעל את המנוע למצב הנוכחי}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -786,6 +786,7 @@ translate V EngineAddRemote {הוסף מנוע מרוחק}
 translate V EngineReload {טען מחדש את המנוע הנוכחי}
 translate V EngineClone {צור עותק של המנוע הנוכחי}
 translate V EngineDelete {מחק את המנוע הנוכחי}
+translate V EngineOpenAnalysis {פתח את הניתוח}
 
 # PGN window menus:
 menuText V PgnFile "קוֹבֶץ" 0

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -723,6 +723,7 @@ translate h Annotate {एन्नोटेट}
 translate h ShowAnalysisBoard {विश्लेषण बोर्ड दिखाएँ}
 translate h ShowInfo {इंजन की जानकारी दिखाएँ}
 translate h FinishGame {खेल ख़त्म करो}
+translate h FinishGameSlot2Warning {इंजन स्लॉट 2 पहले से ही एक खुली विश्लेषण विंडो द्वारा उपयोग में है।\n\nफिनिश गेम इंजन स्लॉट 1 और 2 का उपयोग करता है और उस इंजन का नियंत्रण ले सकता है। जारी रखना?}
 translate h StopEngine {इंजन बंद करो}
 translate h StartEngine {इंजन प्रारंभ करें}
 translate h LockEngine {इंजन को वर्तमान स्थिति में लॉक करें}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -785,6 +785,7 @@ translate h EngineAddRemote {एक रिमोट इंजन जोड़े
 translate h EngineReload {वर्तमान इंजन को पुनः लोड करें}
 translate h EngineClone {वर्तमान इंजन की एक प्रति बनाएँ}
 translate h EngineDelete {वर्तमान इंजन हटाएँ}
+translate h EngineOpenAnalysis {विश्लेषण खोलें}
 
 # PGN window menus:
 menuText h PgnFile "फ़ाइल" 0

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -793,6 +793,7 @@ translate H EngineAddRemote {Adjon hozzá egy távoli motort}
 translate H EngineReload {Töltse be újra az aktuális motort}
 translate H EngineClone {Készítsen másolatot az aktuális motorról}
 translate H EngineDelete {Törölje az aktuális motort}
+translate H EngineOpenAnalysis {Nyissa meg az Elemzést}
 
 # PGN window menus:
 menuText H PgnFile "Fájl" 0

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -731,6 +731,7 @@ translate H Annotate {Lásd el értékelõ jelekkel}
 translate H ShowAnalysisBoard {Mutasd az elemzõtáblát}
 translate H ShowInfo {Mutasd a motor kiírásait}
 translate H FinishGame {Fejezd be a játszmát}
+translate H FinishGameSlot2Warning {A 2. motorhelyet már használja egy megnyitott elemzési ablak.\n\nA játék befejezése az 1. és 2. motorhelyet használja, és átveheti az irányítást a motor felett. Folytatja?}
 translate H StopEngine {Állítsd le a motort}
 translate H StartEngine {Indítsd el a motort}
 translate H LockEngine {Tartsd a motort ennél az állásnál}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -796,6 +796,7 @@ translate I EngineAddRemote {Aggiunge un motore remoto}
 translate I EngineReload {Ricarica il motore corrente}
 translate I EngineClone {Crea una copia del motore corrente}
 translate I EngineDelete {Elimina il motore corrente}
+translate I EngineOpenAnalysis {Apri analisi}
 
 # PGN window menus:
 menuText I PgnFile "File" 0

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -734,6 +734,7 @@ translate I Annotate {Annota}
 translate I ShowAnalysisBoard {Mostra la finestra dell'analisi}
 translate I ShowInfo {Mostra le informazioni del motore}
 translate I FinishGame {Termina la partita}
+translate I FinishGameSlot2Warning {Lo slot motore 2 è già utilizzato da una finestra di analisi aperta.\n\nFinisci gioco utilizza gli slot motore 1 e 2 e può prendere il controllo di quel motore. Continuare?}
 translate I StopEngine {Ferma il motore}
 translate I StartEngine {Avvia il motore}
 translate I LockEngine {Blocca il motore alla posizione corrente}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -826,6 +826,7 @@ translate A EngineAddRemote {リモート エンジンを追加する}
 translate A EngineReload {現在のエンジンをリロードします}
 translate A EngineClone {現在のエンジンのコピーを作成する}
 translate A EngineDelete {現在のエンジンを削除します}
+translate A EngineOpenAnalysis {オープン分析}
 
 # PGN window menus:
 menuText A PgnFile "ファイル" 0

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -764,6 +764,7 @@ translate A Annotate {Annotate}
 translate A ShowAnalysisBoard {分析ボードを表示する}
 translate A ShowInfo {エンジン情報を表示}
 translate A FinishGame {ゲームを終了する}
+translate A FinishGameSlot2Warning {エンジン スロット 2 は、開いている分析ウィンドウですでに使用されています。\n\nゲームを終了すると、エンジン スロット 1 と 2 が使用され、そのエンジンの制御が取得される可能性があります。続く？}
 translate A StopEngine {エンジンを停止する}
 translate A StartEngine {エンジンを始動する}
 translate A LockEngine {エンジンを現在の位置にロックする}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -764,6 +764,7 @@ translate k Annotate {달기}
 translate k ShowAnalysisBoard {분석판표시}
 translate k ShowInfo {엔진 정보 표시}
 translate k FinishGame {게임 종료}
+translate k FinishGameSlot2Warning {엔진 슬롯 2는 열려 있는 분석 창에서 이미 사용 중입니다.\n\nFinish Game은 엔진 슬롯 1과 2를 사용하며 해당 엔진을 제어할 수 있습니다. 계속하다?}
 translate k StopEngine {엔진 정지}
 translate k StartEngine {엔진의 변화}
 translate k LockEngine {엔진을 현재 위치로 고정}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -826,6 +826,7 @@ translate k EngineAddRemote {원격 엔진 추가}
 translate k EngineReload {현재 엔진을 다시 로드합니다.}
 translate k EngineClone {현재 엔진의 활동을 참여합니다.}
 translate k EngineDelete {현재 엔진 삭제}
+translate k EngineOpenAnalysis {공개 분석}
 
 # PGN window menus:
 menuText k PgnFile "파일" 0

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -753,6 +753,7 @@ translate N Annotate {Annotatie}
 translate N ShowAnalysisBoard {Toon het analysebord}
 translate N ShowInfo {Toon engine informatie}
 translate N FinishGame {Beeindig de partij}
+translate N FinishGameSlot2Warning {Engine-slot 2 wordt al gebruikt door een geopend analysevenster.\n\nFinish Game gebruikt engine-slots 1 en 2 en kan de controle over die engine overnemen. Doorgaan?}
 translate N StopEngine {Stop de engine}
 translate N StartEngine {Start de engine}
 translate N LockEngine {Fixeer de engine op de huidige stelling}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -815,6 +815,7 @@ translate N EngineAddRemote {Voeg een externe motor toe}
 translate N EngineReload {Herlaad de huidige engine}
 translate N EngineClone {Maak een kopie van de huidige engine}
 translate N EngineDelete {Verwijder de huidige engine}
+translate N EngineOpenAnalysis {Analyse openen}
 
 # PGN window menus:
 menuText N PgnFile "Bestand" 0

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -795,6 +795,7 @@ translate O EngineAddRemote {Legg til en ekstern motor}
 translate O EngineReload {Last inn gjeldende motor på nytt}
 translate O EngineClone {Lag en kopi av gjeldende motor}
 translate O EngineDelete {Slett gjeldende motor}
+translate O EngineOpenAnalysis {Åpne Analyse}
 
 # PGN window menus:
 menuText O PgnFile "Fil" 0

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -733,6 +733,7 @@ translate O Annotate {Annoter}
 translate O ShowAnalysisBoard {Vis analysetavle}
 translate O ShowInfo {Vis motorinfo}
 translate O FinishGame {Fullfør spillet}
+translate O FinishGameSlot2Warning {Motorspor 2 er allerede i bruk av et åpent analysevindu.\n\nFinish Game bruker motorspor 1 og 2 og kan ta kontroll over denne motoren. Fortsette?}
 translate O StopEngine {Stopp motoren}
 translate O StartEngine {Start motoren}
 translate O LockEngine {Lås motoren til gjeldende posisjon}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -744,6 +744,7 @@ translate P Annotate {Komentuj}
 translate P ShowAnalysisBoard {Poka tablic angielsk}
 translate P ShowInfo {Poka informacje o silniku}
 translate P FinishGame {Zakocz gr}
+translate P FinishGameSlot2Warning {Gniazdo silnika 2 jest już używane przez otwarte okno analizy.\n\nZakończ grę korzysta z gniazd silnika 1 i 2 i może przejąć kontrolę nad tym silnikiem. Kontynuować?}
 translate P StopEngine {Zatrzymaj silnik}
 translate P StartEngine {Uruchomiony silnik}
 translate P LockEngine {Zablokuj silnik w pozycjach biecych}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -806,6 +806,7 @@ translate P EngineAddRemote {Dodaj odczalny silnik}
 translate P EngineReload {Zaaduj ponownie rozruch}
 translate P EngineClone {Utwrz baz gwn}
 translate P EngineDelete {Usu uruchomienie silnika}
+translate P EngineOpenAnalysis {Otwarta analiza}
 
 # PGN window menus:
 menuText P PgnFile "Plik" 0

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -798,6 +798,7 @@ translate B EngineAddRemote {Adicionar um mecanismo remoto}
 translate B EngineReload {Recarregue o mecanismo atual}
 translate B EngineClone {Crie uma cópia do mecanismo atual}
 translate B EngineDelete {Exclua o mecanismo atual}
+translate B EngineOpenAnalysis {Análise aberta}
 
 # PGN window menus:
 menuText B PgnFile "Arquivo" 0

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -736,6 +736,7 @@ translate B Annotate {Anotar}
 translate B ShowAnalysisBoard {Mostrar tabuleiro de análise}
 translate B ShowInfo {Mostrar informações do engine}
 translate B FinishGame {Encerrar jogo}
+translate B FinishGameSlot2Warning {O slot 2 do mecanismo já está em uso por uma janela de análise aberta.\n\nConcluir O jogo usa os slots 1 e 2 do mecanismo e pode assumir o controle desse mecanismo. Continuar?}
 translate B StopEngine {Parar engine}
 translate B StartEngine {Iniciar engine}
 translate B LockEngine {Travar engine na posição corrente}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -764,6 +764,7 @@ translate L Annotate {Adnota}
 translate L ShowAnalysisBoard {Afișați panoul de analiză}
 translate L ShowInfo {Afișați informații despre motor}
 translate L FinishGame {Termină jocul}
+translate L FinishGameSlot2Warning {Slot pentru motor 2 este deja utilizat de o fereastră de analiză deschisă.\n\nFinish Game utilizează sloturile pentru motor 1 și 2 și poate prelua controlul asupra motorului respectiv. Continua?}
 translate L StopEngine {Opriți motorul}
 translate L StartEngine {Porniți motorul}
 translate L LockEngine {Blocați motorul în poziția curentă}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -826,6 +826,7 @@ translate L EngineAddRemote {Adăugați un motor de la distanță}
 translate L EngineReload {Reîncărcați motorul actual}
 translate L EngineClone {Creați o copie a motorului curent}
 translate L EngineDelete {Ștergeți motorul actual}
+translate L EngineOpenAnalysis {Analiză deschisă}
 
 # PGN window menus:
 menuText L PgnFile "Fişier" 0

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -730,6 +730,7 @@ translate R Annotate {Аннотация}
 translate R ShowAnalysisBoard {Показать доску анализа}
 translate R ShowInfo {Показать информацию движка}
 translate R FinishGame {Завершить партию}
+translate R FinishGameSlot2Warning {Слот движка 2 уже используется открытым окном анализа.\n\nЗавершить игру использует слоты движка 1 и 2 и может взять под свой контроль этот движок. Продолжать?}
 translate R StopEngine {Остановить движок}
 translate R StartEngine {Запустить движок}
 translate R LockEngine {Закрепить движок в этой позиции}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -792,6 +792,7 @@ translate R EngineAddRemote {Добавить удаленный двигате�
 translate R EngineReload {Перезагрузить текущий движок}
 translate R EngineClone {Создать действующую движку}
 translate R EngineDelete {Удалить текущий движок}
+translate R EngineOpenAnalysis {Открытый анализ}
 
 # PGN window menus:
 menuText R PgnFile "Файл" 0

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -1253,6 +1253,8 @@ translate Y EngineClone {Create a copy of the current engine}
 # ====== TODO To be translated ======
 translate Y EngineDelete {Delete the current engine}
 # ====== TODO To be translated ======
+translate Y EngineOpenAnalysis {Open Analysis}
+# ====== TODO To be translated ======
 menuText Y PgnFile "File" 0
 # ====== TODO To be translated ======
 menuText Y PgnFileCopy "Copy Game to Clipboard" 0

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -1139,6 +1139,8 @@ translate Y ShowInfo {Show engine info}
 # ====== TODO To be translated ======
 translate Y FinishGame {Finish game}
 # ====== TODO To be translated ======
+translate Y FinishGameSlot2Warning {Engine slot 2 is already in use by an open Analysis window.\n\nFinish Game uses engine slots 1 and 2 and may take control of that engine. Continue?}
+# ====== TODO To be translated ======
 translate Y StopEngine {Stop engine}
 # ====== TODO To be translated ======
 translate Y StartEngine {Start engine}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -780,6 +780,7 @@ translate S Annotate {Anotar}
 translate S ShowAnalysisBoard {Mostrar tablero de análisis}
 translate S ShowInfo {Muestra info del motor}
 translate S FinishGame {Finalizar partida}
+translate S FinishGameSlot2Warning {La ranura del motor 2 ya está en uso en una ventana de Análisis abierta.\n\nFinish Game utiliza las ranuras del motor 1 y 2 y puede tomar el control de ese motor. ¿Continuar?}
 translate S StopEngine {Parar motor}
 translate S StartEngine {Empezar motor}
 translate S LockEngine {Bloquea motor en posición actual}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -842,6 +842,7 @@ translate S EngineAddRemote {Agregar un motor remoto}
 translate S EngineReload {Recargar el motor actual}
 translate S EngineClone {Crear una copia del motor actual.}
 translate S EngineDelete {Eliminar el motor actual}
+translate S EngineOpenAnalysis {Análisis abierto}
 
 # PGN window menus:
 menuText S PgnFile "Archivo" 0

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -824,6 +824,7 @@ translate U EngineAddRemote {Lisää etämoottori}
 translate U EngineReload {Lataa nykyinen moottori uudelleen}
 translate U EngineClone {Luo kopio nykyisestä moottorista}
 translate U EngineDelete {Poista nykyinen moottori}
+translate U EngineOpenAnalysis {Avaa analyysi}
 
 # PGN window menus:
 menuText U PgnFile "Tiedosto" 0

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -762,6 +762,7 @@ translate U Annotate {Kommentoi}
 translate U ShowAnalysisBoard {Näytä analyysilauta}
 translate U ShowInfo {Näytä tiedot moottorista}
 translate U FinishGame {Lopeta peli}
+translate U FinishGameSlot2Warning {Moottoripaikka 2 on jo avoimen analyysiikkunan käytössä.\n\nFinish Game käyttää moottorin paikkoja 1 ja 2 ja saattaa ottaa kyseisen moottorin hallintaansa. Jatkaa?}
 translate U StopEngine {Pysäytä moottori}
 translate U StartEngine {Käynnistä moottori}
 translate U LockEngine {Lukitse moottori nykyiseen asemaan}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -723,6 +723,7 @@ translate Z Annotate {Dokeza}
 translate Z ShowAnalysisBoard {Onyesha ubao wa uchambuzi}
 translate Z ShowInfo {Onyesha habari ya injini}
 translate Z FinishGame {Maliza mchezo}
+translate Z FinishGameSlot2Warning {Nafasi ya injini 2 tayari inatumika kwenye dirisha lililofunguliwa la Uchambuzi.\n\nFinish Game hutumia nafasi za injini 1 na 2 na inaweza kuchukua udhibiti wa injini hiyo. Ungependa kuendelea?}
 translate Z StopEngine {Simamisha injini}
 translate Z StartEngine {Anza injini}
 translate Z LockEngine {Funga injini kwa nafasi ya sasa}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -785,6 +785,7 @@ translate Z EngineAddRemote {Ongeza injini ya mbali}
 translate Z EngineReload {Pakia tena injini ya sasa}
 translate Z EngineClone {Unda nakala ya injini ya sasa}
 translate Z EngineDelete {Futa injini ya sasa}
+translate Z EngineOpenAnalysis {Fungua Uchambuzi}
 
 # PGN window menus:
 menuText Z PgnFile "Faili" 0

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -734,6 +734,7 @@ translate W Annotate {Kommentera}
 translate W ShowAnalysisBoard {Visa Analysbräde}
 translate W ShowInfo {Visa schackmotorinformation}
 translate W FinishGame {Avsluta parti}
+translate W FinishGameSlot2Warning {Motorplats 2 används redan av ett öppet analysfönster.\n\nFinish Game använder motorplats 1 och 2 och kan ta kontroll över den motorn. Fortsätta?}
 translate W StopEngine {Stoppa schackmotor}
 translate W StartEngine {Starta schackmotor}
 translate W LockEngine {Lås schackmotor vid nuvarande position}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -796,6 +796,7 @@ translate W EngineAddRemote {Lägg till en fjärrmotor}
 translate W EngineReload {Ladda om den nuvarande motorn}
 translate W EngineClone {Skapa en kopia av den aktuella motorn}
 translate W EngineDelete {Ta bort den aktuella motorn}
+translate W EngineOpenAnalysis {Öppna Analys}
 
 # PGN window menus:
 menuText W PgnFile "Fil" 0

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -789,6 +789,7 @@ translate T EngineAddRemote {Uzak motor ekleme}
 translate T EngineReload {Mevcut motoru yeniden yükleyin}
 translate T EngineClone {Geçerli motorun bir kopyasını oluşturun}
 translate T EngineDelete {Mevcut motoru sil}
+translate T EngineOpenAnalysis {Açık Analiz}
 
 # PGN window menus:
 menuText T PgnFile "Dosya" 0

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -727,6 +727,7 @@ translate T Annotate {Açıklama ekle}
 translate T ShowAnalysisBoard {Analiz panosunu göster}
 translate T ShowInfo {Motor bilgilerini göster}
 translate T FinishGame {Oyunu bitir}
+translate T FinishGameSlot2Warning {Motor yuvası 2 zaten açık bir Analiz penceresi tarafından kullanılıyor.\n\nOyunu Bitir, motor yuvaları 1 ve 2'yi kullanır ve bu motorun kontrolünü ele geçirebilir. Devam etmek?}
 translate T StopEngine {Motoru durdur}
 translate T StartEngine {Motoru çalıştır}
 translate T LockEngine {Motoru mevcut konuma kilitle}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -724,6 +724,7 @@ translate Q Annotate {Анотуйте}
 translate Q ShowAnalysisBoard {Show analysis board}
 translate Q ShowInfo {Показати інформацію про двигун}
 translate Q FinishGame {Закінчити гру}
+translate Q FinishGameSlot2Warning {Слот двигуна 2 уже використовується відкритим вікном аналізу.\n\nFinish Game використовує слоти двигуна 1 і 2 і може взяти на себе контроль над цим механізмом. Продовжити?}
 translate Q StopEngine {Зупиніть двигун}
 translate Q StartEngine {Запустити двигун}
 translate Q LockEngine {Зафіксуйте двигун у поточному положенні}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -786,6 +786,7 @@ translate Q EngineAddRemote {Додайте віддалений двигун}
 translate Q EngineReload {Перезавантажте поточний двигун}
 translate Q EngineClone {Створіть копію поточного движка}
 translate Q EngineDelete {Видалити поточний механізм}
+translate Q EngineOpenAnalysis {Відкрити аналіз}
 
 # PGN window menus:
 menuText Q PgnFile "Файл" 0

--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -256,7 +256,7 @@ $m  add command -label ToolsStartEngine1 \
     -command "::enginewin::start 1" -accelerator "F2"
 $m  add command -label ToolsStartEngine2 \
     -command "::enginewin::start 2" -accelerator "F3"
-$m  add command -label ToolsAnalysis -command "makeAnalysisWin 1"
+$m  add command -label ToolsAnalysis -command "::enginelist::choose"
 $m add separator
 $m add checkbutton -label ToolsFilterGraph \
     -accelerator "Ctrl+Shift+G" -variable filterGraph -command tools::graphs::filter::Open

--- a/tcl/tools/analysis.tcl
+++ b/tcl/tools/analysis.tcl
@@ -1302,9 +1302,10 @@ proc makeAnalysisWin { {n 1} {index -1} {autostart 1}} {
     set n_engines [llength $::engines(list)]
     if { $index >= $n_engines} {
         if { $n_engines > 0 } {
-            tk_messageBox -message "Invalid Engine Number: [expr $index +1]"
+            set index 0
+        } else {
+            return
         }
-        return
     }
 
     set engineData [lindex $::engines(list) $index]

--- a/tcl/tools/analysis.tcl
+++ b/tcl/tools/analysis.tcl
@@ -1293,22 +1293,16 @@ proc makeAnalysisWin { {n 1} {index -1} {autostart 1}} {
     resetEngine $n
 
     if { $index < 0 } {
-        # engine selection dialog
-        set index [::enginelist::choose]
-        if { $index == "" ||  $index < 0 } { return }
-        catch {
-            ::enginelist::setTime $index
-        }
-    } else {
-        # F2, F3
-        set index [expr {$n - 1}]
+        # No engine specified: show the engine list. It opens the analysis
+        # window itself (in a free slot) once an engine is chosen.
+        ::enginelist::choose
+        return
     }
 
     set n_engines [llength $::engines(list)]
     if { $index >= $n_engines} {
         if { $n_engines > 0 } {
             tk_messageBox -message "Invalid Engine Number: [expr $index +1]"
-            makeAnalysisWin $n -1
         }
         return
     }
@@ -1890,6 +1884,14 @@ proc toggleFinishGame { { n 1 } } {
 		.analysisWin$n.b1.annotate configure -state normal
 		.analysisWin$n.b1.automove configure -state normal
 		return
+	}
+
+	# Safeguard: Finish Game uses engine slots 1 and 2. If slot 2 is already
+	# occupied by another Analysis window, warn before potentially taking it over.
+	if {[winfo exists .analysisWin2]} {
+		set ans [tk_messageBox -title "Scid: $::tr(FinishGame)" -icon warning -type okcancel \
+			-message $::tr(FinishGameSlot2Warning)]
+		if {$ans ne "ok"} { return }
 	}
 
 	set w .configFinishGame

--- a/tcl/tools/enginelist.tcl
+++ b/tcl/tools/enginelist.tcl
@@ -174,6 +174,30 @@ proc engine.singleclick_ {{w} {x} {y}} {
         ::enginelist::sort [$w column $col -id]
     }
 }
+# ::enginelist::freeSlot
+#   Returns the lowest analysis-window slot number (>= 1) that is not
+#   currently in use, so that multiple analysis windows can coexist.
+#
+proc ::enginelist::freeSlot {} {
+    set n 1
+    while {[winfo exists ".analysisWin$n"]} { incr n }
+    return $n
+}
+
+# ::enginelist::openSelected
+#   Opens an analysis window for the engine currently selected in the
+#   engine list, using the lowest free slot. If closeList is true the
+#   engine list dialog is closed afterwards (OK / Return); otherwise it
+#   stays open so several engines can be launched (double-click).
+#
+proc ::enginelist::openSelected {{closeList 1}} {
+    set sel [lindex [.enginelist.list.list selection] 0]
+    if {$sel eq "" || $sel < 0} { return }
+    catch { ::enginelist::setTime $sel }
+    if {$closeList} { destroy .enginelist }
+    ::makeAnalysisWin [::enginelist::freeSlot] $sel
+}
+
 proc ::enginelist::choose {} {
     global engines
     set w .enginelist
@@ -200,7 +224,7 @@ proc ::enginelist::choose {} {
     # The list of choices:
     pack $w.list -side top -fill y -expand 1
     pack $w.buttons -side top -fill x -pady { 5 0 }
-    bind $w.list.list <Double-ButtonRelease-1> "$w.buttons.ok invoke; break"
+    bind $w.list.list <Double-ButtonRelease-1> "::enginelist::openSelected 0; break"
     bind $w.list.list <ButtonRelease-1> "engine.singleclick_ %W %x %y"
 
     set f $w.buttons
@@ -213,11 +237,9 @@ proc ::enginelist::choose {} {
     }
     ttk::label $f.sep -text "   "
     dialogbutton $f.ok -text "OK" -command {
-        set engines(selection) [lindex [.enginelist.list.list selection] 0]
-        destroy .enginelist
+        ::enginelist::openSelected 1
     }
     dialogbutton $f.cancel -text $::tr(Cancel) -command {
-        set engines(selection) ""
         destroy .enginelist
     }
     packbuttons right $f.cancel $f.ok
@@ -229,10 +251,6 @@ proc ::enginelist::choose {} {
     bind $w <F1> { helpWindow Analysis List }
     bind $w <Escape> "destroy $w"
     bind $w.list.list <Return> "$w.buttons.ok invoke; break"
-    set engines(selection) ""
-    catch {grab $w}
-    tkwait window $w
-    return $engines(selection)
 }
 
 # ::enginelist::setTime

--- a/tcl/tools/enginelist.tcl
+++ b/tcl/tools/enginelist.tcl
@@ -236,13 +236,16 @@ proc ::enginelist::choose {} {
         ::enginelist::delete [lindex [.enginelist.list.list selection] 0]
     }
     ttk::label $f.sep -text "   "
-    dialogbutton $f.ok -text "OK" -command {
+    dialogbutton $f.open -text [tr EngineOpenAnalysis] -command {
         ::enginelist::openSelected 1
+    }
+    dialogbutton $f.ok -text "OK" -command {
+        destroy .enginelist
     }
     dialogbutton $f.cancel -text $::tr(Cancel) -command {
         destroy .enginelist
     }
-    packbuttons right $f.cancel $f.ok
+    packbuttons right $f.cancel $f.ok $f.open
     pack $f.add $f.edit $f.delete -side left -padx 1
 
     ::enginelist::sort
@@ -250,7 +253,7 @@ proc ::enginelist::choose {} {
     wm protocol $w WM_DELETE_WINDOW "destroy $w"
     bind $w <F1> { helpWindow Analysis List }
     bind $w <Escape> "destroy $w"
-    bind $w.list.list <Return> "$w.buttons.ok invoke; break"
+    bind $w.list.list <Return> "$w.buttons.open invoke; break"
 }
 
 # ::enginelist::setTime

--- a/tcl/utils/win.tcl
+++ b/tcl/utils/win.tcl
@@ -760,7 +760,7 @@ proc ::docking::create_window {wnd} {
       "\.(fdock)?glistWin([0-9]+)"    { ::windows::gamelist::Open }
       "\.(fdock)?treeWin([0-9]+)"     { ::tree::make [lindex $regmatch end]}
       "\.(fdock)?engineWin([0-9]+)"   { ::enginewin::Open [lindex $regmatch end]}
-      "\.(fdock)?analysisWin([0-9]+)" { ::makeAnalysisWin [lindex $regmatch end] 0 0}
+      "\.(fdock)?analysisWin([0-9]+)" { ::makeAnalysisWin [lindex $regmatch end] [expr {[lindex $regmatch end] - 1}] 0}
       "\.(fdock)?crosstableWin"       { ::crosstab::Open }
       }
 }


### PR DESCRIPTION
…gine slots and adding a warning when taking over slot 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Finish Game” warning when engine slot 2 is already in use by an open analysis window, with a confirmation prompt to proceed or cancel.
  * Improved the engine selection flow so choosing an engine (double-click or OK) immediately launches the analysis with the selected engine.

* **Localization**
  * Added the new warning text to supported languages (28 languages total).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->