### PR TITLE
Fix bug on arrow display if engine started from eval bar

### DIFF
--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -380,6 +380,8 @@ proc ::updateMainEvalBar {engineID bestmove evaluation {pvlines {}}} {
             # Convert all PV moves to UCI format
             set uciMoves {}
             set lineCount 0
+            set legalUciMoves {}
+            set haveLegalUciMoves 0
             foreach move $pvlines {
                 # If showEngineVariationArrows is disabled, only show the best move (first line)
                 if {!$::showEngineVariationArrows && $lineCount >= 1} { break }
@@ -387,7 +389,14 @@ proc ::updateMainEvalBar {engineID bestmove evaluation {pvlines {}}} {
                 if {[catch { sc_game SANtoUCI $cleanMove } moveUCI] == 0 && $moveUCI ne ""} {
                     lappend uciMoves $moveUCI
                 } elseif {[regexp {^[a-h][1-8][a-h][1-8][qrbn]?$} $cleanMove]} {
-                    lappend uciMoves $cleanMove
+                    if {!$haveLegalUciMoves} {
+                        set legalUciMoves {}
+                        foreach {san uci} [sc_pos moves 1] { lappend legalUciMoves $uci }
+                        set haveLegalUciMoves 1
+                    }
+                    if {$cleanMove in $legalUciMoves} {
+                        lappend uciMoves $cleanMove
+                    }
                 }
                 incr lineCount
             }

--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -386,6 +386,8 @@ proc ::updateMainEvalBar {engineID bestmove evaluation {pvlines {}}} {
                 set cleanMove [string map {"\u2654" K "\u2655" Q "\u2656" R "\u2657" B "\u2658" N} [::untrans $move]]
                 if {[catch { sc_game SANtoUCI $cleanMove } moveUCI] == 0 && $moveUCI ne ""} {
                     lappend uciMoves $moveUCI
+                } elseif {[regexp {^[a-h][1-8][a-h][1-8][qrbn]?$} $cleanMove]} {
+                    lappend uciMoves $cleanMove
                 }
                 incr lineCount
             }

--- a/tcl/windows/engine.tcl
+++ b/tcl/windows/engine.tcl
@@ -790,9 +790,11 @@ proc ::enginewin::updateDisplay {id msgData} {
         $pv_lines configure -state disabled
         # Clear stored PV lines for multi-arrow display
         set ::enginewin::m_(pvlines,$id) {}
-        foreach key [array names ::enginewin::pvBestMove $id,*] {
-            unset ::enginewin::pvBestMove($key)
-        }
+if {[array exists ::enginewin::pvBestMove]} {
+    foreach key [array names ::enginewin::pvBestMove "$id,*"] {
+        unset ::enginewin::pvBestMove($key)
+    }
+}
         return
     }
 

--- a/tcl/windows/engine.tcl
+++ b/tcl/windows/engine.tcl
@@ -1115,9 +1115,11 @@ proc ::enginewin::changeState {id newState} {
             ::pgnviewer::EngineBestMove $::enginewin::pgnviewer($id) $id "" "" [::enginewin::getEngineColor 1 2]
             ::pgnviewer::EngineBestMove $::enginewin::pgnviewer($id) $id "" "" [::enginewin::getEngineColor 1 3]
         } else {
-            foreach key [array names ::enginewin::pvBestMove $id,*] {
-                unset ::enginewin::pvBestMove($key)
-            }
+if {[array exists ::enginewin::pvBestMove]} {
+    foreach key [array names ::enginewin::pvBestMove "$id,*"] {
+        unset ::enginewin::pvBestMove($key)
+    }
+}
             ::notify::EngineBestMove $id "" "" {}
             ::notify::EngineBestMove $id "" "" {}
             ::notify::EngineBestMove $id "" "" {}

--- a/tcl/windows/engine.tcl
+++ b/tcl/windows/engine.tcl
@@ -912,14 +912,17 @@ if {[array exists ::enginewin::pvBestMove]} {
                     if {$key ne "$id,1"} { unset ::enginewin::pvBestMove($key) }
                 }
             }
-            set allMoves {}
-            for {set pv 1} {$pv <= 3} {incr pv} {
-                if {[info exists ::enginewin::pvBestMove($id,$pv)]} {
-                    lappend allMoves $::enginewin::pvBestMove($id,$pv)
-                }
-            }
-            ::notify::EngineBestMove $id $best_move $scoreStr $allMoves
-        }
+set allMoves {}
+for {set pv 1} {$pv <= 3} {incr pv} {
+    if {[info exists ::enginewin::pvBestMove($id,$pv)]} {
+        lappend allMoves $::enginewin::pvBestMove($id,$pv)
+    }
+}
+set notifyScore $scoreStr
+if {$multipv != 1 && [info exists ::enginewin::scorePV1($id)]} {
+    set notifyScore $::enginewin::scorePV1($id)
+}
+::notify::EngineBestMove $id $best_move $notifyScore $allMoves
     }
 }
 

--- a/tcl/windows/engine.tcl
+++ b/tcl/windows/engine.tcl
@@ -790,6 +790,9 @@ proc ::enginewin::updateDisplay {id msgData} {
         $pv_lines configure -state disabled
         # Clear stored PV lines for multi-arrow display
         set ::enginewin::m_(pvlines,$id) {}
+        foreach key [array names ::enginewin::pvBestMove $id,*] {
+            unset ::enginewin::pvBestMove($key)
+        }
         return
     }
 
@@ -901,7 +904,19 @@ proc ::enginewin::updateDisplay {id msgData} {
         if { [info exists ::enginewin::pgnviewer($id)] && $::enginewin::pgnviewer($id) } {
             ::pgnviewer::EngineBestMove $::enginewin::pgnviewer($id) $id $scoreStr $best_move [::enginewin::getEngineColor 1 $line]
         } else {
-            ::notify::EngineBestMove $id $best_move $scoreStr [list $best_move]
+            set ::enginewin::pvBestMove($id,$multipv) $best_move
+            if {$multipv == 1} {
+                foreach key [array names ::enginewin::pvBestMove $id,*] {
+                    if {$key ne "$id,1"} { unset ::enginewin::pvBestMove($key) }
+                }
+            }
+            set allMoves {}
+            for {set pv 1} {$pv <= 3} {incr pv} {
+                if {[info exists ::enginewin::pvBestMove($id,$pv)]} {
+                    lappend allMoves $::enginewin::pvBestMove($id,$pv)
+                }
+            }
+            ::notify::EngineBestMove $id $best_move $scoreStr $allMoves
         }
     }
 }
@@ -1098,6 +1113,9 @@ proc ::enginewin::changeState {id newState} {
             ::pgnviewer::EngineBestMove $::enginewin::pgnviewer($id) $id "" "" [::enginewin::getEngineColor 1 2]
             ::pgnviewer::EngineBestMove $::enginewin::pgnviewer($id) $id "" "" [::enginewin::getEngineColor 1 3]
         } else {
+            foreach key [array names ::enginewin::pvBestMove $id,*] {
+                unset ::enginewin::pvBestMove($key)
+            }
             ::notify::EngineBestMove $id "" "" {}
             ::notify::EngineBestMove $id "" "" {}
             ::notify::EngineBestMove $id "" "" {}

--- a/tcl/windows/engine.tcl
+++ b/tcl/windows/engine.tcl
@@ -901,7 +901,7 @@ proc ::enginewin::updateDisplay {id msgData} {
         if { [info exists ::enginewin::pgnviewer($id)] && $::enginewin::pgnviewer($id) } {
             ::pgnviewer::EngineBestMove $::enginewin::pgnviewer($id) $id $scoreStr $best_move [::enginewin::getEngineColor 1 $line]
         } else {
-            ::notify::EngineBestMove $id $best_move $scoreStr [::enginewin::getEngineColor $id $line]
+            ::notify::EngineBestMove $id $best_move $scoreStr [list $best_move]
         }
     }
 }
@@ -1098,9 +1098,9 @@ proc ::enginewin::changeState {id newState} {
             ::pgnviewer::EngineBestMove $::enginewin::pgnviewer($id) $id "" "" [::enginewin::getEngineColor 1 2]
             ::pgnviewer::EngineBestMove $::enginewin::pgnviewer($id) $id "" "" [::enginewin::getEngineColor 1 3]
         } else {
-            ::notify::EngineBestMove $id "" "" [::enginewin::getEngineColor $id 1]
-            ::notify::EngineBestMove $id "" "" [::enginewin::getEngineColor $id 2]
-            ::notify::EngineBestMove $id "" "" [::enginewin::getEngineColor $id 3]
+            ::notify::EngineBestMove $id "" "" {}
+            ::notify::EngineBestMove $id "" "" {}
+            ::notify::EngineBestMove $id "" "" {}
         }
     } elseif {$::enginewin::engState($id) in {paused.idle paused.closed}} {
         ::enginewin::toggleConfigPane $id hide


### PR DESCRIPTION
Fix bug where engine arrow behavior was not working properly if chess engine started by right-clicking the evaluation bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved best-move arrow display so already-coordinate-style moves are handled correctly.
  * Fixed best-move updates in views without the embedded board, helping the highlighted move stay accurate.
  * Cleaned up the best-move indicator when the engine stops or the move display is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->