### PR TITLE
Menu font on Windows; engine blunders in Play versus Engine

### DIFF
--- a/tcl/start.tcl
+++ b/tcl/start.tcl
@@ -676,6 +676,10 @@ proc configure_menus {} {
   option add *Menu*TearOff 0
   if {[llength $::fontOptions(Menu)] == 4} { option add *Menu*Font font_Menu }
 
+  if {[winfo exists .menu]} {
+    catch { .menu configure -font font_Menu }
+  }
+
   if {$::unixOS} {
     set bg [ttk::style lookup . -background]
     set activeBg [ttk::style lookup . -background active]
@@ -1037,6 +1041,8 @@ tools/batch_annotate.tcl
 foreach f $tcl_files {
   source -encoding utf-8 [file nativename [file join $::scidTclDir "$f"]]
 }
+
+configure_menus
 
 ###
 ### End of file: start.tcl

--- a/tcl/tools/sergame.tcl
+++ b/tcl/tools/sergame.tcl
@@ -1075,6 +1075,8 @@ namespace eval sergame {
     ::uci::sendToEngine $n "position fen [sc_pos fen]"
     set ::sergame::lastAnalyzeFen [sc_pos fen]
     ::uci::sendToEngine $n "go depth 12"
+    set ::uci::uciInfo(score2) ""
+    set ::uci::uciInfo(bestmove2) ""
     set ::sergame::coachAnalyzed 1
 
     if { $isLimitedAnalysisTime == 1 } {

--- a/tcl/windows/preferences.tcl
+++ b/tcl/windows/preferences.tcl
@@ -276,6 +276,7 @@ proc ::preferences::fonts { w } {
             if {$new_options != ""} {
                 set ::fontOptions($name) $new_options
             }
+            if {$name eq "Menu"} { configure_menus }
         }} $font]
         grid $w.lb$f -row $idx -column 0 -sticky w -pady 5
         grid $w.font$f -row $idx -column 1 -sticky w -padx 5 -pady 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Menu text now updates immediately when the Menu font is changed in Preferences.
  * Menu styling is reapplied consistently during startup.
  * Coach analysis now starts with cleared previous evaluation data, preventing stale results from carrying over.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->