### PR TITLE
Bug fixes for Play vs. Engine

### DIFF
--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -1641,6 +1641,7 @@ translate J AnnotateVariations {Означите варијације}
 translate J ShortAnnotations {Кратке напомене}
 translate J addAnnotatorTag {Додајте ознаку анотатора}
 translate J AddScoreToShortAnnotations {Додајте резултат напоменама}
+translate J AddScoreToAllMoves {Add score to all moves}
 translate J Export {Извоз}
 translate J BookPartiallyLoaded {Књига је делимично учитана}
 translate J Calvar {Прорачун варијација}

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -1641,7 +1641,7 @@ translate J AnnotateVariations {Означите варијације}
 translate J ShortAnnotations {Кратке напомене}
 translate J addAnnotatorTag {Додајте ознаку анотатора}
 translate J AddScoreToShortAnnotations {Додајте резултат напоменама}
-translate J AddScoreToAllMoves {Add score to all moves}
+translate J AddScoreToAllMoves {Додајте резултат свим потезима}
 translate J Export {Извоз}
 translate J BookPartiallyLoaded {Књига је делимично учитана}
 translate J Calvar {Прорачун варијација}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -1600,7 +1600,7 @@ translate b AnnotateVariations {বৈচিত্র টীকা}
 translate b ShortAnnotations {সংক্ষিপ্ত টীকা}
 translate b addAnnotatorTag {টীকা ট্যাগ যোগ করুন}
 translate b AddScoreToShortAnnotations {টীকাগুলিতে স্কোর যোগ করুন}
-translate b AddScoreToAllMoves {Add score to all moves}
+translate b AddScoreToAllMoves {সমস্ত চালে স্কোর যোগ করুন}
 translate b Export {রপ্তানি}
 translate b BookPartiallyLoaded {বই আংশিক লোড}
 translate b Calvar {বৈচিত্র্যের গণনা}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -1600,6 +1600,7 @@ translate b AnnotateVariations {বৈচিত্র টীকা}
 translate b ShortAnnotations {সংক্ষিপ্ত টীকা}
 translate b addAnnotatorTag {টীকা ট্যাগ যোগ করুন}
 translate b AddScoreToShortAnnotations {টীকাগুলিতে স্কোর যোগ করুন}
+translate b AddScoreToAllMoves {Add score to all moves}
 translate b Export {রপ্তানি}
 translate b BookPartiallyLoaded {বই আংশিক লোড}
 translate b Calvar {বৈচিত্র্যের গণনা}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -1641,6 +1641,7 @@ translate g AnnotateVariations {Анотирайте вариации}
 translate g ShortAnnotations {Кратки анотации}
 translate g addAnnotatorTag {Добавете етикет за анотатор}
 translate g AddScoreToShortAnnotations {Добавете резултат към анотациите}
+translate g AddScoreToAllMoves {Add score to all moves}
 translate g Export {Експортиране}
 translate g BookPartiallyLoaded {Книгата е частично заредена}
 translate g Calvar {Изчисляване на вариации}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -1641,7 +1641,7 @@ translate g AnnotateVariations {Анотирайте вариации}
 translate g ShortAnnotations {Кратки анотации}
 translate g addAnnotatorTag {Добавете етикет за анотатор}
 translate g AddScoreToShortAnnotations {Добавете резултат към анотациите}
-translate g AddScoreToAllMoves {Add score to all moves}
+translate g AddScoreToAllMoves {Добавете резултат към всички ходове}
 translate g Export {Експортиране}
 translate g BookPartiallyLoaded {Книгата е частично заредена}
 translate g Calvar {Изчисляване на вариации}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -1644,6 +1644,7 @@ translate K AnnotateVariations {Anotar variants}
 translate K ShortAnnotations {Anotacions curtes}
 translate K addAnnotatorTag {Afegir etiqueta d'anotador}
 translate K AddScoreToShortAnnotations {Afegir puntuació per anotaciones curtes}
+translate K AddScoreToAllMoves {Add score to all moves}
 translate K Export {Exportar}
 translate K BookPartiallyLoaded {Llibre carregat parcialment}
 translate K Calvar {Càlcul de variants}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -1644,7 +1644,7 @@ translate K AnnotateVariations {Anotar variants}
 translate K ShortAnnotations {Anotacions curtes}
 translate K addAnnotatorTag {Afegir etiqueta d'anotador}
 translate K AddScoreToShortAnnotations {Afegir puntuació per anotaciones curtes}
-translate K AddScoreToAllMoves {Add score to all moves}
+translate K AddScoreToAllMoves {Afegiu puntuació a tots els moviments}
 translate K Export {Exportar}
 translate K BookPartiallyLoaded {Llibre carregat parcialment}
 translate K Calvar {Càlcul de variants}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1576,6 +1576,7 @@ translate M AnnotateVariations {注释变化}
 translate M ShortAnnotations {简短的注释}
 translate M addAnnotatorTag {添加注释器标签}
 translate M AddScoreToShortAnnotations {为注释添加分数}
+translate M AddScoreToAllMoves {Add score to all moves}
 translate M Export {出口}
 translate M BookPartiallyLoaded {书已部分加载}
 translate M Calvar {变化的计算}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1576,7 +1576,7 @@ translate M AnnotateVariations {注释变化}
 translate M ShortAnnotations {简短的注释}
 translate M addAnnotatorTag {添加注释器标签}
 translate M AddScoreToShortAnnotations {为注释添加分数}
-translate M AddScoreToAllMoves {Add score to all moves}
+translate M AddScoreToAllMoves {为所有动作添加分数}
 translate M Export {出口}
 translate M BookPartiallyLoaded {书已部分加载}
 translate M Calvar {变化的计算}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -1622,6 +1622,7 @@ translate C AnnotateVariations {Anotovat varianty}
 translate C ShortAnnotations {Krtk anotace}
 translate C addAnnotatorTag {Pidat znaku anottora}
 translate C AddScoreToShortAnnotations {Pidat skre ke krtkm anotacm}
+translate C AddScoreToAllMoves {Add score to all moves}
 translate C Export {Export}
 translate C BookPartiallyLoaded {Knihovna zahjen sten nataena}
 translate C Calvar {Propoet variant}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -1622,7 +1622,7 @@ translate C AnnotateVariations {Anotovat varianty}
 translate C ShortAnnotations {Krtk anotace}
 translate C addAnnotatorTag {Pidat znaku anottora}
 translate C AddScoreToShortAnnotations {Pidat skre ke krtkm anotacm}
-translate C AddScoreToAllMoves {Add score to all moves}
+translate C AddScoreToAllMoves {Přidejte skóre ke všem tahům}
 translate C Export {Export}
 translate C BookPartiallyLoaded {Knihovna zahjen sten nataena}
 translate C Calvar {Propoet variant}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -1672,6 +1672,7 @@ translate D AnnotateVariations {Varianten kommentieren}
 translate D ShortAnnotations {Kurze Kommentare}
 translate D addAnnotatorTag {Kommentar Tag hinzufügen}
 translate D AddScoreToShortAnnotations {Bewertung hinzufügen}
+translate D AddScoreToAllMoves {Add score to all moves}
 translate D Export {Export}
 translate D BookPartiallyLoaded {Buch teilweise geladen}
 translate D Calvar {Training: Variantenberechnung}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -1672,7 +1672,7 @@ translate D AnnotateVariations {Varianten kommentieren}
 translate D ShortAnnotations {Kurze Kommentare}
 translate D addAnnotatorTag {Kommentar Tag hinzufügen}
 translate D AddScoreToShortAnnotations {Bewertung hinzufügen}
-translate D AddScoreToAllMoves {Add score to all moves}
+translate D AddScoreToAllMoves {Fügen Sie allen Zügen Punkte hinzu}
 translate D Export {Export}
 translate D BookPartiallyLoaded {Buch teilweise geladen}
 translate D Calvar {Training: Variantenberechnung}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -1628,7 +1628,7 @@ translate F AnnotateVariations {Annoter les variantes}
 translate F ShortAnnotations {Annotations courtes}
 translate F addAnnotatorTag {Ajouter Annotateur}
 translate F AddScoreToShortAnnotations {Ajouter score aux annotations courtes}
-translate F AddScoreToAllMoves {Add score to all moves}
+translate F AddScoreToAllMoves {Ajouter un score à tous les mouvements}
 translate F Export {Exporter}
 translate F BookPartiallyLoaded {Bibliothèque chargée en partie}
 translate F Calvar {Calcul de variantes}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -1628,6 +1628,7 @@ translate F AnnotateVariations {Annoter les variantes}
 translate F ShortAnnotations {Annotations courtes}
 translate F addAnnotatorTag {Ajouter Annotateur}
 translate F AddScoreToShortAnnotations {Ajouter score aux annotations courtes}
+translate F AddScoreToAllMoves {Add score to all moves}
 translate F Export {Exporter}
 translate F BookPartiallyLoaded {Bibliothèque chargée en partie}
 translate F Calvar {Calcul de variantes}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -1649,6 +1649,7 @@ translate G AnnotateVariations {Υπομνηματισμός βαριαντών}
 translate G ShortAnnotations {Σύντομος υπομνηματισμός}
 translate G addAnnotatorTag {Προσθήκη εκτικέτας του υπομνηματιστή}
 translate G AddScoreToShortAnnotations {Προσθήκη σκορ στους υπομνηματισμούς}
+translate G AddScoreToAllMoves {Add score to all moves}
 translate G Export {Εξαγωγή}
 translate G BookPartiallyLoaded {Το βιβλίο φορτώθηκε μερικώς}
 translate G Calvar {Υπολογισμο βαριαντών}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -1649,7 +1649,7 @@ translate G AnnotateVariations {Υπομνηματισμός βαριαντών}
 translate G ShortAnnotations {Σύντομος υπομνηματισμός}
 translate G addAnnotatorTag {Προσθήκη εκτικέτας του υπομνηματιστή}
 translate G AddScoreToShortAnnotations {Προσθήκη σκορ στους υπομνηματισμούς}
-translate G AddScoreToAllMoves {Add score to all moves}
+translate G AddScoreToAllMoves {Προσθέστε σκορ σε όλες τις κινήσεις}
 translate G Export {Εξαγωγή}
 translate G BookPartiallyLoaded {Το βιβλίο φορτώθηκε μερικώς}
 translate G Calvar {Υπολογισμο βαριαντών}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -1601,6 +1601,7 @@ translate V AnnotateVariations {הערה וריאציות}
 translate V ShortAnnotations {הערות קצרות}
 translate V addAnnotatorTag {הוסף תג יוצר}
 translate V AddScoreToShortAnnotations {הוסף ניקוד להערות}
+translate V AddScoreToAllMoves {Add score to all moves}
 translate V Export {יְצוּא}
 translate V BookPartiallyLoaded {הספר נטען חלקית}
 translate V Calvar {חישוב וריאציות}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -1601,7 +1601,7 @@ translate V AnnotateVariations {הערה וריאציות}
 translate V ShortAnnotations {הערות קצרות}
 translate V addAnnotatorTag {הוסף תג יוצר}
 translate V AddScoreToShortAnnotations {הוסף ניקוד להערות}
-translate V AddScoreToAllMoves {Add score to all moves}
+translate V AddScoreToAllMoves {הוסף ניקוד לכל המהלכים}
 translate V Export {יְצוּא}
 translate V BookPartiallyLoaded {הספר נטען חלקית}
 translate V Calvar {חישוב וריאציות}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -1600,6 +1600,7 @@ translate h AnnotateVariations {विविधताओं पर टिप्�
 translate h ShortAnnotations {लघु टिप्पणियाँ}
 translate h addAnnotatorTag {एनोटेटर टैग जोड़ें}
 translate h AddScoreToShortAnnotations {एनोटेशन में स्कोर जोड़ें}
+translate h AddScoreToAllMoves {Add score to all moves}
 translate h Export {निर्यात}
 translate h BookPartiallyLoaded {पुस्तक आंशिक रूप से भरी हुई है}
 translate h Calvar {विविधताओं की गणना}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -1600,7 +1600,7 @@ translate h AnnotateVariations {विविधताओं पर टिप्�
 translate h ShortAnnotations {लघु टिप्पणियाँ}
 translate h addAnnotatorTag {एनोटेटर टैग जोड़ें}
 translate h AddScoreToShortAnnotations {एनोटेशन में स्कोर जोड़ें}
-translate h AddScoreToAllMoves {Add score to all moves}
+translate h AddScoreToAllMoves {सभी चालों में स्कोर जोड़ें}
 translate h Export {निर्यात}
 translate h BookPartiallyLoaded {पुस्तक आंशिक रूप से भरी हुई है}
 translate h Calvar {विविधताओं की गणना}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -1623,6 +1623,7 @@ translate H AnnotateVariations {Változatok kommentálása}
 translate H ShortAnnotations {Rövid kommentár}
 translate H addAnnotatorTag {Értékelõ jel hozzáadása}
 translate H AddScoreToShortAnnotations {Rövid kommentár kiegészítése értékeléssel}
+translate H AddScoreToAllMoves {Add score to all moves}
 translate H Export {Export}
 translate H BookPartiallyLoaded {Megnyitástár részlegesen betöltve}
 translate H Calvar {Változatok számítása}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -1623,7 +1623,7 @@ translate H AnnotateVariations {Változatok kommentálása}
 translate H ShortAnnotations {Rövid kommentár}
 translate H addAnnotatorTag {Értékelõ jel hozzáadása}
 translate H AddScoreToShortAnnotations {Rövid kommentár kiegészítése értékeléssel}
-translate H AddScoreToAllMoves {Add score to all moves}
+translate H AddScoreToAllMoves {Add pontszámot az összes lépéshez}
 translate H Export {Export}
 translate H BookPartiallyLoaded {Megnyitástár részlegesen betöltve}
 translate H Calvar {Változatok számítása}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -1624,6 +1624,7 @@ translate I AnnotateVariations {Annota le varianti}
 translate I ShortAnnotations {Annotazione breve}
 translate I addAnnotatorTag {Aggiungi il tag dell'annotazione}
 translate I AddScoreToShortAnnotations {Aggiungi il punteggio alle annotazioni brevi}
+translate I AddScoreToAllMoves {Add score to all moves}
 translate I Export {Esporta}
 translate I BookPartiallyLoaded {Libro caricato parzialmente}
 translate I Calvar {Calcolo delle varianti}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -1624,7 +1624,7 @@ translate I AnnotateVariations {Annota le varianti}
 translate I ShortAnnotations {Annotazione breve}
 translate I addAnnotatorTag {Aggiungi il tag dell'annotazione}
 translate I AddScoreToShortAnnotations {Aggiungi il punteggio alle annotazioni brevi}
-translate I AddScoreToAllMoves {Add score to all moves}
+translate I AddScoreToAllMoves {Aggiungi punteggio a tutte le mosse}
 translate I Export {Esporta}
 translate I BookPartiallyLoaded {Libro caricato parzialmente}
 translate I Calvar {Calcolo delle varianti}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -1641,6 +1641,7 @@ translate A AnnotateVariations {バリエーションに注釈を付ける}
 translate A ShortAnnotations {短い注釈}
 translate A addAnnotatorTag {アノテータータグを追加する}
 translate A AddScoreToShortAnnotations {注釈にスコアを追加する}
+translate A AddScoreToAllMoves {Add score to all moves}
 translate A Export {輸出}
 translate A BookPartiallyLoaded {本が部分的に読み込まれています}
 translate A Calvar {変動の計算}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -1641,7 +1641,7 @@ translate A AnnotateVariations {バリエーションに注釈を付ける}
 translate A ShortAnnotations {短い注釈}
 translate A addAnnotatorTag {アノテータータグを追加する}
 translate A AddScoreToShortAnnotations {注釈にスコアを追加する}
-translate A AddScoreToAllMoves {Add score to all moves}
+translate A AddScoreToAllMoves {すべての動きにスコアを追加します}
 translate A Export {輸出}
 translate A BookPartiallyLoaded {本が部分的に読み込まれています}
 translate A Calvar {変動の計算}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -1641,7 +1641,7 @@ translate k AnnotateVariations {변형에 달기}
 translate k ShortAnnotations {지하철}
 translate k addAnnotatorTag {자 태그 표시}
 translate k AddScoreToShortAnnotations {추가 점수를 찾았습니다}
-translate k AddScoreToAllMoves {Add score to all moves}
+translate k AddScoreToAllMoves {모든 동작에 점수 추가}
 translate k Export {다}
 translate k BookPartiallyLoaded {책이 부분적으로 읽혔어요}
 translate k Calvar {변형작업}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -1641,6 +1641,7 @@ translate k AnnotateVariations {변형에 달기}
 translate k ShortAnnotations {지하철}
 translate k addAnnotatorTag {자 태그 표시}
 translate k AddScoreToShortAnnotations {추가 점수를 찾았습니다}
+translate k AddScoreToAllMoves {Add score to all moves}
 translate k Export {다}
 translate k BookPartiallyLoaded {책이 부분적으로 읽혔어요}
 translate k Calvar {변형작업}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -1647,7 +1647,7 @@ translate N AnnotateVariations {Becommentarieer varianten}
 translate N ShortAnnotations {Korte commentaren}
 translate N addAnnotatorTag {Voeg een commentaar label toe}
 translate N AddScoreToShortAnnotations {Voeg de score toe aan de korte commentaren}
-translate N AddScoreToAllMoves {Add score to all moves}
+translate N AddScoreToAllMoves {Voeg score toe aan alle zetten}
 translate N Export {Export}
 translate N BookPartiallyLoaded {Boek gedeeltelijk geladen}
 translate N Calvar {Berekening van de varianten}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -1647,6 +1647,7 @@ translate N AnnotateVariations {Becommentarieer varianten}
 translate N ShortAnnotations {Korte commentaren}
 translate N addAnnotatorTag {Voeg een commentaar label toe}
 translate N AddScoreToShortAnnotations {Voeg de score toe aan de korte commentaren}
+translate N AddScoreToAllMoves {Add score to all moves}
 translate N Export {Export}
 translate N BookPartiallyLoaded {Boek gedeeltelijk geladen}
 translate N Calvar {Berekening van de varianten}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -1622,6 +1622,7 @@ translate O AnnotateVariations {Kommenter varianter}
 translate O ShortAnnotations {Korte merknader}
 translate O addAnnotatorTag {Legg til annotator-tag}
 translate O AddScoreToShortAnnotations {Legg poengsum til korte merknader}
+translate O AddScoreToAllMoves {Add score to all moves}
 translate O Export {Eksport}
 translate O BookPartiallyLoaded {Boken er delvis lastet}
 translate O Calvar {Beregning av variasjoner}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -1622,7 +1622,7 @@ translate O AnnotateVariations {Kommenter varianter}
 translate O ShortAnnotations {Korte merknader}
 translate O addAnnotatorTag {Legg til annotator-tag}
 translate O AddScoreToShortAnnotations {Legg poengsum til korte merknader}
-translate O AddScoreToAllMoves {Add score to all moves}
+translate O AddScoreToAllMoves {Legg til poengsum til alle trekk}
 translate O Export {Eksport}
 translate O BookPartiallyLoaded {Boken er delvis lastet}
 translate O Calvar {Beregning av variasjoner}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -1552,7 +1552,7 @@ translate P AnnotateVariations {Komentuj warianty}
 translate P ShortAnnotations {Krótkie adnotacje}
 translate P addAnnotatorTag {Dodaj znacznik komentatora}
 translate P AddScoreToShortAnnotations {Dodaj ocenę do adnotacji}
-translate P AddScoreToAllMoves {Add score to all moves}
+translate P AddScoreToAllMoves {Dodaj wynik do wszystkich ruchów}
 translate P Export {Eksportuj}
 translate P BookPartiallyLoaded {Księga częściowo wczytana}
 translate P Calvar {Liczenie wariantów}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -1552,6 +1552,7 @@ translate P AnnotateVariations {Komentuj warianty}
 translate P ShortAnnotations {Krótkie adnotacje}
 translate P addAnnotatorTag {Dodaj znacznik komentatora}
 translate P AddScoreToShortAnnotations {Dodaj ocenę do adnotacji}
+translate P AddScoreToAllMoves {Add score to all moves}
 translate P Export {Eksportuj}
 translate P BookPartiallyLoaded {Księga częściowo wczytana}
 translate P Calvar {Liczenie wariantów}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -1630,6 +1630,7 @@ translate B AnnotateVariations {Anotar variantes}
 translate B ShortAnnotations {Anotações curtas}
 translate B addAnnotatorTag {Adicionar tag do anotador}
 translate B AddScoreToShortAnnotations {Adicionar o score às anotações curtas}
+translate B AddScoreToAllMoves {Add score to all moves}
 translate B Export {Exportar}
 translate B BookPartiallyLoaded {Livro parcialmente carregado}
 translate B Calvar {Cálculo de variantes}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -1630,7 +1630,7 @@ translate B AnnotateVariations {Anotar variantes}
 translate B ShortAnnotations {Anotações curtas}
 translate B addAnnotatorTag {Adicionar tag do anotador}
 translate B AddScoreToShortAnnotations {Adicionar o score às anotações curtas}
-translate B AddScoreToAllMoves {Add score to all moves}
+translate B AddScoreToAllMoves {Adicione pontuação a todos os movimentos}
 translate B Export {Exportar}
 translate B BookPartiallyLoaded {Livro parcialmente carregado}
 translate B Calvar {Cálculo de variantes}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -1641,7 +1641,7 @@ translate L AnnotateVariations {Adnotați variațiile}
 translate L ShortAnnotations {Adnotări scurte}
 translate L addAnnotatorTag {Adăugați etichetă de adnotator}
 translate L AddScoreToShortAnnotations {Adăugați scor la adnotări}
-translate L AddScoreToAllMoves {Add score to all moves}
+translate L AddScoreToAllMoves {Adaugă scor la toate mișcările}
 translate L Export {Export}
 translate L BookPartiallyLoaded {Cartea încărcată parțial}
 translate L Calvar {Calculul variațiilor}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -1641,6 +1641,7 @@ translate L AnnotateVariations {Adnotați variațiile}
 translate L ShortAnnotations {Adnotări scurte}
 translate L addAnnotatorTag {Adăugați etichetă de adnotator}
 translate L AddScoreToShortAnnotations {Adăugați scor la adnotări}
+translate L AddScoreToAllMoves {Add score to all moves}
 translate L Export {Export}
 translate L BookPartiallyLoaded {Cartea încărcată parțial}
 translate L Calvar {Calculul variațiilor}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -1624,7 +1624,7 @@ translate R AnnotateVariations {Комментировать варианты}
 translate R ShortAnnotations {Показать комментарии}
 translate R addAnnotatorTag {Добавить тег аннотирующего}
 translate R AddScoreToShortAnnotations {Добавить счёт в короткие аннотации}
-translate R AddScoreToAllMoves {Add score to all moves}
+translate R AddScoreToAllMoves {Добавляйте очки ко всем ходам}
 translate R Export {Экспорт}
 translate R BookPartiallyLoaded {Книга частично загружена}
 translate R Calvar {Расчёт вариантов}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -1624,6 +1624,7 @@ translate R AnnotateVariations {Комментировать варианты}
 translate R ShortAnnotations {Показать комментарии}
 translate R addAnnotatorTag {Добавить тег аннотирующего}
 translate R AddScoreToShortAnnotations {Добавить счёт в короткие аннотации}
+translate R AddScoreToAllMoves {Add score to all moves}
 translate R Export {Экспорт}
 translate R BookPartiallyLoaded {Книга частично загружена}
 translate R Calvar {Расчёт вариантов}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -2705,6 +2705,7 @@ translate Y ShortAnnotations {Short annotations}
 translate Y addAnnotatorTag {Add annotator tag}
 # ====== TODO To be translated ======
 translate Y AddScoreToShortAnnotations {Add score to annotations}
+translate Y AddScoreToAllMoves {Add score to all moves}
 # ====== TODO To be translated ======
 translate Y Export {Export}
 # ====== TODO To be translated ======

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -1675,7 +1675,7 @@ translate S AnnotateVariations {Anotar variantes}
 translate S ShortAnnotations {Anotaciones cortas}
 translate S addAnnotatorTag {Añadir etiqueta de anotador}
 translate S AddScoreToShortAnnotations {Añadir puntuación para anotaciones cortas}
-translate S AddScoreToAllMoves {Add score to all moves}
+translate S AddScoreToAllMoves {Añade puntuación a todos los movimientos.}
 translate S Export {Exportar}
 translate S BookPartiallyLoaded {Libro parcialmente cargado}
 translate S Calvar {Cálculo de variantes}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -1675,6 +1675,7 @@ translate S AnnotateVariations {Anotar variantes}
 translate S ShortAnnotations {Anotaciones cortas}
 translate S addAnnotatorTag {Añadir etiqueta de anotador}
 translate S AddScoreToShortAnnotations {Añadir puntuación para anotaciones cortas}
+translate S AddScoreToAllMoves {Add score to all moves}
 translate S Export {Exportar}
 translate S BookPartiallyLoaded {Libro parcialmente cargado}
 translate S Calvar {Cálculo de variantes}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -1653,6 +1653,7 @@ translate U AnnotateVariations {Annotoi muunnelmat}
 translate U ShortAnnotations {Lyhyet annotaatiot}
 translate U addAnnotatorTag {Lisää merkintä annotaattorista}
 translate U AddScoreToShortAnnotations {Lisää tulos annotaatioihin}
+translate U AddScoreToAllMoves {Add score to all moves}
 translate U Export {Vie}
 translate U BookPartiallyLoaded {Kirja osittain ladattu}
 translate U Calvar {Muunnelmien laskenta}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -1653,7 +1653,7 @@ translate U AnnotateVariations {Annotoi muunnelmat}
 translate U ShortAnnotations {Lyhyet annotaatiot}
 translate U addAnnotatorTag {Lisää merkintä annotaattorista}
 translate U AddScoreToShortAnnotations {Lisää tulos annotaatioihin}
-translate U AddScoreToAllMoves {Add score to all moves}
+translate U AddScoreToAllMoves {Lisää pisteet kaikkiin liikkeisiin}
 translate U Export {Vie}
 translate U BookPartiallyLoaded {Kirja osittain ladattu}
 translate U Calvar {Muunnelmien laskenta}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -1600,6 +1600,7 @@ translate Z AnnotateVariations {Fafanua tofauti}
 translate Z ShortAnnotations {Maelezo mafupi}
 translate Z addAnnotatorTag {Ongeza lebo ya kichambuzi}
 translate Z AddScoreToShortAnnotations {Ongeza alama kwa vidokezo}
+translate Z AddScoreToAllMoves {Add score to all moves}
 translate Z Export {Hamisha}
 translate Z BookPartiallyLoaded {Kitabu kimejaa kiasi}
 translate Z Calvar {Uhesabuji wa tofauti}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -1600,7 +1600,7 @@ translate Z AnnotateVariations {Fafanua tofauti}
 translate Z ShortAnnotations {Maelezo mafupi}
 translate Z addAnnotatorTag {Ongeza lebo ya kichambuzi}
 translate Z AddScoreToShortAnnotations {Ongeza alama kwa vidokezo}
-translate Z AddScoreToAllMoves {Add score to all moves}
+translate Z AddScoreToAllMoves {Ongeza alama kwa hatua zote}
 translate Z Export {Hamisha}
 translate Z BookPartiallyLoaded {Kitabu kimejaa kiasi}
 translate Z Calvar {Uhesabuji wa tofauti}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -1628,6 +1628,7 @@ translate W AnnotateVariations {Kommentera variationer}
 translate W ShortAnnotations {Korta kommentarer}
 translate W addAnnotatorTag {Lägg till kommentator-tagg}
 translate W AddScoreToShortAnnotations {Lägg till värdering till korta kommentarer}
+translate W AddScoreToAllMoves {Add score to all moves}
 translate W Export {Exportera}
 translate W BookPartiallyLoaded {Bok delvis öppnad}
 translate W Calvar {Beräkning av variationer}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -1628,7 +1628,7 @@ translate W AnnotateVariations {Kommentera variationer}
 translate W ShortAnnotations {Korta kommentarer}
 translate W addAnnotatorTag {Lägg till kommentator-tagg}
 translate W AddScoreToShortAnnotations {Lägg till värdering till korta kommentarer}
-translate W AddScoreToAllMoves {Add score to all moves}
+translate W AddScoreToAllMoves {Lägg till poäng till alla drag}
 translate W Export {Exportera}
 translate W BookPartiallyLoaded {Bok delvis öppnad}
 translate W Calvar {Beräkning av variationer}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -1604,7 +1604,7 @@ translate T AnnotateVariations {Varyasyonlara açıklama ekleyin}
 translate T ShortAnnotations {Kısa açıklamalar}
 translate T addAnnotatorTag {Ek açıklama etiketi ekle}
 translate T AddScoreToShortAnnotations {Ek açıklamalara puan ekleyin}
-translate T AddScoreToAllMoves {Add score to all moves}
+translate T AddScoreToAllMoves {Tüm hamlelere puan ekle}
 translate T Export {İhracat}
 translate T BookPartiallyLoaded {Kitap kısmen yüklendi}
 translate T Calvar {Varyasyonların hesaplanması}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -1604,6 +1604,7 @@ translate T AnnotateVariations {Varyasyonlara açıklama ekleyin}
 translate T ShortAnnotations {Kısa açıklamalar}
 translate T addAnnotatorTag {Ek açıklama etiketi ekle}
 translate T AddScoreToShortAnnotations {Ek açıklamalara puan ekleyin}
+translate T AddScoreToAllMoves {Add score to all moves}
 translate T Export {İhracat}
 translate T BookPartiallyLoaded {Kitap kısmen yüklendi}
 translate T Calvar {Varyasyonların hesaplanması}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -1601,6 +1601,7 @@ translate Q AnnotateVariations {Примітки до варіацій}
 translate Q ShortAnnotations {Короткі анотації}
 translate Q addAnnotatorTag {Додайте тег анотатора}
 translate Q AddScoreToShortAnnotations {Додайте оцінку до анотацій}
+translate Q AddScoreToAllMoves {Add score to all moves}
 translate Q Export {Експорт}
 translate Q BookPartiallyLoaded {Книга завантажена частково}
 translate Q Calvar {Розрахунок варіацій}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -1601,7 +1601,7 @@ translate Q AnnotateVariations {Примітки до варіацій}
 translate Q ShortAnnotations {Короткі анотації}
 translate Q addAnnotatorTag {Додайте тег анотатора}
 translate Q AddScoreToShortAnnotations {Додайте оцінку до анотацій}
-translate Q AddScoreToAllMoves {Add score to all moves}
+translate Q AddScoreToAllMoves {Додати оцінку до всіх ходів}
 translate Q Export {Експорт}
 translate Q BookPartiallyLoaded {Книга завантажена частково}
 translate Q Calvar {Розрахунок варіацій}

--- a/tcl/tools/sergame.tcl
+++ b/tcl/tools/sergame.tcl
@@ -292,7 +292,7 @@ namespace eval sergame {
     # Config options 2
     ttk::checkbutton $w.fconfig2.cbPosition -text $::tr(StartFromCurrentPosition) -variable ::sergame::startFromCurrent
     ttk::checkbutton $w.fconfig2.storeEval -text $::tr(AddScoreToShortAnnotations) -variable ::sergame::storeEval
-    ttk::checkbutton $w.fconfig2.storeEvalAll -text $::tr(AddScoreToAllMoves) -variable ::sergame::storeEvalAll
+    ttk::checkbutton $w.fconfig2.storeEvalAll -text [::tr AddScoreToAllMoves] -variable ::sergame::storeEvalAll
     pack $w.fconfig2.cbPosition $w.fconfig2.storeEval $w.fconfig2.storeEvalAll -side top -anchor w
 
     # Specific opening
@@ -403,6 +403,7 @@ namespace eval sergame {
     set ::sergame::blunderWarningLabel ""
     set ::sergame::scoreLabel ""
     set ::sergame::coachNag ""
+    set ::sergame::blunderCheckPending 0
     set ::sergame::coachAnalyzed 0
     set ::sergame::playerBlunderDelta 0.0
     set ::sergame::playerBlunderSeverity 0


### PR DESCRIPTION
Fix reported errors (if user plays Black; missing translations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added the “Add score to all moves” label to additional supported languages (new translation entries for multiple locales).
* **Bug Fixes**
  * Corrected how the “Add score to all moves” option text is populated in the configuration dialog so it displays properly.
  * Reset blunder-check state when starting gameplay to prevent stale results from previous sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->