### PR TITLE
Fix file read for UTF8

### DIFF
--- a/src/epdbook.cpp
+++ b/src/epdbook.cpp
@@ -17,7 +17,9 @@
 #include "epdbook.h"
 #include "misc.h"
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
+#include <system_error>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -147,7 +149,8 @@ errorT EpdBook::readFile() {
 	if (fileName_ == nullptr) {
 		return ERROR_FileOpen;
 	}
-	std::ifstream in(fileName_, std::ios::binary);
+	const auto filePath = pathFromUtf8(fileName_);
+	std::ifstream in(filePath, std::ios::binary);
 	if (!in) {
 		return ERROR_FileOpen;
 	}
@@ -155,7 +158,7 @@ errorT EpdBook::readFile() {
 	// Determine whether the file is writable. Opening in append mode does
 	// not truncate or modify the file if nothing is written.
 	{
-		std::ofstream test(fileName_, std::ios::app);
+		std::ofstream test(filePath, std::ios::app);
 		readOnly_ = !test.is_open();
 	}
 
@@ -233,8 +236,10 @@ errorT EpdBook::writeFile() {
 	}
 
 	// Create a temporary file in the same directory as the target file
-	std::string tempFileName = std::string(fileName_) + ".tmp";
-	std::ofstream out(tempFileName, std::ios::binary | std::ios::trunc);
+	const auto targetPath = pathFromUtf8(fileName_);
+	auto tempPath = targetPath;
+	tempPath += ".tmp";
+	std::ofstream out(tempPath, std::ios::binary | std::ios::trunc);
 	if (!out) {
 		return ERROR_FileOpen;
 	}
@@ -278,12 +283,14 @@ errorT EpdBook::writeFile() {
 	out.flush();
 	if (!out) {
 		out.close();
-		std::remove(tempFileName.c_str());
+		std::error_code ec;
+		std::filesystem::remove(tempPath, ec);
 		return ERROR_FileWrite;
 	}
 	out.close();
 	if (out.fail()) {
-		std::remove(tempFileName.c_str());
+		std::error_code ec;
+		std::filesystem::remove(tempPath, ec);
 		return ERROR_FileWrite;
 	}
 
@@ -293,14 +300,16 @@ errorT EpdBook::writeFile() {
 	// Windows CRT rename() fails if the destination exists. Use MoveFileEx
 	// with MOVEFILE_REPLACE_EXISTING so the original file stays intact until
 	// the temporary file is successfully promoted (no delete-then-rename gap).
-	if (!MoveFileExA(tempFileName.c_str(), fileName_,
+	if (!MoveFileExW(tempPath.c_str(), targetPath.c_str(),
 	                 MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
-		std::remove(tempFileName.c_str());
+		std::error_code ec;
+		std::filesystem::remove(tempPath, ec);
 		return ERROR_FileWrite;
 	}
 #else
-	if (std::rename(tempFileName.c_str(), fileName_) != 0) {
-		std::remove(tempFileName.c_str());
+	if (std::rename(tempPath.c_str(), targetPath.c_str()) != 0) {
+		std::error_code ec;
+		std::filesystem::remove(tempPath, ec);
 		return ERROR_FileWrite;
 	}
 #endif

--- a/src/misc.h
+++ b/src/misc.h
@@ -20,12 +20,36 @@
 
 #include "common.h"
 #include <algorithm>
+#include <filesystem>
 #include <string>
+#include <string_view>
 #include <cstring>
 #include <stdio.h>
 #include <ctype.h>   // For isspace(), etc
 #include <cstdlib>
 #include <vector>
+
+/// Converts a UTF-8 encoded filename (e.g. the strings returned by the Tcl C
+/// API) into a std::filesystem::path.
+/// On Windows the narrow-string file APIs interpret filenames using the ANSI
+/// code page, breaking paths that contain non-ASCII characters; constructing
+/// the path from char8_t performs the correct UTF-8 conversion instead.
+inline std::filesystem::path pathFromUtf8(std::string_view filename) {
+	auto fname = reinterpret_cast<const char8_t*>(filename.data());
+	return {fname, fname + filename.size()};
+}
+
+/// fopen() replacement that interprets @e filename as UTF-8 on all platforms.
+inline FILE* fopenUtf8(const char* filename, const char* mode) {
+#ifdef _WIN32
+	wchar_t wmode[8] = {};
+	for (size_t i = 0; i < 7 && mode[i]; ++i)
+		wmode[i] = static_cast<wchar_t>(mode[i]);
+	return _wfopen(pathFromUtf8(filename).c_str(), wmode);
+#else
+	return fopen(filename, mode);
+#endif
+}
 
 /**
  * class StrRange - parse a string interpreting its content as 1 or 2 integers

--- a/src/pbook.cpp
+++ b/src/pbook.cpp
@@ -125,7 +125,7 @@ std::string PBook::EcoSummary(const std::string_view prefix) const {
 std::pair<errorT, std::unique_ptr<PBook> >
 PBook::ReadEcoFile(const char* FileName) {
     std::filebuf fp;
-    if (!fp.open(FileName, std::ios::in | std::ios::binary))
+    if (!fp.open(pathFromUtf8(FileName), std::ios::in | std::ios::binary))
         return std::make_pair(ERROR_FileOpen, nullptr);
 
     std::unique_ptr<PBook> pb(new PBook);

--- a/src/polyglot/book.cpp
+++ b/src/polyglot/book.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 
 #include "board.h"
 #include "book.h"
@@ -17,6 +18,23 @@
 #include "move_legal.h"
 #include "san.h"
 #include "util.h"
+
+// The filenames received from Tcl are UTF-8 encoded, but on Windows fopen()
+// interprets narrow strings using the ANSI code page: convert explicitly.
+// Note: cannot use misc.h/fopenUtf8 here because the polyglot headers clash
+// with the scid ones (e.g. the global A1..H8 constants).
+static FILE* fopen_utf8(const char* filename, const char* mode) {
+#ifdef _WIN32
+	auto fname = reinterpret_cast<const char8_t*>(filename);
+	std::filesystem::path path{fname, fname + strlen(filename)};
+	wchar_t wmode[8] = {};
+	for (size_t i = 0; i < 7 && mode[i]; ++i)
+		wmode[i] = static_cast<wchar_t>(mode[i]);
+	return _wfopen(path.c_str(), wmode);
+#else
+	return fopen(filename, mode);
+#endif
+}
 
 // types
 
@@ -175,7 +193,7 @@ int scid_book_movesupdate(char* moves, char* probs, const int BookNumber,
 		// file return 0; // nothing to do
 	}
 
-	if (!(f = fopen(tempfile, "wb+"))) {
+	if (!(f = fopen_utf8(tempfile, "wb+"))) {
 		return -1; // fail
 	}
 	probs_written = 0;
@@ -255,12 +273,12 @@ int scid_book_open(const char file_name[], const int BookNumber) {
 
 	int ReadOnlyFile = 0;
 
-	BookFile[BookNumber] = fopen(file_name, "rb+");
+	BookFile[BookNumber] = fopen_utf8(file_name, "rb+");
 
 	//--------------------------------------------------
 	if (BookFile[BookNumber] == NULL) {
 		// the book can not be opened in read/write mode, try read only
-		BookFile[BookNumber] = fopen(file_name, "rb");
+		BookFile[BookNumber] = fopen_utf8(file_name, "rb");
 		ReadOnlyFile = 1;
 		if (BookFile[BookNumber] == NULL)
 			return -1;
@@ -390,7 +408,7 @@ void book_open(const char file_name[], const int BookNumber) {
 
 	ASSERT(file_name != NULL);
 
-	BookFile[BookNumber] = fopen(file_name, "rb+");
+	BookFile[BookNumber] = fopen_utf8(file_name, "rb+");
 
 	if (BookFile[BookNumber] == NULL)
 		my_fatal("book_open(): can't open file \"%s\": %s\n", file_name,

--- a/src/sc_base.cpp
+++ b/src/sc_base.cpp
@@ -68,7 +68,8 @@ static UI_res_t doOpenBase(UI_handle_t ti, const char* codec, fileModeT fMode,
 	Progress progress = UI_CreateProgress(ti);
 	errorT err = dbase->open(codec, fMode, filename, progress);
 
-	if ((err == ERROR_FileOpen || err == ERROR_FileMode) &&
+	if ((err == ERROR_FileOpen || err == ERROR_FileMode ||
+	     err == ERROR_FileWrite) &&
 	    fMode == FMODE_Both) {
 		err = dbase->open(codec, FMODE_ReadOnly, filename, progress);
 	}

--- a/src/scidbase.cpp
+++ b/src/scidbase.cpp
@@ -22,6 +22,7 @@
 #include "codec_scid4.h"
 #include "codec_scid5.h"
 #include "common.h"
+#include "misc.h"
 #include "sortcache.h"
 #include "stored.h"
 #include <algorithm>
@@ -91,8 +92,10 @@ errorT scidBaseT::openHelper(ICodecDatabase::Codec dbtype, fileModeT fMode,
 	// File-based locking for write modes (skip for MEMORY databases)
 	if (dbtype != ICodecDatabase::MEMORY &&
 	    (fMode == FMODE_WriteOnly || fMode == FMODE_Both || fMode == FMODE_Create)) {
-		std::string lockPath = std::string(filename) + ".lock";
-		if (std::filesystem::exists(lockPath)) {
+		auto lockPath = pathFromUtf8(filename);
+		lockPath += ".lock";
+		std::error_code ec;
+		if (std::filesystem::exists(lockPath, ec)) {
 			return ERROR_FileInUse;
 		}
 		// Create the lock file
@@ -101,7 +104,7 @@ errorT scidBaseT::openHelper(ICodecDatabase::Codec dbtype, fileModeT fMode,
 			return ERROR_FileWrite;
 		}
 		lockStream.close();
-		lockFile_ = lockPath;
+		lockFile_ = std::move(lockPath);
 	}
 
 	auto [db, err] = ICodecDatabase::open(dbtype, fMode, filename, progress,
@@ -126,7 +129,8 @@ errorT scidBaseT::openHelper(ICodecDatabase::Codec dbtype, fileModeT fMode,
 		nb_->Clear();
 		// Clean up lock file on failure
 		if (!lockFile_.empty()) {
-			std::filesystem::remove(lockFile_);
+			std::error_code ec;
+			std::filesystem::remove(lockFile_, ec);
 			lockFile_.clear();
 		}
 	}
@@ -139,7 +143,8 @@ void scidBaseT::Close() {
 
 	// Remove lock file if present
 	if (!lockFile_.empty()) {
-		std::filesystem::remove(lockFile_);
+		std::error_code ec;
+		std::filesystem::remove(lockFile_, ec);
 		lockFile_.clear();
 	}
 

--- a/src/scidbase.h
+++ b/src/scidbase.h
@@ -29,6 +29,7 @@
 #include "tree.h"
 #include <array>
 #include <cassert>
+#include <filesystem>
 #include <memory>
 #include <string_view>
 #include <unordered_map>
@@ -424,7 +425,7 @@ private:
 	std::vector<std::pair<std::string, SortCache*>> sortCaches_;
 	mutable std::unordered_map<idNumberT, eloT> peakEloCache_;
 	errorT err_open_ = OK;
-	std::string lockFile_;
+	std::filesystem::path lockFile_;
 
 private:
 	errorT openHelper(ICodecDatabase::Codec dbtype, fileModeT mode,

--- a/src/spellchk.cpp
+++ b/src/spellchk.cpp
@@ -253,7 +253,8 @@ errorT SpellChecker::read(const char* filename, const Progress& progress)
 	// Open the file and get the file size.
 	Filebuf file;
 	std::streamsize fileSize = -1;
-	if (file.open(filename, std::ios::in | std::ios::binary | std::ios::ate) != 0) {
+	if (file.open(pathFromUtf8(filename),
+	              std::ios::in | std::ios::binary | std::ios::ate) != 0) {
 		fileSize = file.pubseekoff(0, std::ios::cur, std::ios::in);
 		file.pubseekoff(0, std::ios::beg, std::ios::in);
 	}

--- a/src/tkscid.cpp
+++ b/src/tkscid.cpp
@@ -481,9 +481,7 @@ int sc_base_export(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
     }
   }
 
-  const auto tcl_strings_are_utf8 = std::filesystem::path(argv[4]).string();
-  const auto exportFileName = tcl_strings_are_utf8.c_str();
-  auto exportFile = fopen(exportFileName, (appendToFile ? "r+" : "w"));
+  auto exportFile = fopenUtf8(argv[4], (appendToFile ? "r+" : "w"));
   if (exportFile == NULL) {
     return errorResult(ti, "Error opening file for exporting games.");
   }
@@ -2068,9 +2066,7 @@ int sc_filter_old(ClientData cd, Tcl_Interp *ti, int argc, const char **argv) {
 
   case FILTER_EXPORT:
     if (argc >= 7 && argc <= 9) {
-      const auto tcl_strings_are_utf8 = std::filesystem::path(argv[5]).string();
-      const auto exportFileName = tcl_strings_are_utf8.c_str();
-      auto exportFile = fopen(exportFileName, "wb");
+      auto exportFile = fopenUtf8(argv[5], "wb");
       if (exportFile == NULL)
         return errorResult(ti, "Error opening file for exporting games.");
       auto old_language = language;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when opening, saving, exporting, and locking files with UTF-8 filenames, especially on Windows.
  * Improved temporary-file cleanup and file replacement reliability during saves.
  * Databases that cannot be opened for writing now retry in read-only mode when appropriate.
  * Improved lock-file cleanup and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->