### PR TITLE
Add ability to copy/paste epd records

### DIFF
--- a/tcl/file/epd.tcl
+++ b/tcl/file/epd.tcl
@@ -372,7 +372,7 @@ namespace eval epd {
       storeEpdText $id
     }
 
-    set clipFen [string range [sc_pos fen] 0 end-4]
+    set clipFen [join [lrange [split [sc_pos fen] " "] 0 3] " "]
     set clipOpcodes [sc_epd get $id]
   }
 
@@ -400,19 +400,16 @@ namespace eval epd {
     if {!$exists} {
       set size [sc_epd size $id]
       $w.lb insert end "$size    $clipFen"
-      set idx [expr $size - 1]
+      set idx [expr {$size - 1}]
     } else {
       set idx [sc_epd index $id]
     }
 
     sc_game pop
 
-    $w.lb selection clear 0 end
-    $w.lb selection set $idx
-    $w.lb see $idx
     updateEpdWin $id
+    $w.lb see $idx
   }
-
   ################################################################################
   ### Save changes to the EPD file.
   ################################################################################

--- a/tcl/file/epd.tcl
+++ b/tcl/file/epd.tcl
@@ -34,6 +34,8 @@ namespace eval epd {
   variable bestMoves {}
   variable epdName
   variable saveLog 0
+  variable clipFen {}
+  variable clipOpcodes {}
 
   set maxEpd [sc_info limit epd]
   array set epdTimer {}
@@ -204,6 +206,8 @@ namespace eval epd {
     $m add command -label [tr EpdSortOpcodes] -accelerator "Ctrl+Shift+S" -underline 0 -command "::epd::sortEpdText $id"
     $m add command -label [tr EpdAddPosition] -accelerator "Ctrl+A" -underline 0 -command "::epd::addPosition $id"
     $m add command -label [tr EpdDeletePosition] -command "::epd::deleteEpdRow $id"
+    $m add command -label [tr EpdCopyRecord] -command "::epd::copyEpdRecord $id"
+    $m add command -label [tr EpdPasteRecord] -command "::epd::pasteEpdRecord $id"
     $m add command -label [tr EpdFindPos] -command "::epd::moveToDeepestMatch $id"
     $m add separator
     $m add command -label [tr EpdAnalPosition] -command "::epd::configAnnotateEpd $id"
@@ -234,6 +238,7 @@ namespace eval epd {
 
     # Right-mouse button menu for listbox:
     menu $w.lb.edit -tearoff 0
+    $w.lb.edit add command -label [tr EpdCopyRecord] -command "::epd::copyEpdRecord $id"
     $w.lb.edit add command -label [tr EpdDeleteRow] -command "::epd::deleteEpdRow $id"
     bind $w.lb <ButtonPress-3> "tk_popup $w.lb.edit %X %Y"
 
@@ -347,6 +352,62 @@ namespace eval epd {
     if {$idx >= $remaining} {
       set idx [expr {$remaining - 1}]
     }
+    $w.lb selection set $idx
+    $w.lb see $idx
+    updateEpdWin $id
+  }
+
+  ################################################################################
+  ### Copy the selected EPD record (FEN + opcodes) to a clipboard variable.
+  ################################################################################
+  proc copyEpdRecord {id} {
+    variable clipFen
+    variable clipOpcodes
+    set w .epd$id
+    if {![winfo exists $w]} { return }
+    set idx [$w.lb curselection]
+    if {$idx == ""} { return }
+
+    if {[$w.text edit modified]} {
+      storeEpdText $id
+    }
+
+    set clipFen [string range [sc_pos fen] 0 end-4]
+    set clipOpcodes [sc_epd get $id]
+  }
+
+  ################################################################################
+  ### Paste the previously copied EPD record into this EPD file.
+  ################################################################################
+  proc pasteEpdRecord {id} {
+    variable clipFen
+    variable clipOpcodes
+    if {$clipFen eq ""} { return }
+    set w .epd$id
+    if {![winfo exists $w]} { return }
+    if {[sc_epd readonly $id]} { return }
+
+    if {[$w.text edit modified]} {
+      storeEpdText $id
+    }
+
+    sc_game push
+    sc_game startBoard $clipFen
+
+    set exists [sc_epd exists $id]
+    sc_epd set $id $clipOpcodes
+
+    if {!$exists} {
+      set size [sc_epd size $id]
+      $w.lb insert end "$size    $clipFen"
+      set idx [expr $size - 1]
+    } else {
+      set idx [sc_epd index $id]
+    }
+
+    sc_game pop
+
+    $w.lb selection clear 0 end
     $w.lb selection set $idx
     $w.lb see $idx
     updateEpdWin $id

--- a/tcl/file/epd.tcl
+++ b/tcl/file/epd.tcl
@@ -408,7 +408,6 @@ namespace eval epd {
     sc_game pop
 
     updateEpdWin $id
-    $w.lb see $idx
   }
   ################################################################################
   ### Save changes to the EPD file.

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -204,6 +204,8 @@ translate J positions {позиције}
 translate J EpdDeleteRow {Избриши ред}
 translate J EpdCloseWarning {Ова ЕПД датотека је измењена.\nЖелите ли да је сачувате?}
 translate J EpdDeletePosition {Избриши позицију}
+translate J EpdCopyRecord {Копирај запис}
+translate J EpdPasteRecord {Пасте Рецорд}
 
 # Tools menu:
 menuText J Tools "Алати" 0

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -205,7 +205,7 @@ translate J EpdDeleteRow {Избриши ред}
 translate J EpdCloseWarning {Ова ЕПД датотека је измењена.\nЖелите ли да је сачувате?}
 translate J EpdDeletePosition {Избриши позицију}
 translate J EpdCopyRecord {Копирај запис}
-translate J EpdPasteRecord {Пасте Рецорд}
+translate J EpdPasteRecord {Налепи запис}
 
 # Tools menu:
 menuText J Tools "Алати" 0

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -163,6 +163,8 @@ translate b positions {অবস্থান}
 translate b EpdDeleteRow {সারি মুছুন}
 translate b EpdCloseWarning {এই EPD ফাইলটি পরিবর্তন করা হয়েছে।\nআপনি কি এটি সংরক্ষণ করতে চান?}
 translate b EpdDeletePosition {অবস্থান মুছুন}
+translate b EpdCopyRecord {কপি রেকর্ড}
+translate b EpdPasteRecord {পেস্ট রেকর্ড}
 
 # Tools menu:
 menuText b Tools "টুলস" 0

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -204,6 +204,8 @@ translate g positions {позиции}
 translate g EpdDeleteRow {Изтриване на ред}
 translate g EpdCloseWarning {Този EPD файл е променен.\nИскате ли да го запазите?}
 translate g EpdDeletePosition {Изтриване на позиция}
+translate g EpdCopyRecord {Копиране на запис}
+translate g EpdPasteRecord {Поставяне на запис}
 
 # Tools menu:
 menuText g Tools "Инструменти" 0

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -179,6 +179,8 @@ translate K positions {posicions}
 translate K EpdDeleteRow {Suprimeix la fila}
 translate K EpdCloseWarning {Aquest fitxer EPD s'ha alterat.\nEl voleu desar?}
 translate K EpdDeletePosition {Suprimeix la posició}
+translate K EpdCopyRecord {Copia el registre}
+translate K EpdPasteRecord {Enganxa el registre}
 
 # Tools menu:
 menuText K Tools "Eines" 0

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -143,6 +143,8 @@ translate M positions {位置}
 translate M EpdDeleteRow {删除行}
 translate M EpdCloseWarning {此 EPD 文件已被更改。\n您要保存它吗？}
 translate M EpdDeletePosition {删除职位}
+translate M EpdCopyRecord {复制记录}
+translate M EpdPasteRecord {粘贴记录}
 
 # Tools menu:
 menuText M Tools "工具" 0

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -162,6 +162,8 @@ translate C positions {pozice}
 translate C EpdDeleteRow {Smazat řádek}
 translate C EpdCloseWarning {Tento soubor EPD byl změněn.\nPřejete si jej uložit?}
 translate C EpdDeletePosition {Smazat pozici}
+translate C EpdCopyRecord {Kopírovat záznam}
+translate C EpdPasteRecord {Vložit záznam}
 
 # Tools menu:
 menuText C Tools "Nstroje" 3

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -190,6 +190,8 @@ translate D positions {Positionen}
 translate D EpdDeleteRow {Zeile löschen}
 translate D EpdCloseWarning {Diese EPD-Datei wurde geändert.\nMöchten Sie sie speichern?}
 translate D EpdDeletePosition {Position löschen}
+translate D EpdCopyRecord {Datensatz kopieren}
+translate D EpdPasteRecord {Datensatz einfügen}
 
 # Tools menu:
 menuText D Tools "Werkzeuge" 0

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -203,6 +203,8 @@ translate E positions {positions}
 translate E EpdDeleteRow {Delete row}
 translate E EpdCloseWarning {This EPD file has been altered.\nDo you wish to save it?}
 translate E EpdDeletePosition {Delete Position}
+translate E EpdCopyRecord {Copy Record}
+translate E EpdPasteRecord {Paste Record}
 
 # Tools menu:
 menuText E Tools "Tools" 0

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -176,6 +176,8 @@ translate F positions {postes}
 translate F EpdDeleteRow {Supprimer la ligne}
 translate F EpdCloseWarning {Ce fichier EPD a été modifié.\nVoulez-vous le sauvegarder ?}
 translate F EpdDeletePosition {Supprimer le poste}
+translate F EpdCopyRecord {Copier l'enregistrement}
+translate F EpdPasteRecord {Coller l'enregistrement}
 
 # Tools menu:
 menuText F Tools "Outils" 2

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -195,6 +195,8 @@ translate G positions {θέσεις}
 translate G EpdDeleteRow {Διαγραφή σειράς}
 translate G EpdCloseWarning {Αυτό το αρχείο EPD έχει τροποποιηθεί.\nΘέλετε να το αποθηκεύσετε;}
 translate G EpdDeletePosition {Διαγραφή θέσης}
+translate G EpdCopyRecord {Αντιγραφή εγγραφής}
+translate G EpdPasteRecord {Επικόλληση εγγραφής}
 
 # Tools menu:
 menuText G Tools "Εργαλεία" 0

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -164,6 +164,8 @@ translate V positions {עמדות}
 translate V EpdDeleteRow {מחק שורה}
 translate V EpdCloseWarning {קובץ EPD זה השתנה.\nהאם ברצונך לשמור אותו?}
 translate V EpdDeletePosition {מחק עמדה}
+translate V EpdCopyRecord {העתק רשומה}
+translate V EpdPasteRecord {הדבק רשומה}
 
 # Tools menu:
 menuText V Tools "כְּלֵי עֲבוֹדָה" 0

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -163,6 +163,8 @@ translate h positions {पदों}
 translate h EpdDeleteRow {पंक्ति को हटाएं}
 translate h EpdCloseWarning {यह EPD फ़ाइल बदल दी गई है.\nक्या आप इसे सहेजना चाहते हैं?}
 translate h EpdDeletePosition {स्थिति हटाएँ}
+translate h EpdCopyRecord {रिकॉर्ड कॉपी करें}
+translate h EpdPasteRecord {रिकार्ड चिपकाएँ}
 
 # Tools menu:
 menuText h Tools "औजार" 0

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -166,6 +166,8 @@ translate H positions {pozíciókat}
 translate H EpdDeleteRow {Sor törlése}
 translate H EpdCloseWarning {Ez az EPD-fájl módosult.\nSzeretné menteni?}
 translate H EpdDeletePosition {Pozíció törlése}
+translate H EpdCopyRecord {Rekord másolása}
+translate H EpdPasteRecord {Paste Record}
 
 # Tools menu:
 menuText H Tools "Eszközök" 0

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -167,7 +167,7 @@ translate H EpdDeleteRow {Sor törlése}
 translate H EpdCloseWarning {Ez az EPD-fájl módosult.\nSzeretné menteni?}
 translate H EpdDeletePosition {Pozíció törlése}
 translate H EpdCopyRecord {Rekord másolása}
-translate H EpdPasteRecord {Paste Record}
+translate H EpdPasteRecord {Rekord beillesztése}
 
 # Tools menu:
 menuText H Tools "Eszközök" 0

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -166,6 +166,8 @@ translate I positions {posizioni}
 translate I EpdDeleteRow {Elimina riga}
 translate I EpdCloseWarning {Questo file EPD è stato modificato.\nVuoi salvarlo?}
 translate I EpdDeletePosition {Elimina posizione}
+translate I EpdCopyRecord {Copia registrazione}
+translate I EpdPasteRecord {Incolla registrazione}
 
 # Tools menu:
 menuText I Tools "Strumenti" 0

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -204,6 +204,8 @@ translate A positions {ポジション}
 translate A EpdDeleteRow {行の削除}
 translate A EpdCloseWarning {この EPD ファイルは変更されています。\n保存しますか?}
 translate A EpdDeletePosition {位置の削除}
+translate A EpdCopyRecord {レコードのコピー}
+translate A EpdPasteRecord {レコードの貼り付け}
 
 # Tools menu:
 menuText A Tools "ツール" 0

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -204,6 +204,8 @@ translate k positions {위치}
 translate k EpdDeleteRow {행 삭제}
 translate k EpdCloseWarning {이 EPD 파일은 변경되었습니다.\n저장하시겠습니까?}
 translate k EpdDeletePosition {위치 삭제}
+translate k EpdCopyRecord {기록 복사}
+translate k EpdPasteRecord {기록 붙여넣기}
 
 # Tools menu:
 menuText k Tools "도구" 0

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -184,6 +184,8 @@ translate N positions {posities}
 translate N EpdDeleteRow {Rij verwijderen}
 translate N EpdCloseWarning {Dit EPD-bestand is gewijzigd.\nWilt u het opslaan?}
 translate N EpdDeletePosition {Positie verwijderen}
+translate N EpdCopyRecord {Kopieer opname}
+translate N EpdPasteRecord {Plak record}
 
 # Tools menu:
 menuText N Tools "Gereedschappen" 0

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -168,6 +168,8 @@ translate O positions {stillinger}
 translate O EpdDeleteRow {Slett rad}
 translate O EpdCloseWarning {Denne EPD-filen har blitt endret.\nVil du lagre den?}
 translate O EpdDeletePosition {Slett posisjon}
+translate O EpdCopyRecord {Kopier posten}
+translate O EpdPasteRecord {Lim inn post}
 
 # Tools menu:
 menuText O Tools "Verktøy" 0

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -125,6 +125,8 @@ translate P positions {pozycje}
 translate P EpdDeleteRow {Usuń wiersz}
 translate P EpdCloseWarning {Ten plik EPD został zmieniony.\nCzy chcesz go zapisać?}
 translate P EpdDeletePosition {Usuń pozycję}
+translate P EpdCopyRecord {Kopiuj zapis}
+translate P EpdPasteRecord {Wklej zapis}
 
 # Tools menu:
 menuText P Tools {Narzędzia} 0
@@ -1824,7 +1826,7 @@ translate P TBNotFound {Nie znaleziono pozycji w tablicy końcówek albo wystąp
 translate P TBCategory {Kategoria pozycji:}
 translate P TBTrainingHidden {(Tryb treningu; wyniki są ukryte)}
 }
-# end of polish.tcl
+# end of english.tcl
 
 
 ############################################################

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -1826,7 +1826,7 @@ translate P TBNotFound {Nie znaleziono pozycji w tablicy końcówek albo wystąp
 translate P TBCategory {Kategoria pozycji:}
 translate P TBTrainingHidden {(Tryb treningu; wyniki są ukryte)}
 }
-# end of english.tcl
+# end of polish.tcl
 
 
 ############################################################

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -167,6 +167,8 @@ translate B positions {posições}
 translate B EpdDeleteRow {Excluir linha}
 translate B EpdCloseWarning {Este arquivo EPD foi alterado.\nDeseja salvá-lo?}
 translate B EpdDeletePosition {Excluir posição}
+translate B EpdCopyRecord {Copiar registro}
+translate B EpdPasteRecord {Colar registro}
 
 # Tools menu:
 menuText B Tools "Ferramentas" 0

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -204,6 +204,8 @@ translate L positions {pozitii}
 translate L EpdDeleteRow {Ștergeți rândul}
 translate L EpdCloseWarning {Acest fișier EPD a fost modificat.\nDoriți să-l salvați?}
 translate L EpdDeletePosition {Șterge poziție}
+translate L EpdCopyRecord {Copiați înregistrarea}
+translate L EpdPasteRecord {Lipiți înregistrarea}
 
 # Tools menu:
 menuText L Tools "Instrumente" 0

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -170,6 +170,8 @@ translate R positions {позиции}
 translate R EpdDeleteRow {Удалить строку}
 translate R EpdCloseWarning {Этот файл EPD был изменен.\nХотите сохранить его?}
 translate R EpdDeletePosition {Удалить позицию}
+translate R EpdCopyRecord {Копировать запись}
+translate R EpdPasteRecord {Вставить запись}
 
 # Tools menu:
 menuText R Tools "Инструменты" 2

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -193,6 +193,10 @@ translate Y EpdDeleteRow {Delete row}
 translate Y EpdCloseWarning {This EPD file has been altered.\nDo you wish to save it?}
 # ====== TODO To be translated ======
 translate Y EpdDeletePosition {Delete Position}
+# ====== TODO To be translated ======
+translate Y EpdCopyRecord {Copy Record}
+# ====== TODO To be translated ======
+translate Y EpdPasteRecord {Paste Record}
 
 # Tools menu:
 menuText Y Tools "Alati" 0

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -181,6 +181,8 @@ translate S positions {posiciones}
 translate S EpdDeleteRow {Eliminar fila}
 translate S EpdCloseWarning {Este archivo EPD ha sido modificado.\n¿Desea guardarlo?}
 translate S EpdDeletePosition {Eliminar posición}
+translate S EpdCopyRecord {Copiar registro}
+translate S EpdPasteRecord {Pegar registro}
 
 # Tools menu:
 menuText S Tools "Herramientas" 0

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -202,6 +202,8 @@ translate U positions {asemat}
 translate U EpdDeleteRow {Poista rivi}
 translate U EpdCloseWarning {Tätä EPD-tiedostoa on muutettu.\nHaluatko tallentaa sen?}
 translate U EpdDeletePosition {Poista sijainti}
+translate U EpdCopyRecord {Kopioi tietue}
+translate U EpdPasteRecord {Liitä tietue}
 
 # Tools menu:
 menuText U Tools "Työkalut" 1

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -163,6 +163,8 @@ translate Z positions {nafasi}
 translate Z EpdDeleteRow {Futa safu mlalo}
 translate Z EpdCloseWarning {Faili hii ya EPD imebadilishwa.\nJe, ungependa kuihifadhi?}
 translate Z EpdDeletePosition {Futa Nafasi}
+translate Z EpdCopyRecord {Nakili Rekodi}
+translate Z EpdPasteRecord {Bandika Rekodi}
 
 # Tools menu:
 menuText Z Tools "Zana" 0

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -169,6 +169,8 @@ translate W positions {positioner}
 translate W EpdDeleteRow {Ta bort rad}
 translate W EpdCloseWarning {Denna EPD-fil har ändrats.\nVill du spara den?}
 translate W EpdDeletePosition {Ta bort position}
+translate W EpdCopyRecord {Kopiera post}
+translate W EpdPasteRecord {Klistra in post}
 
 # Tools menu:
 menuText W Tools "Verktyg" 0

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -167,6 +167,8 @@ translate T positions {pozisyonlar}
 translate T EpdDeleteRow {Satırı sil}
 translate T EpdCloseWarning {Bu EPD dosyası değiştirildi.\nKaydetmek istiyor musunuz?}
 translate T EpdDeletePosition {Pozisyonu Sil}
+translate T EpdCopyRecord {Kaydı Kopyala}
+translate T EpdPasteRecord {Kaydı Yapıştır}
 
 # Tools menu:
 menuText T Tools "Aletler" 0

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -164,6 +164,8 @@ translate Q positions {позиції}
 translate Q EpdDeleteRow {Видалити рядок}
 translate Q EpdCloseWarning {Цей файл EPD було змінено.\nЗберегти його?}
 translate Q EpdDeletePosition {Видалити позицію}
+translate Q EpdCopyRecord {Копіювати запис}
+translate Q EpdPasteRecord {Вставити запис}
 
 # Tools menu:
 menuText Q Tools "Інструменти" 0

--- a/tcl/tools/sergame.tcl
+++ b/tcl/tools/sergame.tcl
@@ -185,7 +185,7 @@ namespace eval sergame {
 
     ttk::frame $w.fcoach.ad
     ttk::checkbutton $w.fcoach.ad.cbLimitAnalysis -text $::tr(limitanalysis) -variable ::sergame::isLimitedAnalysisTime
-    ttk::spinbox $w.fcoach.ad.val -width 3 -from 5 -to 360 -increment 1 -textvariable ::sergame::analysisTime -validate all -validatecommand { regexp {^[0-9]+$} %P }
+    ttk::spinbox $w.fcoach.ad.val -width 3 -from 1 -to 360 -increment 1 -textvariable ::sergame::analysisTime -validate all -validatecommand { regexp {^[0-9]+$} %P }
     ttk::label $w.fcoach.ad.lblSec -text $::tr(seconds)
     pack $w.fcoach.ad.cbLimitAnalysis $w.fcoach.ad.val $w.fcoach.ad.lblSec -side left -anchor w -padx 4
 
@@ -1065,6 +1065,7 @@ namespace eval sergame {
     global ::sergame::isLimitedAnalysisTime ::sergame::analysisTime
     set n 2
     after cancel ::sergame::stopAnalyze
+    ::sergame::sendToEngine $n "stop"
     set ::analysis(waitForReadyOk$n) 0
     ::uci::sendToEngine $n "isready"
     vwaitTimed ::analysis(waitForReadyOk$n) 5000 "nowarn"

--- a/tcl/tools/sergame.tcl
+++ b/tcl/tools/sergame.tcl
@@ -415,7 +415,7 @@ namespace eval sergame {
 
     set ::sergame::activeColor $::sergame::playerColor
     if {$::sergame::activeColor == "random"} {
-      set ::sergame::activeColor [expr {rand() < 0.5 ? "white" : "black"}]
+      set ::sergame::activeColor [lindex {white black} [expr {int(rand() * 2)}]]
     }
 
     # Engine plays for the opposite side of player color


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to copy and paste complete EPD records, including position and opcode data.
  * Pasting can update an existing record or create a new one when needed.
  * Added copy and paste commands to the EPD Tools menu and row context menu.
* **Localization**
  * Added translated labels for the new actions across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->