### PR TITLE
Add ability to show annotations in Tree View

### DIFF
--- a/src/gameview.h
+++ b/src/gameview.h
@@ -426,15 +426,23 @@ public:
 		while (it < end) {
 			switch (*it++) {
 			case 11: // ENCODE_NAG
-				if (it < end)
-					nags.push_back(*it++);
+				if (it < end) {
+					if (varDepth == 0)
+						nags.push_back(*it);
+					++it; // skip nag byte
+				}
 				break;
 			case 12: // ENCODE_COMMENT
 				break;
 			case 13: // ENCODE_START_MARKER
+				// Variations start here; NAGs inside them belong to variation moves.
+				if (varDepth == 0)
+					return nags;
 				++varDepth;
 				break;
 			case 14: // ENCODE_END_MARKER
+				if (varDepth <= 0)
+					return nags; // corrupted stream; avoid underflow
 				--varDepth;
 				break;
 			case 15: // ENCODE_END_GAME

--- a/src/gameview.h
+++ b/src/gameview.h
@@ -28,6 +28,7 @@
 #include <cstring>
 #include <sstream>
 #include <string>
+#include <vector>
 
 /// Store the number of pieces for each type and color.
 class MaterialCount {

--- a/src/gameview.h
+++ b/src/gameview.h
@@ -417,6 +417,37 @@ public:
 		}
 	}
 
+	std::vector<byte> collectNextNAGs() {
+		auto it = bbuf_.data();
+		const auto end = bbuf_.data() + bbuf_.size();
+		std::vector<byte> nags;
+		int varDepth = 0;
+
+		while (it < end) {
+			switch (*it++) {
+			case 11: // ENCODE_NAG
+				if (it < end)
+					nags.push_back(*it++);
+				break;
+			case 12: // ENCODE_COMMENT
+				break;
+			case 13: // ENCODE_START_MARKER
+				++varDepth;
+				break;
+			case 14: // ENCODE_END_MARKER
+				--varDepth;
+				break;
+			case 15: // ENCODE_END_GAME
+				return nags;
+			default: // Move byte
+				if (varDepth == 0)
+					return nags;
+				break;
+			}
+		}
+		return nags;
+	}
+
 	FullMove getMove(int ply_to_skip) {
 		for (int ply = 0; ply <= ply_to_skip; ply++, cToMove_ = 1 - cToMove_) {
 			auto move = (cToMove_ == WHITE) ? DecodeNextMove<FullMove, WHITE>()

--- a/src/scidbase.cpp
+++ b/src/scidbase.cpp
@@ -705,9 +705,7 @@ scidBaseT::getTreeNAGs(const HFilter& filter, eloT minElo) const {
 		if (nags.empty())
 			continue;
 
-		char san[10];
-		std::strcpy(san, fm.getSAN().c_str());
-		std::string key(san);
+		std::string key = fm.getSAN();
 
 		for (auto nag : nags) {
 			nagHist[key][nag]++;

--- a/src/scidbase.cpp
+++ b/src/scidbase.cpp
@@ -674,6 +674,68 @@ std::vector<TreeNode> scidBaseT::getTreeStat(const HFilter& filter, int moveDept
 	return res;
 }
 
+std::vector<scidBaseT::TreeNAGEntry>
+scidBaseT::getTreeNAGs(const HFilter& filter, eloT minElo) const {
+	std::vector<TreeNAGEntry> results;
+	std::map<std::string, std::map<byte, uint>> nagHist;
+	std::map<std::string, std::pair<uint64_t, uint>> eloData;
+
+	for (gamenumT gnum = 0, n = numGames(); gnum < n; gnum++) {
+		uint ply = filter.get(gnum);
+		if (ply == 0)
+			continue;
+		ply--;
+
+		const IndexEntry* ie = getIndexEntry(gnum);
+
+		if (ie->GetNagCount() == 0)
+			continue;
+
+		eloT wElo = ie->GetWhiteElo();
+		eloT bElo = ie->GetBlackElo();
+		if (minElo > 0 && std::max(wElo, bElo) < minElo)
+			continue;
+
+		auto gv = getGame(ie);
+		FullMove fm = gv.getMove(ply);
+		if (!fm)
+			continue;
+
+		auto nags = gv.collectNextNAGs();
+		if (nags.empty())
+			continue;
+
+		char san[10];
+		std::strcpy(san, fm.getSAN().c_str());
+		std::string key(san);
+
+		for (auto nag : nags) {
+			nagHist[key][nag]++;
+		}
+
+		auto& elo = eloData[key];
+		elo.first += std::max(wElo, bElo);
+		elo.second++;
+	}
+
+	results.reserve(nagHist.size());
+	for (auto& [key, nags] : nagHist) {
+		TreeNAGEntry entry;
+		entry.moveSAN = key;
+		entry.nagFreqs = std::move(nags);
+
+		auto it = eloData.find(key);
+		if (it != eloData.end() && it->second.second > 0) {
+			entry.avgElo = static_cast<eloT>(
+			    it->second.first / it->second.second);
+		}
+
+		results.push_back(std::move(entry));
+	}
+
+	return results;
+}
+
 errorT scidBaseT::getCompactStat(unsigned long long* n_deleted,
                                  unsigned long long* n_unused,
                                  unsigned long long* n_sparse,

--- a/src/scidbase.h
+++ b/src/scidbase.h
@@ -28,6 +28,7 @@
 #include "namebase.h"
 #include "tree.h"
 #include <array>
+#include <map>
 #include <cassert>
 #include <filesystem>
 #include <memory>
@@ -217,6 +218,14 @@ struct scidBaseT {
 
 	const Stats& getStats() const;
 	std::vector<TreeNode> getTreeStat(const HFilter& filter, int moveDepth = 1) const;
+
+	struct TreeNAGEntry {
+		std::string moveSAN;
+		eloT avgElo = 0;
+		std::map<byte, uint> nagFreqs;
+	};
+	std::vector<TreeNAGEntry> getTreeNAGs(const HFilter& filter, eloT minElo) const;
+
 	uint getNameFreq(nameT nt, idNumberT id) {
 		if (nameFreq_[nt].size() == 0)
 			nameFreq_ = getNameBase()->calcNameFreq(*idx);

--- a/src/tkscid.cpp
+++ b/src/tkscid.cpp
@@ -8093,8 +8093,8 @@ int sc_report_select(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
 //  SEARCH and TREE functions
 
 int sc_tree(ClientData cd, Tcl_Interp *ti, int argc, const char **argv) {
-  static const char *options[] = {"stats", "cachesize", "cacheinfo", nullptr};
-  enum { TREE_STATS, TREE_CACHESIZE, TREE_CACHEINFO };
+  static const char *options[] = {"stats", "cachesize", "cacheinfo", "nags", nullptr};
+  enum { TREE_STATS, TREE_CACHESIZE, TREE_CACHEINFO, TREE_NAGS };
 
   int index = -1;
   if (argc > 1) {
@@ -8110,6 +8110,9 @@ int sc_tree(ClientData cd, Tcl_Interp *ti, int argc, const char **argv) {
 
   case TREE_CACHEINFO:
     return sc_tree_cacheinfo(cd, ti, argc, argv);
+
+  case TREE_NAGS:
+    return sc_tree_nags(cd, ti, argc, argv);
 
   default:
     return InvalidCommand(ti, "sc_tree", options);
@@ -8357,6 +8360,42 @@ int sc_tree_cacheinfo(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
     return UI_Result(ti, OK, base->treeCache.Size());
 
   return UI_Result(ti, OK, 0);
+}
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// sc_tree_nags:
+//    Extract evaluation NAGs from games in the tree filter.
+//    Returns a Tcl list: { {moveSAN {nagSym count}...} ... }
+int sc_tree_nags(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
+  static const char *usage = "Usage: sc_tree nags baseId filterId [minElo]";
+  if (argc < 4)
+    return UI_Result(ti, ERROR_BadArg, usage);
+
+  scidBaseT *base = DBasePool::getBase(strGetUnsigned(argv[2]));
+  if (!base)
+    return UI_Result(ti, ERROR_BadArg, usage);
+
+  HFilter filter = base->getFilter(argv[3]);
+  if (filter == nullptr)
+    return UI_Result(ti, ERROR_BadArg, usage);
+
+  eloT minElo = (argc > 4) ? static_cast<eloT>(strGetUnsigned(argv[4])) : 0;
+
+  auto results = base->getTreeNAGs(filter, minElo);
+
+  UI_List resList(results.size());
+  for (auto& entry : results) {
+    size_t nPairs = entry.nagFreqs.size();
+    UI_List entryInfo(1 + 2 * nPairs);
+    entryInfo.push_back(entry.moveSAN);
+    for (auto& [nag, count] : entry.nagFreqs) {
+      char temp[16];
+      game_printNag(nag, temp, true, PGN_FORMAT_Plain);
+      entryInfo.push_back(temp);
+      entryInfo.push_back(count);
+    }
+    resList.push_back(entryInfo);
+  }
+  return UI_Result(ti, OK, resList);
 }
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // sc_search:

--- a/src/tkscid.cpp
+++ b/src/tkscid.cpp
@@ -8364,7 +8364,7 @@ int sc_tree_cacheinfo(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // sc_tree_nags:
 //    Extract evaluation NAGs from games in the tree filter.
-//    Returns a Tcl list: { {moveSAN {nagSym count}...} ... }
+//    Returns a Tcl list: { {moveSAN nagSym count ...} ... }
 int sc_tree_nags(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
   static const char *usage = "Usage: sc_tree nags baseId filterId [minElo]";
   if (argc < 4)

--- a/src/tkscid.h
+++ b/src/tkscid.h
@@ -80,6 +80,7 @@ int sc_pos_setComment (TCL_ARGS);
 int sc_tree_stats    (TCL_ARGS);
 int sc_tree_cachesize (TCL_ARGS);
 int sc_tree_cacheinfo (TCL_ARGS);
+int sc_tree_nags      (TCL_ARGS);
 
 int sc_var_delete     (TCL_ARGS);
 int sc_var_enter      (TCL_ARGS);

--- a/tcl/windows/tree.tcl
+++ b/tcl/windows/tree.tcl
@@ -117,8 +117,7 @@ proc ::tree::make { { baseNumber -1 } {locked 0} } {
   $w.menu.opt add checkbutton -label TreeOptTraining -variable tree(training$baseNumber) -command "::tree::toggleTraining $baseNumber"
   set helpMessage($w.menu.opt,1) TreeOptTraining
 
-  $w.menu.opt add checkbutton -label [tr Annotations] -variable tree(nagsAutopopulate$baseNumber) -command "::tree::refresh $baseNumber"
-  set helpMessage($w.menu.opt,2) Annotations
+  $w.menu.opt add checkbutton -label Annotations -variable tree(nagsAutopopulate$baseNumber) -command "::tree::refresh $baseNumber"
 
   $w.menu.helpmenu add command -label TreeHelpTree -accelerator F1 -command {helpWindow Tree}
   $w.menu.helpmenu add command -label TreeHelpIndex -command {helpWindow Index}

--- a/tcl/windows/tree.tcl
+++ b/tcl/windows/tree.tcl
@@ -421,6 +421,9 @@ proc ::tree::dorefresh { baseNumber {filter "tree"}} {
     unset -nocomplain tree(nagsError$baseNumber)
     if { [catch {
       set nagsData [sc_tree nags $baseNumber $filter 0]
+      if { $::tree::mask::maskFile != "" } {
+        ::tree::mask::setCacheFenIndex
+      }
       foreach entry $nagsData {
         set moveSAN [lindex $entry 0]
         set bestNag ""
@@ -433,11 +436,8 @@ proc ::tree::dorefresh { baseNumber {filter "tree"}} {
         }
         if { $bestNag != "" } {
           set ::tree::autoNag($baseNumber,$moveSAN) $bestNag
-          if { $::tree::mask::maskFile != "" } {
-            ::tree::mask::setCacheFenIndex
-            if { [::tree::mask::moveExists $moveSAN] } {
-              catch { ::tree::mask::setNag $moveSAN $bestNag "" 0 }
-            }
+          if { $::tree::mask::maskFile != "" && [::tree::mask::moveExists $moveSAN] } {
+            catch { ::tree::mask::setNag $moveSAN $bestNag "" 0 }
           }
         }
       }

--- a/tcl/windows/tree.tcl
+++ b/tcl/windows/tree.tcl
@@ -117,8 +117,8 @@ proc ::tree::make { { baseNumber -1 } {locked 0} } {
   $w.menu.opt add checkbutton -label TreeOptTraining -variable tree(training$baseNumber) -command "::tree::toggleTraining $baseNumber"
   set helpMessage($w.menu.opt,1) TreeOptTraining
 
-  $w.menu.opt add checkbutton -label [tr Annotations] -variable tree(nagsAutopopulate$baseNumber)
-  set helpMessage($w.menu.opt,2) "Automatically populate evaluation symbols (!, ?, !!, etc.) from database games"
+  $w.menu.opt add checkbutton -label [tr Annotations] -variable tree(nagsAutopopulate$baseNumber) -command "::tree::refresh $baseNumber"
+  set helpMessage($w.menu.opt,2) Annotations
 
   $w.menu.helpmenu add command -label TreeHelpTree -accelerator F1 -command {helpWindow Tree}
   $w.menu.helpmenu add command -label TreeHelpIndex -command {helpWindow Index}
@@ -164,7 +164,7 @@ proc ::tree::make { { baseNumber -1 } {locked 0} } {
       -textvariable tree(movedepth$baseNumber) -command "::tree::refresh $baseNumber"
   bind $w.buttons.depth <Return> "::tree::refresh $baseNumber"
 
-  foreach {b t} { best TreeFileBest graph TreeFileGraph allgames TreeOptLock  training TreeOptTraining bStartStop TreeOptStartStop depth TreeOptDepth depthlabel TreeOptDepth annotations TreeOptAnnotations } {
+  foreach {b t} { best TreeFileBest graph TreeFileGraph allgames TreeOptLock  training TreeOptTraining bStartStop TreeOptStartStop depth TreeOptDepth depthlabel TreeOptDepth annotations Annotations } {
     set helpMessage($w.buttons.$b) $t
   }
 
@@ -416,7 +416,10 @@ proc ::tree::dorefresh { baseNumber {filter "tree"}} {
   # Extract evaluation NAGs from games and populate the mask or autoNag array
   if { !$err && $tree(nagsAutopopulate$baseNumber) == 1 } {
     # Clear stale auto NAGs from the previous position
-    if { [info exists ::tree::autoNag] } { array unset ::tree::autoNag }
+    foreach key [array names ::tree::autoNag "$baseNumber,*"] {
+      unset ::tree::autoNag($key)
+    }
+    unset -nocomplain tree(nagsError$baseNumber)
     if { [catch {
       set nagsData [sc_tree nags $baseNumber $filter 0]
       foreach entry $nagsData {
@@ -433,7 +436,9 @@ proc ::tree::dorefresh { baseNumber {filter "tree"}} {
           set ::tree::autoNag($baseNumber,$moveSAN) $bestNag
           if { $::tree::mask::maskFile != "" } {
             ::tree::mask::setCacheFenIndex
-            catch { ::tree::mask::setNag $moveSAN $bestNag "" 0 }
+            if { [::tree::mask::moveExists $moveSAN] } {
+              catch { ::tree::mask::setNag $moveSAN $bestNag "" 0 }
+            }
           }
         }
       }

--- a/tcl/windows/tree.tcl
+++ b/tcl/windows/tree.tcl
@@ -43,6 +43,9 @@ proc ::tree::make { { baseNumber -1 } {locked 0} } {
   set tree(order$baseNumber) "frequency"
   set tree(allgames$baseNumber) 1
   set tree(movedepth$baseNumber) $tree(moveDepth)
+  if { ! [info exists tree(nagsAutopopulate$baseNumber)] } {
+    set tree(nagsAutopopulate$baseNumber) 0
+  }
 
   bind $w <Destroy> "::tree::closeTree $baseNumber"
 
@@ -114,6 +117,9 @@ proc ::tree::make { { baseNumber -1 } {locked 0} } {
   $w.menu.opt add checkbutton -label TreeOptTraining -variable tree(training$baseNumber) -command "::tree::toggleTraining $baseNumber"
   set helpMessage($w.menu.opt,1) TreeOptTraining
 
+  $w.menu.opt add checkbutton -label [tr Annotations] -variable tree(nagsAutopopulate$baseNumber)
+  set helpMessage($w.menu.opt,2) "Automatically populate evaluation symbols (!, ?, !!, etc.) from database games"
+
   $w.menu.helpmenu add command -label TreeHelpTree -accelerator F1 -command {helpWindow Tree}
   $w.menu.helpmenu add command -label TreeHelpIndex -command {helpWindow Index}
 
@@ -150,14 +156,15 @@ proc ::tree::make { { baseNumber -1 } {locked 0} } {
 
   ttk::checkbutton $w.buttons.allgames -textvar ::tr(allGames) -variable tree(allgames$baseNumber) -command "::tree::refresh $baseNumber"
   ttk::checkbutton $w.buttons.training -textvar ::tr(Training) -variable tree(training$baseNumber) -command "::tree::toggleTraining $baseNumber"
-  
+  ttk::checkbutton $w.buttons.annotations -textvar ::tr(Annotations) -variable tree(nagsAutopopulate$baseNumber) -command "::tree::refresh $baseNumber"
+
   # Add move depth selector
   ttk::label $w.buttons.depthlabel -textvar ::tr(TreeDepth)
   ttk::spinbox $w.buttons.depth -from 1 -to 4 -width 3 \
       -textvariable tree(movedepth$baseNumber) -command "::tree::refresh $baseNumber"
   bind $w.buttons.depth <Return> "::tree::refresh $baseNumber"
 
-  foreach {b t} { best TreeFileBest graph TreeFileGraph allgames TreeOptLock  training TreeOptTraining bStartStop TreeOptStartStop depth TreeOptDepth depthlabel TreeOptDepth } {
+  foreach {b t} { best TreeFileBest graph TreeFileGraph allgames TreeOptLock  training TreeOptTraining bStartStop TreeOptStartStop depth TreeOptDepth depthlabel TreeOptDepth annotations TreeOptAnnotations } {
     set helpMessage($w.buttons.$b) $t
   }
 
@@ -165,6 +172,7 @@ proc ::tree::make { { baseNumber -1 } {locked 0} } {
   dialogbutton $w.buttons.close -textvar ::tr(Close) -command "::tree::closeTree $baseNumber"
 
   pack $w.buttons.best $w.buttons.graph $w.buttons.bStartStop $w.buttons.allgames $w.buttons.training \
+      $w.buttons.annotations \
       -side left -padx 3 -pady 2
   pack $w.buttons.depthlabel -side left -padx "15 3" -pady 2
   pack $w.buttons.depth -side left -padx "0 3" -pady 2
@@ -405,8 +413,40 @@ proc ::tree::dorefresh { baseNumber {filter "tree"}} {
   }
   catch {$w.f.tl itemconfigure 0 -foreground darkBlue}
 
+  # Extract evaluation NAGs from games and populate the mask or autoNag array
+  if { !$err && $tree(nagsAutopopulate$baseNumber) == 1 } {
+    # Clear stale auto NAGs from the previous position
+    if { [info exists ::tree::autoNag] } { array unset ::tree::autoNag }
+    if { [catch {
+      set nagsData [sc_tree nags $baseNumber $filter 0]
+      foreach entry $nagsData {
+        set moveSAN [lindex $entry 0]
+        set bestNag ""
+        set bestCount 0
+        foreach {nag count} [lrange $entry 1 end] {
+          if { $count > $bestCount } {
+            set bestNag $nag
+            set bestCount $count
+          }
+        }
+        if { $bestNag != "" } {
+          set ::tree::autoNag($baseNumber,$moveSAN) $bestNag
+          if { $::tree::mask::maskFile != "" } {
+            ::tree::mask::setCacheFenIndex
+            catch { ::tree::mask::setNag $moveSAN $bestNag "" 0 }
+          }
+        }
+      }
+    } errMsg ] } {
+      set tree(nagsError$baseNumber) $errMsg
+    }
+  }
+
   ::tree::restoreButtons $w
   ::tree::status "" $baseNumber
+  if { [info exists tree(nagsError$baseNumber)] } {
+    ::tree::status "[tr Annotations]: $tree(nagsError$baseNumber)" $baseNumber
+  }
   displayLines $baseNumber $moves
 
   if {[winfo exists .treeGraph$baseNumber]} { ::tree::graph $baseNumber }
@@ -420,12 +460,13 @@ proc ::tree::dorefresh { baseNumber {filter "tree"}} {
 #
 ################################################################################
 proc ::tree::displayLines { baseNumber moves } {
-  global ::tree::mask::maskFile
+  global ::tree::mask::maskFile tree
 
   ::tree::mask::setCacheFenIndex
 
   set lMoves {}
   set w .treeWin$baseNumber
+  set showAutoNagCol 0
 
   $w.f.tl configure -state normal
 
@@ -459,12 +500,35 @@ proc ::tree::displayLines { baseNumber moves } {
     }
   }
 
+  # Determine if we have any auto NAGs for this display (mask-less mode)
+  if { $maskFile == "" && $tree(nagsAutopopulate$baseNumber) == 1 } {
+    for { set i 1 } { $i < [expr $len - 3 ] } { incr i } {
+      set line [lindex $moves $i]
+      if {$line == ""} { continue }
+      set move [lindex $line 1]
+      set move [::untrans $move]
+      set lookMove [lindex [split $move " "] 0]
+      if { [info exists ::tree::autoNag($baseNumber,$lookMove)] } {
+        set showAutoNagCol 1
+        break
+      }
+    }
+  }
+
+  # Pick the best empty spacer image (transparent if available, opaque GIF fallback)
+  set autoNagImg "tb_empty"
+  if { [lsearch [image names] "::icon::tb_empty"] != -1 } { set autoNagImg "::icon::tb_empty" }
+
   # Display the first line
-  if { $maskFile != "" } {
-    $w.f.tl image create end -image tb_empty -align center
-    $w.f.tl image create end -image tb_empty -align center
-    $w.f.tl insert end "    "
-    $w.f.tl tag bind tagclick0 <ButtonPress-$::MB3> "::tree::mask::contextMenu $w.f.tl dummy %x %y %X %Y ; break"
+  if { $maskFile != "" || $showAutoNagCol } {
+    $w.f.tl image create end -image $autoNagImg -align center
+    $w.f.tl image create end -image $autoNagImg -align center
+    if { $maskFile != "" } {
+      $w.f.tl insert end "    "
+      $w.f.tl tag bind tagclick0 <ButtonPress-$::MB3> "::tree::mask::contextMenu $w.f.tl dummy %x %y %X %Y ; break"
+    } else {
+      $w.f.tl insert end "     "
+    }
   }
   $w.f.tl insert end "[lindex $moves 0]\n" tagclick0
 
@@ -500,6 +564,23 @@ proc ::tree::displayLines { baseNumber moves } {
         $w.f.tl image create end -image tb_empty -align center
         $w.f.tl image create end -image tb_empty -align center
       }
+    } elseif { $showAutoNagCol } {
+      $w.f.tl image create end -image $autoNagImg -align center
+      $w.f.tl image create end -image $autoNagImg -align center
+      $w.f.tl insert end "  "
+      set autoNag ""
+      if { $i > 0 && $i < [expr $len - 3] && $move != "\[end\]" } {
+        set lookMove [lindex [split $move " "] 0]
+        if { [info exists ::tree::autoNag($baseNumber,$lookMove)] } {
+          set autoNag $::tree::autoNag($baseNumber,$lookMove)
+        }
+      }
+      if { $autoNag == "" } {
+        set autoNag "   "
+      } else {
+        set autoNag [string range "$autoNag   " 0 2]
+      }
+      $w.f.tl insert end $autoNag
     }
     # Move and stats
     set lineStart [$w.f.tl index "end - 1 chars"]
@@ -539,10 +620,15 @@ proc ::tree::displayLines { baseNumber moves } {
 
   # Display the last lines (total)
   for { set i [expr $len - 3 ] } { $i < [expr $len - 1 ] } { incr i } {
-    if { $maskFile != "" } {
-      $w.f.tl image create end -image tb_empty -align center
-      $w.f.tl image create end -image tb_empty -align center
-      $w.f.tl insert end "    "
+    if { $maskFile != "" || $showAutoNagCol } {
+      set img [expr { $maskFile != "" ? "tb_empty" : $autoNagImg }]
+      $w.f.tl image create end -image $img -align center
+      $w.f.tl image create end -image $img -align center
+      if { $maskFile != "" } {
+        $w.f.tl insert end "    "
+      } else {
+        $w.f.tl insert end "     "
+      }
     }
     $w.f.tl insert end "[lindex $moves $i]\n"
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evaluation annotation statistics to tree views, including move-specific NAG frequencies and average Elo.
  * Added an option to automatically populate move annotations from the most frequent evaluations.
  * Tree displays now include an annotation column when no mask is active.
  * Added support for retrieving tree annotation data through the command interface.
* **Bug Fixes**
  * Tree refreshes now report annotation extraction errors in the status area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->