### PR TITLE
Engine playout enhancement and Board window undocking

### DIFF
--- a/tcl/tools/analysis.tcl
+++ b/tcl/tools/analysis.tcl
@@ -2005,6 +2005,12 @@ proc toggleFinishGame { { n 1 } } {
 	grab .analysisWin$n
 
 	while { [string index [sc_game info previousMove] end] != "#"} {
+		if {[::pgn::getRepetitionCount] >= 3} {
+			sc_game tags set -result "1/2-1/2"
+			updateBoard -pgn
+			break
+		}
+
 		# Check for 7-man tablebase position before making the move
 		set fen [sc_pos fen]
 		set pieceCount [::tablebase::countPieces $fen]
@@ -2055,6 +2061,12 @@ proc toggleFinishGame { { n 1 } } {
 			makeAnalysisMove $current_engine
 		}
 
+		if {[::pgn::getRepetitionCount] >= 3} {
+			sc_game tags set -result "1/2-1/2"
+			updateBoard -pgn
+			break
+		}
+
 		incr current_cmd
 		if {$current_cmd > 2} { set current_cmd 1 }
 		if {$::finishGameMode == 2} {
@@ -2075,6 +2087,14 @@ proc autoplayFinishGame { {n 1} } {
         toggleFinishGame $n
         return
     }
+
+    # Check for 3-fold repetition
+    if {[::pgn::getRepetitionCount] >= 3} {
+        sc_game tags set -result "1/2-1/2"
+        updateBoard -pgn
+        toggleFinishGame $n
+        return
+    }
     
     # Make the engine move
     .analysisWin$n.b1.move invoke
@@ -2086,6 +2106,14 @@ proc autoplayFinishGame { {n 1} } {
 proc ::autoplayFinishGameCheck { {n 1} } {
     if {!$::finishGameMode || ![winfo exists .analysisWin$n]} {return}
     
+    # Check for 3-fold repetition after move has been applied
+    if {[::pgn::getRepetitionCount] >= 3} {
+        sc_game tags set -result "1/2-1/2"
+        updateBoard -pgn
+        toggleFinishGame $n
+        return
+    }
+
     # Check piece count after move has been applied
     set fen [sc_pos fen]
     set pieceCount [::tablebase::countPieces $fen]

--- a/tcl/utils/win.tcl
+++ b/tcl/utils/win.tcl
@@ -215,7 +215,7 @@ proc ::win::toggleDocked {wnd} {
 	lassign [::win::isDocked $wnd] docked_nb wnd
 
 	# Check if the window can be docked/undocked
-	if {$wnd eq ".main" || [winfo class $wnd] ne "Frame"} {
+	if {[winfo class $wnd] ne "Frame"} {
 		return
 	}
 
@@ -646,10 +646,10 @@ proc ::docking::manage_rightclick_ {noteb x y localX localY} {
 		-command "::docking::move_tab_ $wnd $noteb w"
 	$m add command -label [ ::tr DockRight ] -state $state \
 		-command "::docking::move_tab_ $wnd $noteb e"
-	# Main board can not be closed or undocked
+	# Main board can not be closed
+	$m add separator
+	$m add command -label [ ::tr Undock ] -command "::win::undockWindow $wnd $noteb"
 	if { $wnd != ".main" } {
-		$m add separator
-		$m add command -label [ ::tr Undock ] -command "::win::undockWindow $wnd $noteb"
 		$m add command -label [ ::tr Close ] -command "::win::closeWindow $wnd"
 	}
 	tk_popup $m $x $y

--- a/tcl/windows/pgn.tcl
+++ b/tcl/windows/pgn.tcl
@@ -496,7 +496,7 @@ proc ::pgn::openInChessDB {} {
   openURL $url
 }
 
-proc ::pgn::CheckRepetition {} {
+proc ::pgn::getRepetitionCount {} {
   set currentFen [lrange [split [sc_pos fen]] 0 3]
   set savedLoc [sc_pos pgnOffset]
   
@@ -518,6 +518,11 @@ proc ::pgn::CheckRepetition {} {
   
   # Restore position
   sc_move pgn $savedLoc
+  return $count
+}
+
+proc ::pgn::CheckRepetition {} {
+  set count [::pgn::getRepetitionCount]
   
   if {$count == 2} {
     tk_messageBox -message "2-fold repetition             " -title "Repetition Detection" -icon info -parent .
@@ -525,4 +530,5 @@ proc ::pgn::CheckRepetition {} {
     tk_messageBox -message "Draw - 3 Fold Repetition      " \
         -title "Repetition Detection" -icon info -parent .
   }
+  return $count
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Games now automatically end in a draw after threefold repetition during finish-game and autoplay modes.
  - Repetition counts are returned for improved game-state handling.

- **Improvements**
  - Board and PGN displays update immediately when a repetition draw is detected.
  - Autoplay stops automatically when the game becomes a draw.
  - Main-board tabs can now be undocked while remaining protected from closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->