### PR TITLE
Add average length column to Tree Window

### DIFF
--- a/src/scidbase.cpp
+++ b/src/scidbase.cpp
@@ -665,6 +665,8 @@ std::vector<TreeNode> scidBaseT::getTreeStat(const HFilter& filter, int moveDept
 		}
 		res[mapIt->second].add(ie->GetResult(), ie->GetWhiteElo(),
 		                       ie->GetBlackElo(), ie->GetYear());
+		res[mapIt->second].gameLengths.push_back(
+		    (ie->GetNumHalfMoves() + 1) / 2);
 	}
 
 	std::sort(res.begin(), res.end(), TreeNode::cmp_ngames_desc());

--- a/src/scidbase.cpp
+++ b/src/scidbase.cpp
@@ -665,8 +665,9 @@ std::vector<TreeNode> scidBaseT::getTreeStat(const HFilter& filter, int moveDept
 		}
 		res[mapIt->second].add(ie->GetResult(), ie->GetWhiteElo(),
 		                       ie->GetBlackElo(), ie->GetYear());
-		res[mapIt->second].gameLengths.push_back(
-		    (ie->GetNumHalfMoves() + 1) / 2);
+		res[mapIt->second].lengthSum +=
+		    (ie->GetNumHalfMoves() + 1) / 2;
+		res[mapIt->second].lengthCount++;
 	}
 
 	std::sort(res.begin(), res.end(), TreeNode::cmp_ngames_desc());

--- a/src/tkscid.cpp
+++ b/src/tkscid.cpp
@@ -8298,9 +8298,8 @@ int sc_tree_stats(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
       totals.eloCount += node.eloCount;
       totals.yearSum += node.yearSum;
       totals.yearCount += node.yearCount;
-      totals.gameLengths.insert(totals.gameLengths.end(),
-                                node.gameLengths.begin(),
-                                node.gameLengths.end());
+      totals.lengthSum += node.lengthSum;
+      totals.lengthCount += node.lengthCount;
     }
 
     // Now we print the list into the return string:

--- a/src/tkscid.cpp
+++ b/src/tkscid.cpp
@@ -8237,7 +8237,7 @@ int sc_tree_stats(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
   char temp[512]; // Increased size to accommodate longer move sequences
   std::string output;
   const char *titleRow = "    Move(s)                   ECO       Frequency    "
-                         "Score  AvElo Perf AvYear %Draws     %Win";
+                         "Score  AvElo Perf avLen AvYear %Draws     %Win";
   titleRow = translate(ti, "TreeTitleRow", titleRow);
   output.append(titleRow);
 
@@ -8248,6 +8248,7 @@ int sc_tree_stats(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
     const auto score = node.score();
     const auto perf =
         node.eloCount < 10 ? 0 : static_cast<int>(node.eloPerformance());
+    const auto avLen = node.avgLength();
 
     std::snprintf(temp, sizeof(temp), "  %3d%c%1d%%", score / 10,
                   decimalPointChar, score % 10);
@@ -8262,6 +8263,12 @@ int sc_tree_stats(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
       dest.append("      ");
     } else {
       std::snprintf(temp, sizeof(temp), "  %4d", perf);
+      dest.append(temp);
+    }
+    if (avLen == 0) {
+      dest.append("      ");
+    } else {
+      std::snprintf(temp, sizeof(temp), "  %4d", avLen);
       dest.append(temp);
     }
     if (avgYear == 0) {
@@ -8291,6 +8298,9 @@ int sc_tree_stats(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
       totals.eloCount += node.eloCount;
       totals.yearSum += node.yearSum;
       totals.yearCount += node.yearCount;
+      totals.gameLengths.insert(totals.gameLengths.end(),
+                                node.gameLengths.begin(),
+                                node.gameLengths.end());
     }
 
     // Now we print the list into the return string:
@@ -8314,7 +8324,7 @@ int sc_tree_stats(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
     // Print a totals line as well, if there are any moves in the tree:
     const char *totalString = translate(ti, "TreeTotal:", "TOTAL:");
     output.append("\n__________________________________________________________"
-                  "________________________________________\n");
+                  "______________________________________________\n");
     std::snprintf(temp, sizeof(temp), "%-32s    %7u:100%c0%%", totalString,
                   totals.freq[0], decimalPointChar);
     output.append(temp);

--- a/src/tree.h
+++ b/src/tree.h
@@ -34,7 +34,8 @@ struct TreeNode {
 	gamenumT freq[NUM_RESULT_TYPES] = {}; // freq[0] is the total count.
 	gamenumT eloCount = 0;                // Count of games with an Elo.
 	gamenumT yearCount = 0;               // Count of games with year != 0.
-	std::vector<gamenumT> gameLengths;    // Length of each game in full moves.
+	unsigned long long lengthSum = 0;     // Sum of game lengths in full moves.
+	gamenumT lengthCount = 0;             // Count of games with a recorded length.
 	std::vector<FullMove> moves;          // Sequence of moves (1-4 half-moves)
 
 public:
@@ -112,12 +113,9 @@ public:
 	}
 
 	int avgLength() const {
-		if (gameLengths.empty())
+		if (lengthCount == 0)
 			return 0;
-		unsigned long long sum = 0;
-		for (auto len : gameLengths)
-			sum += len;
-		return static_cast<int>(sum / gameLengths.size());
+		return static_cast<int>(lengthSum / lengthCount);
 	}
 
 	static auto cmp_ngames_desc() {

--- a/src/tree.h
+++ b/src/tree.h
@@ -34,6 +34,7 @@ struct TreeNode {
 	gamenumT freq[NUM_RESULT_TYPES] = {}; // freq[0] is the total count.
 	gamenumT eloCount = 0;                // Count of games with an Elo.
 	gamenumT yearCount = 0;               // Count of games with year != 0.
+	std::vector<gamenumT> gameLengths;    // Length of each game in full moves.
 	std::vector<FullMove> moves;          // Sequence of moves (1-4 half-moves)
 
 public:
@@ -108,6 +109,15 @@ public:
 
 	double percDraws() const {
 		return freq[0] ? 100.0 * freq[RESULT_Draw] / freq[0] : 0;
+	}
+
+	int avgLength() const {
+		if (gameLengths.empty())
+			return 0;
+		unsigned long long sum = 0;
+		for (auto len : gameLengths)
+			sum += len;
+		return static_cast<int>(sum / gameLengths.size());
 	}
 
 	static auto cmp_ngames_desc() {

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -660,7 +660,7 @@ translate J TreeBestGames {Најбоље игре са дрветом}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate J TreeTitleRow \
-  {Мове                          ЕЦО       Фрекуенци     Сцоре АвЕло Перф АвИеар %Draws     %Вин}
+  {Мове                          ЕЦО       Фрекуенци     Сцоре АвЕло Перф avLen АвИеар %Draws     %Вин}
 translate J TreeTotal {ТОТАЛ}
 translate J DoYouWantToSaveFirst {Да ли желите прво да сачувате}
 translate J AddToMask {Додајте у маску}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -619,7 +619,7 @@ translate b TreeBestGames {সেরা গাছ গেম}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate b TreeTitleRow \
-  {মুভ(গুলি) ECO ফ্রিকোয়েন্সি স্কোর AvElo Perf AvYear % Draws % Win}
+  {মুভ(গুলি) ECO ফ্রিকোয়েন্সি স্কোর AvElo Perf avLen AvYear % Draws % Win}
 translate b TreeTotal {মোট}
 translate b DoYouWantToSaveFirst {আপনি প্রথমে সংরক্ষণ করতে চান}
 translate b AddToMask {মাস্কে যোগ করুন}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -660,7 +660,7 @@ translate g TreeBestGames {Най-добрите игри с дървета}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate g TreeTitleRow \
-  {Ход(ове) ECO Честота Резултат AvElo Perf AvYear %Равенства %Победа}
+  {Ход(ове) ECO Честота Резултат AvElo Perf avLen AvYear %Равенства %Победа}
 translate g TreeTotal {ОБЩО}
 translate g DoYouWantToSaveFirst {Искате ли първо да спестите}
 translate g AddToMask {Добавете към маската}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -645,7 +645,7 @@ translate K TreeBestGames {Millors partides de l'arbre}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate K TreeTitleRow \
-{Movim.                        ECO       Freqüencia   Puntu. EloPm Perf AnyPm %Taules      %Guanyar}
+{Movim.                        ECO       Freqüencia   Puntu. EloPm Perf avLen AnyPm %Taules      %Guanyar}
 translate K TreeTotal {TOTAL}
 translate K DoYouWantToSaveFirst {Vols desar-ho abans}
 translate K AddToMask {Afegir a màscara}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -595,7 +595,7 @@ translate M TreeBestGames {Best Tree Games}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate M TreeTitleRow \
-{Move                          ECO       Frequency    Score  AvElo Perf AvYear %Draws     %赢}
+{Move                          ECO       Frequency    Score  AvElo Perf avLen AvYear %Draws     %赢}
 translate M TreeTotal {总计}
 translate M DoYouWantToSaveFirst {Do you want to save first}
 translate M AddToMask {Add to Mask}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -624,7 +624,7 @@ translate C TreeBestGames {Nejlep partie stromu}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate C TreeTitleRow \
-{Tah                           ECO       Frekvence    Skre  PrElo Perf  PrRok %remz   %Vyhrt}
+{Tah                           ECO       Frekvence    Skre  PrElo Perf avLen  PrRok %remz   %Vyhrt}
 translate C TreeTotal {CELKEM}
 translate C DoYouWantToSaveFirst {Chcete nejprve uloit}
 translate C AddToMask {Pidat do masky}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -659,7 +659,7 @@ translate D TreeBestGames {Beste Zugbaumpartien}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate D TreeTitleRow \
-{Zug                           ECO       Häufigkeit    Pkte   Elo  Erflg Jahr %Remis  %Gewinnen}
+{Zug                           ECO       Häufigkeit    Pkte   Elo  Erflg avLen Jahr %Remis  %Gewinnen}
 translate D TreeTotal {SUMME}
 translate D DoYouWantToSaveFirst {Soll zuerst gespeichert werden}
 translate D AddToMask {Zur Maske hinzufügen}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -659,7 +659,7 @@ translate D TreeBestGames {Beste Zugbaumpartien}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate D TreeTitleRow \
-{Zug                           ECO       Häufigkeit    Pkte   Elo  Erflg avLen Jahr %Remis  %Gewinnen}
+{    Zug                       ECO       Häufigkeit   Pkte   Elo   Erfl avLen Jahr   %Remis     %Gew}
 translate D TreeTotal {SUMME}
 translate D DoYouWantToSaveFirst {Soll zuerst gespeichert werden}
 translate D AddToMask {Zur Maske hinzufügen}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -659,7 +659,7 @@ translate E TreeBestGames {Best Tree Games}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate E TreeTitleRow \
-  {    Move(s)                   ECO       Frequency    Score  AvElo Perf AvYear %Draws     %Win}
+  {    Move(s)                   ECO       Frequency    Score  AvElo Perf avLen AvYear %Draws     %Win}
 translate E TreeTotal {TOTAL}
 translate E DoYouWantToSaveFirst {Do you want to save first}
 translate E AddToMask {Add to Mask}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -632,7 +632,7 @@ translate F TreeBestGames {Arbre des meilleures parties}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate F TreeTitleRow \
-{Coup                          ECO        Fréquence   Score EloMoy Perf AnnéeMoy %Nulle   %Gagner}
+{Coup                          ECO        Fréquence   Score EloMoy Perf avLen AnnéeMoy %Nulle   %Gagner}
 translate F TreeTotal {TOTAL}
 translate F DoYouWantToSaveFirst {voulez-vous d'abord sauvegarder}
 translate F AddToMask {Ajouter au masque}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -651,7 +651,7 @@ translate G TreeBestGames {Οι καλύτερες παρτίδες του δέ�
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate G TreeTitleRow \
-{Move                          ECO       Frequency    Score  AvElo Perf AvYear %Draws     %Νίκη}
+{Move                          ECO       Frequency    Score  AvElo Perf avLen AvYear %Draws     %Νίκη}
 translate G TreeTotal {ΣΥΝΟΛΟ}
 translate G DoYouWantToSaveFirst {Θέλετε να αποθηκεύσετε πρώτα;}
 translate G AddToMask {Προσθήκη στην μάσκα}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -620,7 +620,7 @@ translate V TreeBestGames {משחקי העץ הטובים ביותר}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate V TreeTitleRow \
-  {מהלכים ECO תדר ציון AvElo Perf AvYear % הגרלות %Win}
+  {מהלכים ECO תדר ציון AvElo Perf avLen AvYear % הגרלות %Win}
 translate V TreeTotal {סַך הַכֹּל}
 translate V DoYouWantToSaveFirst {האם אתה רוצה לשמור קודם}
 translate V AddToMask {הוסף למסכה}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -619,7 +619,7 @@ translate h TreeBestGames {सर्वश्रेष्ठ वृक्ष ख
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate h TreeTitleRow \
-  {मूव(एं) ईसीओ फ्रीक्वेंसी स्कोर एवएलो पर्फ एवीवर्ष %ड्रॉ %जीत}
+  {मूव(एं) ईसीओ फ्रीक्वेंसी स्कोर एवएलो पर्फ avLen एवीवर्ष %ड्रॉ %जीत}
 translate h TreeTotal {कुल}
 translate h DoYouWantToSaveFirst {क्या आप पहले बचत करना चाहते हैं?}
 translate h AddToMask {मास्क में जोड़ें}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -627,7 +627,7 @@ translate H TreeBestGames {A fa legjobb játszmái}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate H TreeTitleRow \
-{Lépés                         ECO       Gyakoriság  Eredm. ÁtlÉlõ Telj. avLen Átl.év      %Gyõzelem}
+{Lépés                         ECO       Gyakoriság  Eredm. ÁtlÉlõ Telj. avLen Átl.év %Döntetlen %Gyõzelem}
 translate H TreeTotal {ÖSSZESEN}
 translate H DoYouWantToSaveFirst {Akarod elõbb menteni?}
 translate H AddToMask {Add hozzá a maszkhoz}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -627,7 +627,7 @@ translate H TreeBestGames {A fa legjobb játszmái}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate H TreeTitleRow \
-{Lépés                         ECO       Gyakoriság  Eredm. ÁtlÉlõ Telj. Átl.év      %Gyõzelem}
+{Lépés                         ECO       Gyakoriság  Eredm. ÁtlÉlõ Telj. avLen Átl.év      %Gyõzelem}
 translate H TreeTotal {ÖSSZESEN}
 translate H DoYouWantToSaveFirst {Akarod elõbb menteni?}
 translate H AddToMask {Add hozzá a maszkhoz}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -630,7 +630,7 @@ translate I TreeBestGames {Migliori partite}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate I TreeTitleRow \
-{Mossa                         ECO       Frequenza    Punt.  AvElo Perf AvAnno %Patta   %Vincita}
+{Mossa                         ECO       Frequenza    Punt.  AvElo Perf avLen AvAnno %Patta   %Vincita}
 translate I TreeTotal {TOTALE}
 translate I DoYouWantToSaveFirst {Vuoi prima salvare}
 translate I AddToMask {Aggiungi alla maschera}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -660,7 +660,7 @@ translate A TreeBestGames {ベストツリーゲーム}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate A TreeTitleRow \
-{移動                            ECO 頻度スコア AvElo Perf Av Year %Draws     %勝つ}
+{移動                            ECO 頻度スコア AvElo Perf avLen Av Year %Draws     %勝つ}
 translate A TreeTotal {合計}
 translate A DoYouWantToSaveFirst {最初に保存しますか?}
 translate A AddToMask {マスクに追加}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -660,7 +660,7 @@ translate k TreeBestGames {최고의 나무 게임}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate k TreeTitleRow \
-  {이동 ECO 체력 AvElo Perf AvYear %무승부 %승리}
+  {이동 ECO 체력 AvElo Perf avLen AvYear %무승부 %승리}
 translate k TreeTotal {총}
 translate k DoYouWantToSaveFirst {먼저 입력하시겠습니까?}
 translate k AddToMask {마스크에 추가}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -649,7 +649,7 @@ translate N TreeBestGames {Boom Beste partijen}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate N TreeTitleRow \
-{Zet                           ECO    Frekwentie    Score  GemElo Prest GemJaar %Remises  %Winnennen} ;
+{Zet                           ECO    Frekwentie    Score  GemElo Prest avLen GemJaar %Remises  %Winnennen} ;
 translate N TreeTotal {TOTAAL}
 translate N DoYouWantToSaveFirst {Wil u eerst de verandering bewaren?}
 translate N AddToMask {Toevoegen aan het Masker}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -629,7 +629,7 @@ translate O TreeBestGames {Idealtrepartier}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate O TreeTitleRow \
-{Move                          ECO       Frequency    Score  AvElo Perf AvYear %Draws     %Vinne} ;# ***
+{Move                          ECO       Frequency    Score  AvElo Perf avLen AvYear %Draws     %Vinne} ;# ***
 translate O TreeTotal {SAMMENLAGT}
 translate O DoYouWantToSaveFirst {Vil du spare først}
 translate O AddToMask {Legg til maske}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -557,7 +557,7 @@ translate P TreeBest {Najlepsze}
 translate P TreeBestGames {Najlepsze partie z drzewa}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
-translate P TreeTitleRow {    Posunięcie/a              ECO       Częstość     Wynik  ŚrElo Perf ŚrRok  %Remisów   %Wygr.}
+translate P TreeTitleRow {    Posunięcie/a              ECO       Częstość     Wynik  ŚrElo Perf avLen ŚrRok  %Remisów   %Wygr.}
 translate P TreeTotal {RAZEM}
 translate P DoYouWantToSaveFirst {Czy najpierw chcesz zapisać}
 translate P AddToMask {Dodaj do maski}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -632,7 +632,7 @@ translate B TreeBestGames {Melhores jogos da árvore}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate B TreeTitleRow \
-{Mov.                          ECO       Frequência   Score  AvElo Perf AvAno %Empat   %Vitória}
+{Mov.                          ECO       Frequência   Score  AvElo Perf avLen AvAno %Empat   %Vitória}
 translate B TreeTotal {TOTAL}
 translate B DoYouWantToSaveFirst {Quer salvar primeiro?}
 translate B AddToMask {Adicionar  máscara}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -660,7 +660,7 @@ translate L TreeBestGames {Cele mai bune jocuri cu copaci}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate L TreeTitleRow \
-{Mutare Scor de frecvență      ECO AvElo Perf AvYear % Draws      %Câştiga}
+{Mutare Scor de frecvență      ECO AvElo Perf avLen AvYear % Draws      %Câştiga}
 translate L TreeTotal {TOTAL}
 translate L DoYouWantToSaveFirst {Doriți să salvați mai întâi}
 translate L AddToMask {Adaugă la mască}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -626,7 +626,7 @@ translate R TreeBestGames {Дерево лучших партий}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate R TreeTitleRow \
-{Ход                           ECO       Частота     Счёт   СрЭло Прзв СрГод  %ничьих  %Победить}
+{Ход                           ECO       Частота     Счёт   СрЭло Прзв avLen СрГод  %ничьих  %Победить}
 translate R TreeTotal {ИТОГ}
 translate R DoYouWantToSaveFirst {Вы хотите сохранить первым}
 translate R AddToMask {Добавить в маску}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -948,7 +948,7 @@ translate Y TreeBest {Best}
 translate Y TreeBestGames {Best Tree Games}
 # ====== TODO To be translated ======
 translate Y TreeTitleRow \
-  {    Move(s)                   ECO       Frequency    Score  AvElo Perf AvYear %Draws     %Win}
+  {    Move(s)                   ECO       Frequency    Score  AvElo Perf avLen AvYear %Draws     %Win}
 # ====== TODO To be translated ======
 translate Y TreeTotal {TOTAL}
 # ====== TODO To be translated ======
@@ -2826,11 +2826,11 @@ translate Y QGDwithBg5 {QGD with Bg5}
 # ====== TODO To be translated ======
 translate Y QGDOrthodox {QGD Orthodox}
 # ====== TODO To be translated ======
-translate Y Grunfeld {Grünfeld}
+translate Y Grunfeld {Grï¿½nfeld}
 # ====== TODO To be translated ======
-translate Y GrunfeldExchange {Grünfeld Exchange}
+translate Y GrunfeldExchange {Grï¿½nfeld Exchange}
 # ====== TODO To be translated ======
-translate Y GrunfeldRussian {Grünfeld Russian}
+translate Y GrunfeldRussian {Grï¿½nfeld Russian}
 # ====== TODO To be translated ======
 translate Y Catalan {Catalan}
 # ====== TODO To be translated ======
@@ -2848,7 +2848,7 @@ translate Y NimzoIndianRubinstein {Nimzo-Indian Rubinstein}
 # ====== TODO To be translated ======
 translate Y KingsIndian {King's Indian}
 # ====== TODO To be translated ======
-translate Y KingsIndianSamisch {King's Indian Sämisch}
+translate Y KingsIndianSamisch {King's Indian Sï¿½misch}
 # ====== TODO To be translated ======
 translate Y KingsIndianMainLine {King's Indian Main Line}
 # ====== TODO To be translated ======

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -676,7 +676,7 @@ translate S TreeBestGames {Mejores partidas del árbol}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate S TreeTitleRow \
-{Movim.                        ECO       Frecuencia   Puntu. AvElo Perf AvAño %Tablas   %Ganar}
+{Movim.                        ECO       Frecuencia   Puntu. AvElo Perf avLen AvAño %Tablas   %Ganar}
 translate S TreeTotal {TOTAL}
 translate S DoYouWantToSaveFirst {¿Quieres salvar primero?}
 translate S AddToMask {Añadir a máscara}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -658,7 +658,7 @@ translate U TreeBestGames {Parhaat pelit}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate U TreeTitleRow \
-{Siirto                        ECO       Yleisyys     Tulos  AvElo Perf AvYear %Draws     %Voittaa}
+{Siirto                        ECO       Yleisyys     Tulos  AvElo Perf avLen AvYear %Draws     %Voittaa}
 translate U TreeTotal {TOTAL}
 translate U DoYouWantToSaveFirst {Haluatko tallentaa ensin}
 translate U AddToMask {Lisää maskiin}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -619,7 +619,7 @@ translate Z TreeBestGames {Michezo Bora ya Miti}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate Z TreeTitleRow \
-  {Move(s) ECO Frequency Score AvElo Perf AvYear %Draws %Shinda}
+  {Move(s) ECO Frequency Score AvElo Perf avLen AvYear %Draws %Shinda}
 translate Z TreeTotal {JUMLA}
 translate Z DoYouWantToSaveFirst {Je, unataka kuokoa kwanza}
 translate Z AddToMask {Ongeza kwa Mask}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -630,7 +630,7 @@ translate W TreeBestGames {Bästa partier i trädet}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate W TreeTitleRow \
-{Drag                          ECO     Frekvens      Res.    Elo~  Nivå  År~   %Remi      %Vinna} 
+{Drag                          ECO     Frekvens      Res.    Elo~  Nivå avLen  År~   %Remi      %Vinna} 
 translate W TreeTotal {TOTALT} 
 translate W DoYouWantToSaveFirst {Vill du spara först}
 translate W AddToMask {Lägg till i sökmask}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -623,7 +623,7 @@ translate T TreeBestGames {En İyi Ağaç Oyunları}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate T TreeTitleRow \
-{                              ECO Frekans Puanını Taşı AvElo Perf AvYıl %Çekimler      %Win}
+{                              ECO Frekans Puanını Taşı AvElo Perf avLen AvYıl %Çekimler      %Win}
 translate T TreeTotal {TOPLAM}
 translate T DoYouWantToSaveFirst {Önce kaydetmek ister misiniz?}
 translate T AddToMask {Maskeye Ekle}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -620,7 +620,7 @@ translate Q TreeBestGames {Найкращі ігри про дерева}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate Q TreeTitleRow \
-  {Ходи(-и) ECO Частота Оцінка AvElo Perf AvYear %Ничії %Виграш}
+  {Ходи(-и) ECO Частота Оцінка AvElo Perf avLen AvYear %Ничії %Виграш}
 translate Q TreeTotal {РАЗОМ}
 translate Q DoYouWantToSaveFirst {Ви хочете спочатку зберегти}
 translate Q AddToMask {Додати до маски}

--- a/tcl/tools/auto_comment.tcl
+++ b/tcl/tools/auto_comment.tcl
@@ -950,13 +950,17 @@ proc ::auto_comment::getTreeInfo {baseId} {
         if {$count >= 3} break
         # Skip header, total lines and empty lines
         if {[string match "*Move(s)*" $line] || [string match "*TOTAL:*" $line] || [string trim $line] eq ""} continue
-        
+
         # Parse the fixed-width output of sc_tree stats (tkscid.cpp)
+        # Format emitted by tkscid.cpp (lines 8315-8286):
+        # Base (0-49), Score (50-57), AvElo (58-63), Perf (64-69), AvLen (70-75),
+        # AvYear (76-81), %Draws (82-87), %Win (88-99)
+        # Example: " 1: e4 e5 Nf3 Nc6             A00      1234: 45.6%   52.3%  2100  2200    45  1995   32%      48.25%"
         # MoveSeq: 4-28, Games: 36-42, Success%: 51-57, %Draws: 82-87, %Win: 88-99
         catch {
             set moveSeq [string trim [string range $line 4 28]]
             if {$moveSeq eq "" || $moveSeq eq "---"} continue
-            
+
             set games   [string trim [string range $line 36 42]]
             set success [string trim [string range $line 51 57]]
             set draws   [string trim [string range $line 82 87]]

--- a/tcl/tools/auto_comment.tcl
+++ b/tcl/tools/auto_comment.tcl
@@ -952,15 +952,15 @@ proc ::auto_comment::getTreeInfo {baseId} {
         if {[string match "*Move(s)*" $line] || [string match "*TOTAL:*" $line] || [string trim $line] eq ""} continue
         
         # Parse the fixed-width output of sc_tree stats (tkscid.cpp)
-        # MoveSeq: 4-28, Games: 36-42, Success%: 51-57, %Draws: 76-81, %Win: 82-93
+        # MoveSeq: 4-28, Games: 36-42, Success%: 51-57, %Draws: 82-87, %Win: 88-99
         catch {
             set moveSeq [string trim [string range $line 4 28]]
             if {$moveSeq eq "" || $moveSeq eq "---"} continue
             
             set games   [string trim [string range $line 36 42]]
             set success [string trim [string range $line 51 57]]
-            set draws   [string trim [string range $line 76 81]]
-            set win     [string trim [string range $line 82 93]]
+            set draws   [string trim [string range $line 82 87]]
+            set win     [string trim [string range $line 88 99]]
             
             if {$treeBlock eq ""} {
                 append treeBlock "Top 3 most frequent database lines for the current position (depth 4 plies):"

--- a/tcl/windows/tree.tcl
+++ b/tcl/windows/tree.tcl
@@ -602,9 +602,9 @@ proc ::tree::displayLines { baseNumber moves } {
   # $w.f.tl configure -state disabled
 }
 ################################################################################
-# returns a list with (ngames freq success eloavg perf) or
+# returns a list with (ngames freq success eloavg perf avLen) or
 # {} if there was a problem during parsing
-# 1: e4     B00     37752: 47.1%   54.7%  2474  2513  2002   37%
+# 1: e4     B00     37752: 47.1%   54.7%  2474  2513  42  2002   37%
 ################################################################################
 proc ::tree::getLineValues { l } {
   set ret {}
@@ -637,6 +637,11 @@ proc ::tree::getLineValues { l } {
   } else  {
     lappend ret $perf
   }
+
+  if {[scan [string range $l 74 78] "%d" avLen] != 1} {
+    set avLen 0
+  }
+  lappend ret $avLen
 
   # Win column is 9 chars at the end
   set win [string range $l end-8 end]
@@ -688,7 +693,7 @@ proc ::tree::getColorWin { line } {
   if { $ngames < $::tree::scoreHighlight_MinGames } {
     return ""
   }
-  set winAdv [lindex $data 5]
+  set winAdv [lindex $data 6]
 
   # winAdv is White advantage (positive = good for White, negative = good for Black)
   # When it's White to move: positive winAdv is good (green), negative is bad (red)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tree statistics now display the average game length in full moves for each variation and in the totals row.
  - Game lengths are calculated consistently from recorded moves, including incomplete final moves.
- **Localization**
  - Added or corrected average-length column labels across supported languages.
  - Updated tree-window headings and spacing for the new statistic.
- **Bug Fixes**
  - Corrected tree-row interpretation so win indicators and formatting remain accurate with the additional column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->