### PR TITLE
add Dock command with right-click on undocked window tab

### DIFF
--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -1821,6 +1821,7 @@ translate J DockBottom {Помери на дно}
 translate J DockLeft {Помери се лево}
 translate J DockRight {Помери удесно}
 translate J Undock {Одспојите}
+translate J Dock {Доцк}
 
 # Switcher window
 translate J AboutDatabase {О овој бази података}

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -1821,7 +1821,7 @@ translate J DockBottom {Помери на дно}
 translate J DockLeft {Помери се лево}
 translate J DockRight {Помери удесно}
 translate J Undock {Одспојите}
-translate J Dock {Доцк}
+translate J Dock {Докирај}
 
 # Switcher window
 translate J AboutDatabase {О овој бази података}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -1780,7 +1780,7 @@ translate b DockBottom {নীচে সরান}
 translate b DockLeft {বাম দিকে সরান}
 translate b DockRight {ডানদিকে সরান}
 translate b Undock {আনডক করুন}
-translate b Dock {ডক}
+translate b Dock {ডক করুন}
 
 # Switcher window
 translate b AboutDatabase {এই ডাটাবেস সম্পর্কে}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -1780,6 +1780,7 @@ translate b DockBottom {নীচে সরান}
 translate b DockLeft {বাম দিকে সরান}
 translate b DockRight {ডানদিকে সরান}
 translate b Undock {আনডক করুন}
+translate b Dock {ডক}
 
 # Switcher window
 translate b AboutDatabase {এই ডাটাবেস সম্পর্কে}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -1821,6 +1821,7 @@ translate g DockBottom {Преместване надолу}
 translate g DockLeft {Преместете се наляво}
 translate g DockRight {Преместете се надясно}
 translate g Undock {Откачване}
+translate g Dock {Док}
 
 # Switcher window
 translate g AboutDatabase {Относно тази база данни}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -1824,6 +1824,7 @@ translate K DockBottom {Moure abaix}
 translate K DockLeft {Moure a l'esquerra}
 translate K DockRight {Moure a la dreta}
 translate K Undock {Finestra flotant}
+translate K Dock {Moll}
 
 # Switcher window
 translate K AboutDatabase {Sobre aquesta base de dades}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -1824,7 +1824,7 @@ translate K DockBottom {Moure abaix}
 translate K DockLeft {Moure a l'esquerra}
 translate K DockRight {Moure a la dreta}
 translate K Undock {Finestra flotant}
-translate K Dock {Moll}
+translate K Dock {Acobla}
 
 # Switcher window
 translate K AboutDatabase {Sobre aquesta base de dades}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1756,7 +1756,7 @@ translate M DockBottom {移至底部}
 translate M DockLeft {向左移动}
 translate M DockRight {向右移动}
 translate M Undock {取消对接}
-translate M Dock {码头}
+translate M Dock {停靠}
 
 # Switcher window
 translate M AboutDatabase {关于此数据库}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1756,6 +1756,7 @@ translate M DockBottom {移至底部}
 translate M DockLeft {向左移动}
 translate M DockRight {向右移动}
 translate M Undock {取消对接}
+translate M Dock {码头}
 
 # Switcher window
 translate M AboutDatabase {关于此数据库}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -1802,6 +1802,7 @@ translate C DockBottom {Pesunout dol}
 translate C DockLeft {Pesunout doleva}
 translate C DockRight {Pesunout doprava}
 translate C Undock {Odpojit}
+translate C Dock {Dok}
 
 # Switcher window
 translate C AboutDatabase {O tto databzi}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -1802,7 +1802,7 @@ translate C DockBottom {Pesunout dol}
 translate C DockLeft {Pesunout doleva}
 translate C DockRight {Pesunout doprava}
 translate C Undock {Odpojit}
-translate C Dock {Dok}
+translate C Dock {Ukotvit}
 
 # Switcher window
 translate C AboutDatabase {O tto databzi}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -1852,7 +1852,7 @@ translate D DockBottom {Nach unten}
 translate D DockLeft {Nach links}
 translate D DockRight {Nach rechts}
 translate D Undock {Fenster lösen}
-translate D Dock {Dock}
+translate D Dock {Andocken}
 
 # Switcher window
 translate D AboutDatabase {Über diese Datenbank}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -1852,6 +1852,7 @@ translate D DockBottom {Nach unten}
 translate D DockLeft {Nach links}
 translate D DockRight {Nach rechts}
 translate D Undock {Fenster lösen}
+translate D Dock {Dock}
 
 # Switcher window
 translate D AboutDatabase {Über diese Datenbank}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -1834,6 +1834,7 @@ translate E DockBottom {Move to bottom}
 translate E DockLeft {Move to left}
 translate E DockRight {Move to right}
 translate E Undock {Undock}
+translate E Dock {Dock}
 
 # Switcher window
 translate E AboutDatabase {About This Database}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -1808,6 +1808,7 @@ translate F DockBottom {Déplacer en bas}
 translate F DockLeft {Déplacer à gauche}
 translate F DockRight {Déplacer à droite}
 translate F Undock {Détacher}
+translate F Dock {Quai}
 
 # Switcher window
 translate F AboutDatabase {À propos de cette base de données}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -1808,7 +1808,7 @@ translate F DockBottom {Déplacer en bas}
 translate F DockLeft {Déplacer à gauche}
 translate F DockRight {Déplacer à droite}
 translate F Undock {Détacher}
-translate F Dock {Quai}
+translate F Dock {Ancrer}
 
 # Switcher window
 translate F AboutDatabase {À propos de cette base de données}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -1829,7 +1829,7 @@ translate G DockBottom {Μετάβαση στο κάτω μέρος}
 translate G DockLeft {Μετάβαση αριστερά}
 translate G DockRight {Μετάβαση δεξιά}
 translate G Undock {Αποκόληση}
-translate G Dock {Προκυμαία}
+translate G Dock {Προσάρτηση}
 
 # Switcher window
 translate G AboutDatabase {Σχετικά με αυτήν τη βάση δεδομένων}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -1829,6 +1829,7 @@ translate G DockBottom {Μετάβαση στο κάτω μέρος}
 translate G DockLeft {Μετάβαση αριστερά}
 translate G DockRight {Μετάβαση δεξιά}
 translate G Undock {Αποκόληση}
+translate G Dock {Προκυμαία}
 
 # Switcher window
 translate G AboutDatabase {Σχετικά με αυτήν τη βάση δεδομένων}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -1781,6 +1781,7 @@ translate V DockBottom {עברו למטה}
 translate V DockLeft {זז שמאלה}
 translate V DockRight {זז ימינה}
 translate V Undock {בטל עגינה}
+translate V Dock {לַעֲגוֹן}
 
 # Switcher window
 translate V AboutDatabase {על מאגר מידע זה}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -1781,7 +1781,7 @@ translate V DockBottom {עברו למטה}
 translate V DockLeft {זז שמאלה}
 translate V DockRight {זז ימינה}
 translate V Undock {בטל עגינה}
-translate V Dock {לַעֲגוֹן}
+translate V Dock {עגינה}
 
 # Switcher window
 translate V AboutDatabase {על מאגר מידע זה}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -1780,6 +1780,7 @@ translate h DockBottom {नीचे की ओर ले जाएँ}
 translate h DockLeft {बाईं ओर जाएँ}
 translate h DockRight {दाईं ओर जाएँ}
 translate h Undock {अनडॉक}
+translate h Dock {गोदी}
 
 # Switcher window
 translate h AboutDatabase {इस डेटाबेस के बारे में}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -1780,7 +1780,7 @@ translate h DockBottom {नीचे की ओर ले जाएँ}
 translate h DockLeft {बाईं ओर जाएँ}
 translate h DockRight {दाईं ओर जाएँ}
 translate h Undock {अनडॉक}
-translate h Dock {गोदी}
+translate h Dock {डॉक}
 
 # Switcher window
 translate h AboutDatabase {इस डेटाबेस के बारे में}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -1803,6 +1803,7 @@ translate H DockBottom {Mozgatás alulra}
 translate H DockLeft {Mozgatás balra}
 translate H DockRight {Mozgatás jobbra}
 translate H Undock {Feloldás}
+translate H Dock {Dokk}
 
 # Switcher window
 translate H AboutDatabase {Errõl az adatbázisról}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -1803,7 +1803,7 @@ translate H DockBottom {Mozgatás alulra}
 translate H DockLeft {Mozgatás balra}
 translate H DockRight {Mozgatás jobbra}
 translate H Undock {Feloldás}
-translate H Dock {Dokk}
+translate H Dock {Dokkolás}
 
 # Switcher window
 translate H AboutDatabase {Errõl az adatbázisról}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -1804,6 +1804,7 @@ translate I DockBottom {Sposta in basso}
 translate I DockLeft {Sposta a sinistra}
 translate I DockRight {Sposta a destra}
 translate I Undock {Sgancia}
+translate I Dock {Dock}
 
 # Switcher window
 translate I AboutDatabase {Informazioni}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -1804,7 +1804,7 @@ translate I DockBottom {Sposta in basso}
 translate I DockLeft {Sposta a sinistra}
 translate I DockRight {Sposta a destra}
 translate I Undock {Sgancia}
-translate I Dock {Dock}
+translate I Dock {Aggancia}
 
 # Switcher window
 translate I AboutDatabase {Informazioni}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -1821,6 +1821,7 @@ translate A DockBottom {一番下に移動}
 translate A DockLeft {左に移動}
 translate A DockRight {右に移動}
 translate A Undock {アンドック}
+translate A Dock {ドック}
 
 # Switcher window
 translate A AboutDatabase {このデータベースについて}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -1821,6 +1821,7 @@ translate k DockBottom {맨 아래로 이동}
 translate k DockLeft {왼쪽으로 이동}
 translate k DockRight {오른쪽으로 이동}
 translate k Undock {도킹하다}
+translate k Dock {독}
 
 # Switcher window
 translate k AboutDatabase {이 데이터베이스 정보}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -1827,6 +1827,7 @@ translate N DockBottom {Zend naar laatste plaats}
 translate N DockLeft {Zend naar links}
 translate N DockRight {Zend naar rechts}
 translate N Undock {Undock}
+translate N Dock {Dok}
 
 # Switcher window
 translate N AboutDatabase {Over deze databank}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -1802,6 +1802,7 @@ translate O DockBottom {Flytt til bunnen}
 translate O DockLeft {Flytt til venstre}
 translate O DockRight {Flytt til høyre}
 translate O Undock {Koble fra}
+translate O Dock {Dokk}
 
 # Switcher window
 translate O AboutDatabase {Om denne databasen}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -1732,6 +1732,7 @@ translate P DockBottom {Przenieś na dół}
 translate P DockLeft {Przenieś w lewo}
 translate P DockRight {Przenieś w prawo}
 translate P Undock {Oddokuj}
+translate P Dock {Dok}
 
 # Switcher window
 translate P AboutDatabase {O tej bazie}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -1732,7 +1732,7 @@ translate P DockBottom {Przenieś na dół}
 translate P DockLeft {Przenieś w lewo}
 translate P DockRight {Przenieś w prawo}
 translate P Undock {Oddokuj}
-translate P Dock {Dok}
+translate P Dock {Dokuj}
 
 # Switcher window
 translate P AboutDatabase {O tej bazie}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -1810,7 +1810,7 @@ translate B DockBottom {Mover para o final}
 translate B DockLeft {Mover para a esquerda}
 translate B DockRight {Mover para a direita}
 translate B Undock {Desacoplar}
-translate B Dock {Doca}
+translate B Dock {Acoplar}
 
 # Switcher window
 translate B AboutDatabase {Sobre este banco de dados}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -1810,6 +1810,7 @@ translate B DockBottom {Mover para o final}
 translate B DockLeft {Mover para a esquerda}
 translate B DockRight {Mover para a direita}
 translate B Undock {Desacoplar}
+translate B Dock {Doca}
 
 # Switcher window
 translate B AboutDatabase {Sobre este banco de dados}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -1821,7 +1821,7 @@ translate L DockBottom {Mutați în jos}
 translate L DockLeft {Deplasați la stânga}
 translate L DockRight {Deplasați-vă la dreapta}
 translate L Undock {Deconectați}
-translate L Dock {Dock}
+translate L Dock {Andocare}
 
 # Switcher window
 translate L AboutDatabase {Despre această bază de date}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -1821,6 +1821,7 @@ translate L DockBottom {Mutați în jos}
 translate L DockLeft {Deplasați la stânga}
 translate L DockRight {Deplasați-vă la dreapta}
 translate L Undock {Deconectați}
+translate L Dock {Dock}
 
 # Switcher window
 translate L AboutDatabase {Despre această bază de date}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -1804,6 +1804,7 @@ translate R DockBottom {Двигаться вниз}
 translate R DockLeft {Двигаться влево}
 translate R DockRight {Двигаться вправо}
 translate R Undock {Расстыковать}
+translate R Dock {Док}
 
 # Switcher window
 translate R AboutDatabase {Об этой базе данных}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -3033,6 +3033,8 @@ translate Y DockRight {Move to right}
 # ====== TODO To be translated ======
 translate Y Undock {Undock}
 # ====== TODO To be translated ======
+translate Y Dock {Dock}
+# ====== TODO To be translated ======
 translate Y AboutDatabase {About This Database}
 # ====== TODO To be translated ======
 translate Y ChangeIcon {Choose database icon...}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -1855,6 +1855,7 @@ translate S DockBottom {Mover abajo}
 translate S DockLeft {Mover a la izquierda}
 translate S DockRight {Mover a la derecha}
 translate S Undock {Ventana flotante}
+translate S Dock {Muelle}
 
 # Switcher window
 translate S AboutDatabase {Acerca de esta base de datos}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -1855,7 +1855,7 @@ translate S DockBottom {Mover abajo}
 translate S DockLeft {Mover a la izquierda}
 translate S DockRight {Mover a la derecha}
 translate S Undock {Ventana flotante}
-translate S Dock {Muelle}
+translate S Dock {Acoplar}
 
 # Switcher window
 translate S AboutDatabase {Acerca de esta base de datos}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -1833,7 +1833,7 @@ translate U DockBottom {Siirrä alimmaksi}
 translate U DockLeft {Siirrä vasemmalle}
 translate U DockRight {Siirrä oikealle}
 translate U Undock {Vapauta lukitus}
-translate U Dock {Telakka}
+translate U Dock {Telakoi}
 
 # Switcher window
 translate U AboutDatabase {Tietoja tästä tietokannasta}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -1833,6 +1833,7 @@ translate U DockBottom {Siirrä alimmaksi}
 translate U DockLeft {Siirrä vasemmalle}
 translate U DockRight {Siirrä oikealle}
 translate U Undock {Vapauta lukitus}
+translate U Dock {Telakka}
 
 # Switcher window
 translate U AboutDatabase {Tietoja tästä tietokannasta}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -1780,6 +1780,7 @@ translate Z DockBottom {Sogeza hadi chini}
 translate Z DockLeft {Sogeza kushoto}
 translate Z DockRight {Sogeza kulia}
 translate Z Undock {Tendua}
+translate Z Dock {Gati}
 
 # Switcher window
 translate Z AboutDatabase {Kuhusu Hifadhidata Hii}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -1808,6 +1808,7 @@ translate W DockBottom {Drag nederst}
 translate W DockLeft {Drag till vänster}
 translate W DockRight {Drag till höger}
 translate W Undock {Avdocka}
+translate W Dock {Docka}
 
 # Switcher window
 translate W AboutDatabase {Om denna databas}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -1784,7 +1784,7 @@ translate T DockBottom {En alta taşı}
 translate T DockLeft {Sola git}
 translate T DockRight {Sağa git}
 translate T Undock {Bağlantıyı kes}
-translate T Dock {Rıhtım}
+translate T Dock {Yerleştir}
 
 # Switcher window
 translate T AboutDatabase {Bu Veritabanı Hakkında}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -1784,6 +1784,7 @@ translate T DockBottom {En alta taşı}
 translate T DockLeft {Sola git}
 translate T DockRight {Sağa git}
 translate T Undock {Bağlantıyı kes}
+translate T Dock {Rıhtım}
 
 # Switcher window
 translate T AboutDatabase {Bu Veritabanı Hakkında}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -1781,6 +1781,7 @@ translate Q DockBottom {Перемістіть вниз}
 translate Q DockLeft {Рух ліворуч}
 translate Q DockRight {Рух праворуч}
 translate Q Undock {Відстикувати}
+translate Q Dock {Док}
 
 # Switcher window
 translate Q AboutDatabase {Про цю базу даних}

--- a/tcl/utils/win.tcl
+++ b/tcl/utils/win.tcl
@@ -178,6 +178,9 @@ proc ::win::undockWindow { wnd srctab {title ""} } {
 	# Remember the source notebook
 	set ::docking::notebook_name($wnd) $srctab
 
+	# Add a dock tab at the top for right-click re-docking
+	::docking::_addDockTab $wnd
+
 	#HACK: In Linux (tk8.6.8) without "after idle after 1"
 	#      sometimes the geometry is not restored correctly.
 	after idle after 1 "::win::restoreWinGeometry $wnd"
@@ -195,17 +198,36 @@ proc ::win::dockWindow {wnd} {
 	lassign [::win::getMenu $wnd] menu wmenu
 	$wmenu configure -menu {}
 
+	# Temporarily unbind <Destroy> on the embedded toplevel to prevent
+	# wm forget from cascading into window-specific destroy handlers
+	if {[string equal -length 6 $wnd ".fdock"]} {
+		set toplevel [string replace $wnd 1 5]
+		if {[winfo exists $toplevel]} {
+			set savedDestroy [bind $toplevel <Destroy>]
+			bind $toplevel <Destroy> {}
+		}
+	}
+
 	wm forget $wnd
+
+	# Remove dock tab added by undockWindow
+	::docking::_removeDockTab $wnd
 
 	if {[winfo exists $::docking::notebook_name($wnd)]} {
 		set dsttab $::docking::notebook_name($wnd)
 	} else {
 		set dsttab [::docking::choose_notebook $wnd]
 	}
-	unset ::docking::notebook_name($wnd)
+	unset -nocomplain ::docking::notebook_name($wnd)
 	::docking::insert_tab $wnd $dsttab end \
 		[list -text $title -image tb_close -compound left]
 
+	# Restore <Destroy> binding
+	if {[info exists savedDestroy]} {
+		bind $toplevel <Destroy> $savedDestroy
+	}
+
+	update
 	if {$menu ne ""} { ::setMenu $wmenu $menu }
 }
 
@@ -651,6 +673,123 @@ proc ::docking::manage_rightclick_ {noteb x y localX localY} {
 	$m add command -label [ ::tr Undock ] -command "::win::undockWindow $wnd $noteb"
 	if { $wnd != ".main" } {
 		$m add command -label [ ::tr Close ] -command "::win::closeWindow $wnd"
+	}
+	tk_popup $m $x $y
+}
+
+# Add a dock tab to an undocked window for right-click context menu
+proc ::docking::_addDockTab {wnd} {
+	set title [wm title $wnd]
+	if {[string equal -length 15 $title "scidCommunity: "]} {
+		set title [string range $title 15 end]
+	}
+	if {[string equal -length 6 $wnd ".fdock"]} {
+		set topwin [string replace $wnd 1 5]
+	} else {
+		set topwin $wnd
+	}
+
+	set tab ${topwin}.undocktab
+	if {[winfo exists $tab]} { destroy $tab }
+	ttk::frame $tab -relief raised -borderwidth 1
+	ttk::label $tab.label -text $title -image tb_close -compound left
+	pack $tab.label -side left -padx {5 0} -pady 1
+
+	set packSlaves [pack slaves $topwin]
+	set gridSlaves [grid slaves $topwin]
+
+	if {[llength $packSlaves] > 0} {
+		pack $tab -side top -fill x -before [lindex $packSlaves 0]
+	} elseif {[llength $gridSlaves] > 0} {
+		# Save row weights for later restore
+		set savedWeights {}
+		for {set r 0} {$r < 10} {incr r} {
+			if {![catch {grid rowconfigure $topwin $r -weight} w] && $w > 0} {
+				lappend savedWeights $r $w
+				grid rowconfigure $topwin $r -weight 0
+			}
+		}
+		set ::docking::tabWeights($topwin) $savedWeights
+
+		# Shift all existing grid children down by 1
+		foreach child $gridSlaves {
+			set info [grid info $child]
+			set row [dict get $info -row]
+			set column [dict get $info -column]
+			if {[catch {dict get $info -sticky}]} { set sticky {} } else {
+				set sticky [dict get $info -sticky]
+			}
+			if {[catch {dict get $info -columnspan}]} { set colspan 1 } else {
+				set colspan [dict get $info -columnspan]
+			}
+			grid $child -row [expr {$row + 1}] \
+				-column $column -columnspan $colspan -sticky $sticky
+		}
+
+		# Restore shifted weights
+		foreach {r w} $savedWeights {
+			grid rowconfigure $topwin [expr {$r + 1}] -weight $w
+		}
+		grid rowconfigure $topwin 0 -weight 0
+
+		# Insert tab at row 0
+		grid $tab -row 0 -column 0 -sticky ew -columnspan 99
+	} else {
+		pack $tab -side top -fill x
+	}
+	bind $tab <ButtonRelease-$::MB3> [list ::docking::_dockTabMenu $wnd %X %Y]
+	bind $tab.label <Button-1> [list ::win::dockWindow $wnd]
+}
+
+# Remove the dock tab when re-docking
+proc ::docking::_removeDockTab {wnd} {
+	if {[string equal -length 6 $wnd ".fdock"]} {
+		set topwin [string replace $wnd 1 5]
+	} else {
+		set topwin $wnd
+	}
+	set tab ${topwin}.undocktab
+	if {![winfo exists $tab]} { return }
+
+	if {[lsearch [grid slaves $topwin] $tab] >= 0} {
+		destroy $tab
+		# Shift remaining grid children up by 1
+		foreach child [grid slaves $topwin] {
+			set info [grid info $child]
+			set row [dict get $info -row]
+			if {$row > 0} {
+				set column [dict get $info -column]
+				if {[catch {dict get $info -sticky}]} { set sticky {} } else {
+					set sticky [dict get $info -sticky]
+				}
+				if {[catch {dict get $info -columnspan}]} { set colspan 1 } else {
+					set colspan [dict get $info -columnspan]
+				}
+				grid $child -row [expr {$row - 1}] \
+					-column $column -columnspan $colspan -sticky $sticky
+			}
+		}
+		# Restore original row weights
+		if {[info exists ::docking::tabWeights($topwin)]} {
+			foreach {r w} $::docking::tabWeights($topwin) {
+				grid rowconfigure $topwin $r -weight $w
+				grid rowconfigure $topwin [expr {$r + 1}] -weight 0
+			}
+			unset ::docking::tabWeights($topwin)
+		}
+	} else {
+		destroy $tab
+	}
+}
+
+# Right-click on the dock tab: show menu
+proc ::docking::_dockTabMenu {wnd x y} {
+	set m .docktabMenu
+	if {[winfo exists $m]} { destroy $m }
+	menu $m -tearoff 0
+	$m add command -label [::tr Dock] -command [list ::win::dockWindow $wnd]
+	if {$wnd ne ".fdockmain"} {
+		$m add command -label [::tr Close] -command [list ::win::closeWindow $wnd]
 	}
 	tk_popup $m $x $y
 }

--- a/tcl/utils/win.tcl
+++ b/tcl/utils/win.tcl
@@ -715,15 +715,7 @@ proc ::docking::_addDockTab {wnd} {
 		foreach child $gridSlaves {
 			set info [grid info $child]
 			set row [dict get $info -row]
-			set column [dict get $info -column]
-			if {[catch {dict get $info -sticky}]} { set sticky {} } else {
-				set sticky [dict get $info -sticky]
-			}
-			if {[catch {dict get $info -columnspan}]} { set colspan 1 } else {
-				set colspan [dict get $info -columnspan]
-			}
-			grid $child -row [expr {$row + 1}] \
-				-column $column -columnspan $colspan -sticky $sticky
+			grid $child {*}$info -row [expr {$row + 1}]
 		}
 
 		# Restore shifted weights
@@ -758,15 +750,7 @@ proc ::docking::_removeDockTab {wnd} {
 			set info [grid info $child]
 			set row [dict get $info -row]
 			if {$row > 0} {
-				set column [dict get $info -column]
-				if {[catch {dict get $info -sticky}]} { set sticky {} } else {
-					set sticky [dict get $info -sticky]
-				}
-				if {[catch {dict get $info -columnspan}]} { set colspan 1 } else {
-					set colspan [dict get $info -columnspan]
-				}
-				grid $child -row [expr {$row - 1}] \
-					-column $column -columnspan $colspan -sticky $sticky
+				grid $child {*}$info -row [expr {$row - 1}]
 			}
 		}
 		# Restore original row weights


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Undocked windows now include a dedicated tab for quickly docking them again.
  * Right-clicking the dock tab provides options to dock or close the window where applicable.
* **Bug Fixes**
  * Improved docking stability and reduced unintended window cleanup during re-docking.
* **Localization**
  * Added translations for the “Dock” label across numerous supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->