### PR TITLE
Make Lichess Eval clickable and auto-refresh (if left open)

### DIFF
--- a/tcl/game.tcl
+++ b/tcl/game.tcl
@@ -429,6 +429,7 @@ namespace eval ::notify {
     if {[winfo exists .twinchecker]} { updateTwinChecker }
     if {[winfo exists .bookWin]} { ::book::refresh }
     if {[winfo exists .bookTuningWin]} { ::book::refreshTuning }
+    if {[winfo exists .lichessEvalResult]} { ::lichess_eval::refresh }
     updateNoveltyWin
     ::updateTreeFilter
     ::epd::updateEpdWins

--- a/tcl/tools/lichess_eval.tcl
+++ b/tcl/tools/lichess_eval.tcl
@@ -10,6 +10,9 @@ namespace eval ::lichess_eval {
     variable multiPv 5
     variable pvData
     array set pvData {}
+    variable lastFen ""
+    variable latestFen ""
+    variable refreshPending ""
 }
 
 # ::lichess_eval::formatScore
@@ -137,6 +140,14 @@ proc ::lichess_eval::lookupPosition {} {
     set w .lichessEvalResult
     if {[winfo exists $w]} { destroy $w }
 
+    # Reset tracking variables for the new window
+    set ::lichess_eval::lastFen ""
+    set ::lichess_eval::latestFen ""
+    if {$::lichess_eval::refreshPending ne ""} {
+        after cancel $::lichess_eval::refreshPending
+        set ::lichess_eval::refreshPending ""
+    }
+
     toplevel $w
     wm title $w "Lichess Cloud Eval"
     wm resizable $w 1 1
@@ -167,6 +178,10 @@ proc ::lichess_eval::lookupPosition {} {
 
     ::lichess_eval::displayResult $w $result $fen
 
+    # Track the FEN we just displayed so refresh can detect changes
+    set ::lichess_eval::lastFen $fen
+    set ::lichess_eval::latestFen $fen
+
     # Center the window
     update idletasks
     set winWidth [winfo width $w]
@@ -181,18 +196,48 @@ proc ::lichess_eval::lookupPosition {} {
 # ::lichess_eval::refresh
 #   Called automatically when the board position changes while the
 #   Lichess Eval window is open. Re-queries Lichess and updates the display.
+#   This is debounced and async to avoid blocking the UI.
 #
 proc ::lichess_eval::refresh {} {
     set w .lichessEvalResult
     if {![winfo exists $w]} { return }
+
+    # Get current position
+    set fen [sc_pos fen]
+
+    # Skip if FEN hasn't changed (e.g., pgnonly updates)
+    if {$fen eq $::lichess_eval::lastFen} {
+        return
+    }
+
+    # Update the latest FEN we want to display
+    set ::lichess_eval::latestFen $fen
+
+    # Cancel any pending refresh
+    if {$::lichess_eval::refreshPending ne ""} {
+        after cancel $::lichess_eval::refreshPending
+    }
+
+    # Schedule a debounced refresh after 300ms
+    set ::lichess_eval::refreshPending [after 300 ::lichess_eval::doRefresh]
+}
+
+# ::lichess_eval::doRefresh
+#   Internal helper that performs the actual async refresh.
+#   Called after debounce delay expires.
+#
+proc ::lichess_eval::doRefresh {} {
+    set w .lichessEvalResult
+    if {![winfo exists $w]} { return }
+
+    set fen $::lichess_eval::latestFen
+    set ::lichess_eval::refreshPending ""
 
     # Clear existing display
     if {[winfo exists $w.result]} { destroy $w.result }
     if {[winfo exists $w.error]} { destroy $w.error }
     if {[winfo exists $w.content.loading]} { destroy $w.content.loading }
 
-    # Get current position
-    set fen [sc_pos fen]
     set gameVariant [sc_game variant]
     if {$gameVariant eq "chess960"} {
         set variant "chess960"
@@ -202,9 +247,86 @@ proc ::lichess_eval::refresh {} {
 
     ttk::label $w.content.loading -text "Querying Lichess cloud eval..." -font font_Bold
     pack $w.content.loading -pady 10
-    update idletasks
 
-    lassign [::lichess_eval::queryCloudEval $fen $variant] ok result err fen
+    # Start async query
+    ::lichess_eval::queryCloudEvalAsync $fen $variant
+}
+
+# ::lichess_eval::queryCloudEvalAsync
+#   Asynchronously queries the Lichess cloud eval API.
+#   Calls handleAsyncResponse when complete.
+#
+proc ::lichess_eval::queryCloudEvalAsync {fen variant} {
+    set urlFen [string map {" " "%20"} $fen]
+    set url "$::lichess_eval::apiUrl?fen=$urlFen&multiPv=$::lichess_eval::multiPv&variant=$variant"
+
+    # Ensure http and tls packages are available
+    if {[catch {package require http}]} {
+        ::lichess_eval::handleAsyncResponse $fen 0 "" "HTTP package not available"
+        return
+    }
+    catch {package require tls}
+    catch {::http::register https 443 ::tls::socket}
+
+    # Start async HTTP request
+    if {[catch {
+        ::http::geturl $url -timeout 10000 -command [list ::lichess_eval::handleAsyncResponse $fen]
+    } err]} {
+        ::lichess_eval::handleAsyncResponse $fen 0 "" "HTTP request failed: $err"
+    }
+}
+
+# ::lichess_eval::handleAsyncResponse
+#   Callback for async HTTP response.
+#   Only updates display if FEN still matches latest request and window exists.
+#
+proc ::lichess_eval::handleAsyncResponse {requestedFen token {errMsg ""}} {
+    set w .lichessEvalResult
+
+    # Only process if window still exists
+    if {![winfo exists $w]} {
+        if {$token ne "0"} {
+            catch {::http::cleanup $token}
+        }
+        return
+    }
+
+    # Discard stale responses - only process if this FEN is still the latest
+    if {$requestedFen ne $::lichess_eval::latestFen} {
+        if {$token ne "0"} {
+            catch {::http::cleanup $token}
+        }
+        destroy $w.content.loading
+        return
+    }
+
+    # Update lastFen to track what we've displayed
+    set ::lichess_eval::lastFen $requestedFen
+
+    # Handle error case (token is "0" for errors)
+    if {$token eq "0"} {
+        destroy $w.content.loading
+        ::lichess_eval::showError $w "Failed to query Lichess cloud eval: $errMsg"
+        return
+    }
+
+    # Extract response
+    set ok 0
+    set result ""
+    set err ""
+
+    if {[catch {
+        set status [::http::status $token]
+        if {$status eq "ok"} {
+            set result [::http::data $token]
+            set ok 1
+        } else {
+            set err "HTTP status: $status"
+        }
+        ::http::cleanup $token
+    } cleanupErr]} {
+        set err "HTTP error: $cleanupErr"
+    }
 
     destroy $w.content.loading
 
@@ -218,7 +340,7 @@ proc ::lichess_eval::refresh {} {
         return
     }
 
-    ::lichess_eval::displayResult $w $result $fen
+    ::lichess_eval::displayResult $w $result $requestedFen
 }
 
 # ::lichess_eval::displayResult

--- a/tcl/tools/lichess_eval.tcl
+++ b/tcl/tools/lichess_eval.tcl
@@ -273,16 +273,21 @@ proc ::lichess_eval::queryCloudEvalAsync {fen variant} {
     set urlFen [string map {" " "%20"} $fen]
     set url "$::lichess_eval::apiUrl?fen=$urlFen&multiPv=$::lichess_eval::multiPv&variant=$variant"
 
-    if {[catch {
-        set fd [open [list | curl -s --max-time 10 -H {Accept: */*} $url] r]
-        fconfigure $fd -blocking 0 -buffering full
-        variable pendingFd
-        variable queryBuf
-        set pendingFd $fd
-        set queryBuf ""
-        fileevent $fd readable [list ::lichess_eval::onAsyncData_ $fd $fen]
-    } err]} {
-        ::lichess_eval::handleAsyncResponse $fen "" "curl not available: $err"
+if {[catch {
+    set fd [open [list | curl -s --max-time 10 -H {Accept: */*} $url] r]
+    fconfigure $fd -blocking 0 -buffering full
+    variable pendingFd
+    variable queryBuf
+    set pendingFd $fd
+    set queryBuf ""
+    fileevent $fd readable [list ::lichess_eval::onAsyncData_ $fd $fen]
+} err]} {
+    # Fallback to the synchronous implementation (which already falls back to Tcl http)
+    lassign [::lichess_eval::queryCloudEval $fen $variant] ok result err2 dummyFen
+    if {$ok} {
+        ::lichess_eval::handleAsyncResponse $fen $result
+    } else {
+        ::lichess_eval::handleAsyncResponse $fen "" "Failed to query Lichess cloud eval: $err2"
     }
 }
 

--- a/tcl/tools/lichess_eval.tcl
+++ b/tcl/tools/lichess_eval.tcl
@@ -8,6 +8,8 @@
 namespace eval ::lichess_eval {
     variable apiUrl "https://lichess.org/api/cloud-eval"
     variable multiPv 5
+    variable pvData
+    array set pvData {}
 }
 
 # ::lichess_eval::formatScore
@@ -84,12 +86,45 @@ proc ::lichess_eval::formatLine {fen sanMoves} {
     return [string trim $result]
 }
 
+# ::lichess_eval::queryCloudEval
+#   Queries the Lichess cloud eval API and returns {ok result err fen}.
+#   Used by both lookupPosition (new window) and refresh (existing window).
+#
+proc ::lichess_eval::queryCloudEval {fen variant} {
+    set urlFen [string map {" " "%20"} $fen]
+    set url "$::lichess_eval::apiUrl?fen=$urlFen&multiPv=$::lichess_eval::multiPv&variant=$variant"
+
+    set result ""
+    set err ""
+    set ok 0
+
+    set cmd [list curl -s --max-time 10 -H "Accept: */*" $url]
+    if {![catch {exec {*}$cmd} result]} {
+        set ok 1
+    } else {
+        set err $result
+        if {![catch {package require http}]} {
+            catch {package require tls}
+            catch {::http::register https 443 ::tls::socket}
+            set token ""
+            if {![catch {set token [::http::geturl $url -timeout 10000]} httpErr]} {
+                set result [::http::data $token]
+                ::http::cleanup $token
+                set ok 1
+            } else {
+                set err $httpErr
+            }
+        }
+    }
+
+    return [list $ok $result $err $fen]
+}
+
 # ::lichess_eval::lookupPosition
 #   Queries the Lichess cloud eval API for the current position
 #   and displays the results in a popup window.
 #
 proc ::lichess_eval::lookupPosition {} {
-    # Get the current FEN and variant
     set fen [sc_pos fen]
     set gameVariant [sc_game variant]
     if {$gameVariant eq "chess960"} {
@@ -97,12 +132,6 @@ proc ::lichess_eval::lookupPosition {} {
     } else {
         set variant "standard"
     }
-
-    # URL-encode the FEN
-    set urlFen [string map {" " "%20"} $fen]
-
-    # Construct the API URL
-    set url "$::lichess_eval::apiUrl?fen=$urlFen&multiPv=$::lichess_eval::multiPv&variant=$variant"
 
     # Create or reset the popup window
     set w .lichessEvalResult
@@ -122,30 +151,7 @@ proc ::lichess_eval::lookupPosition {} {
 
     update idletasks
 
-    # Make the HTTP request using curl
-    set result ""
-    set err ""
-    set ok 0
-
-    set cmd [list curl -s --max-time 10 -H "Accept: */*" $url]
-    if {![catch {exec {*}$cmd} result]} {
-        set ok 1
-    } else {
-        set err $result
-        # Fallback: Tcl http
-        if {![catch {package require http}]} {
-            catch {package require tls}
-            catch {::http::register https 443 ::tls::socket}
-            set token ""
-            if {![catch {set token [::http::geturl $url -timeout 10000]} httpErr]} {
-                set result [::http::data $token]
-                ::http::cleanup $token
-                set ok 1
-            } else {
-                set err $httpErr
-            }
-        }
-    }
+    lassign [::lichess_eval::queryCloudEval $fen $variant] ok result err fen
 
     destroy $w.content.loading
 
@@ -154,13 +160,11 @@ proc ::lichess_eval::lookupPosition {} {
         return
     }
 
-    # Check for error responses
     if {[string match "*error*" $result] && ![regexp {"pvs"} $result]} {
         ::lichess_eval::showError $w "Position not found in Lichess cloud eval database.\n\nThis position may not have been analyzed by Lichess users yet."
         return
     }
 
-    # Parse and display
     ::lichess_eval::displayResult $w $result $fen
 
     # Center the window
@@ -172,6 +176,49 @@ proc ::lichess_eval::lookupPosition {} {
     set x [expr {([winfo screenwidth $w] - $winWidth) / 2}]
     set y [expr {([winfo screenheight $w] - $winHeight) / 2}]
     wm geometry $w "+$x+$y"
+}
+
+# ::lichess_eval::refresh
+#   Called automatically when the board position changes while the
+#   Lichess Eval window is open. Re-queries Lichess and updates the display.
+#
+proc ::lichess_eval::refresh {} {
+    set w .lichessEvalResult
+    if {![winfo exists $w]} { return }
+
+    # Clear existing display
+    if {[winfo exists $w.result]} { destroy $w.result }
+    if {[winfo exists $w.error]} { destroy $w.error }
+    if {[winfo exists $w.content.loading]} { destroy $w.content.loading }
+
+    # Get current position
+    set fen [sc_pos fen]
+    set gameVariant [sc_game variant]
+    if {$gameVariant eq "chess960"} {
+        set variant "chess960"
+    } else {
+        set variant "standard"
+    }
+
+    ttk::label $w.content.loading -text "Querying Lichess cloud eval..." -font font_Bold
+    pack $w.content.loading -pady 10
+    update idletasks
+
+    lassign [::lichess_eval::queryCloudEval $fen $variant] ok result err fen
+
+    destroy $w.content.loading
+
+    if {!$ok} {
+        ::lichess_eval::showError $w "Failed to query Lichess cloud eval: $err"
+        return
+    }
+
+    if {[string match "*error*" $result] && ![regexp {"pvs"} $result]} {
+        ::lichess_eval::showError $w "Position not found in Lichess cloud eval database.\n\nThis position may not have been analyzed by Lichess users yet."
+        return
+    }
+
+    ::lichess_eval::displayResult $w $result $fen
 }
 
 # ::lichess_eval::displayResult
@@ -238,7 +285,8 @@ proc ::lichess_eval::displayResult {w jsonData fen} {
 
     # Create a text widget for the PV lines
     text $w.result.lines -height 16 -width 70 -wrap word -relief solid \
-        -borderwidth 1 -font font_Regular -spacing1 4 -spacing3 4
+        -borderwidth 1 -font font_Regular -spacing1 4 -spacing3 4 \
+        -cursor hand2
     $w.result.lines tag configure pvnum -font font_Bold
     $w.result.lines tag configure score -font font_Bold -foreground "blue"
     $w.result.lines tag configure moves -font font_Regular
@@ -247,6 +295,9 @@ proc ::lichess_eval::displayResult {w jsonData fen} {
     set lineNum 1
     foreach pv $pvs {
         lassign $pv uciMoves cp mate
+
+        # Store UCI moves for click handling
+        set ::lichess_eval::pvData($w.result.lines,$lineNum) $uciMoves
 
         # Format the score
         set scoreArgs {}
@@ -260,6 +311,9 @@ proc ::lichess_eval::displayResult {w jsonData fen} {
         # Format with move numbers
         set numberedMoves [::lichess_eval::formatLine $fen $sanMoves]
 
+        # Track start position before inserting this PV block
+        set blockStart [$w.result.lines index end]
+
         # Insert into text widget
         $w.result.lines insert end "Line $lineNum" pvnum
         $w.result.lines insert end "  " {}
@@ -267,8 +321,13 @@ proc ::lichess_eval::displayResult {w jsonData fen} {
         $w.result.lines insert end "\n" {}
         $w.result.lines insert end "  $numberedMoves\n\n" moves
 
+        # Tag the entire PV block for click detection
+        $w.result.lines tag add pvline$lineNum $blockStart "end-2c"
+
         incr lineNum
     }
+
+    bind $w.result.lines <ButtonRelease-1> {::lichess_eval::handleClick %W %x %y}
 
     $w.result.lines configure -state disabled
 
@@ -281,6 +340,40 @@ proc ::lichess_eval::displayResult {w jsonData fen} {
     bind $w <Escape> "destroy $w"
     bind $w <Return> "destroy $w"
     focus $w.buttons.close
+
+    bind $w <Destroy> [list ::lichess_eval::cleanupPvData $w.result.lines]
+}
+
+# ::lichess_eval::handleClick
+#   Called when the user clicks on a PV line in the results window.
+#   Plays the first move of the clicked line on the board.
+#
+proc ::lichess_eval::handleClick {w x y} {
+    variable pvData
+    set clickedIndex [$w index @$x,$y]
+    set tags [$w tag names $clickedIndex]
+
+    foreach tag $tags {
+        if {[regexp {^pvline(\d+)$} $tag -> lineNum]} {
+            if {![info exists pvData($w,$lineNum)]} { return }
+            set uciMoves $pvData($w,$lineNum)
+            set firstMove [lindex [split $uciMoves " "] 0]
+            if {$firstMove eq ""} { return }
+
+            addMoveUCI $firstMove
+            return
+        }
+    }
+}
+
+# ::lichess_eval::cleanupPvData
+#   Removes stored PV data for a toplevel window when it is destroyed.
+#
+proc ::lichess_eval::cleanupPvData {toplevel} {
+    variable pvData
+    foreach key [array names pvData "$toplevel.*"] {
+        unset pvData($key)
+    }
 }
 
 # ::lichess_eval::showError

--- a/tcl/tools/lichess_eval.tcl
+++ b/tcl/tools/lichess_eval.tcl
@@ -247,8 +247,9 @@ proc ::lichess_eval::doRefresh {} {
     set queryBuf ""
 
     # Clear existing display
-    if {[winfo exists $w.result]} { destroy $w.result }
-    if {[winfo exists $w.error]} { destroy $w.error }
+    if {[winfo exists $w.result]}  { destroy $w.result }
+    if {[winfo exists $w.error]}   { destroy $w.error }
+    if {[winfo exists $w.buttons]} { destroy $w.buttons }
     if {[winfo exists $w.content.loading]} { destroy $w.content.loading }
 
     set gameVariant [sc_game variant]
@@ -289,6 +290,7 @@ if {[catch {
     } else {
         ::lichess_eval::handleAsyncResponse $fen "" "Failed to query Lichess cloud eval: $err2"
     }
+  }
 }
 
 # ::lichess_eval::onAsyncData_

--- a/tcl/tools/lichess_eval.tcl
+++ b/tcl/tools/lichess_eval.tcl
@@ -270,7 +270,7 @@ proc ::lichess_eval::doRefresh {} {
 #   non-blocking pipe. Calls handleAsyncResponse when complete.
 #
 proc ::lichess_eval::queryCloudEvalAsync {fen variant} {
-    set urlFen [string map {" " "%20"} $fen]
+    set urlFen [string map {" " "%20" "/" "%2F" "+" "%2B" "?" "%3F" "&" "%26" "=" "%3D" "#" "%23" "%" "%25"} $fen]
     set url "$::lichess_eval::apiUrl?fen=$urlFen&multiPv=$::lichess_eval::multiPv&variant=$variant"
 
 if {[catch {

--- a/tcl/tools/lichess_eval.tcl
+++ b/tcl/tools/lichess_eval.tcl
@@ -501,11 +501,11 @@ proc ::lichess_eval::handleClick {w x y} {
 # ::lichess_eval::cleanupPvData
 #   Removes stored PV data for a toplevel window when it is destroyed.
 #
-proc ::lichess_eval::cleanupPvData {toplevel} {
+proc ::lichess_eval::cleanupPvData {textWidget} {
     variable pvData
     variable pendingFd
     variable queryBuf
-    foreach key [array names pvData "$toplevel.*"] {
+    foreach key [array names pvData "${textWidget},*"] {
         unset pvData($key)
     }
     if {$pendingFd ne ""} {

--- a/tcl/tools/lichess_eval.tcl
+++ b/tcl/tools/lichess_eval.tcl
@@ -13,6 +13,8 @@ namespace eval ::lichess_eval {
     variable lastFen ""
     variable latestFen ""
     variable refreshPending ""
+    variable pendingFd ""
+    variable queryBuf ""
 }
 
 # ::lichess_eval::formatScore
@@ -205,8 +207,9 @@ proc ::lichess_eval::refresh {} {
     # Get current position
     set fen [sc_pos fen]
 
-    # Skip if FEN hasn't changed (e.g., pgnonly updates)
-    if {$fen eq $::lichess_eval::lastFen} {
+    # Skip if FEN matches the latest already requested (e.g., pgnonly updates,
+    # or re-triggering while an async query is still in flight)
+    if {$fen eq $::lichess_eval::latestFen} {
         return
     }
 
@@ -227,11 +230,21 @@ proc ::lichess_eval::refresh {} {
 #   Called after debounce delay expires.
 #
 proc ::lichess_eval::doRefresh {} {
+    variable pendingFd
+    variable queryBuf
+
     set w .lichessEvalResult
     if {![winfo exists $w]} { return }
 
     set fen $::lichess_eval::latestFen
     set ::lichess_eval::refreshPending ""
+
+    # Cancel any in-flight async curl
+    if {$pendingFd ne ""} {
+        catch { close $pendingFd }
+        set pendingFd ""
+    }
+    set queryBuf ""
 
     # Clear existing display
     if {[winfo exists $w.result]} { destroy $w.result }
@@ -253,94 +266,91 @@ proc ::lichess_eval::doRefresh {} {
 }
 
 # ::lichess_eval::queryCloudEvalAsync
-#   Asynchronously queries the Lichess cloud eval API.
-#   Calls handleAsyncResponse when complete.
+#   Asynchronously queries the Lichess cloud eval API using curl via a
+#   non-blocking pipe. Calls handleAsyncResponse when complete.
 #
 proc ::lichess_eval::queryCloudEvalAsync {fen variant} {
     set urlFen [string map {" " "%20"} $fen]
     set url "$::lichess_eval::apiUrl?fen=$urlFen&multiPv=$::lichess_eval::multiPv&variant=$variant"
 
-    # Ensure http and tls packages are available
-    if {[catch {package require http}]} {
-        ::lichess_eval::handleAsyncResponse $fen 0 "" "HTTP package not available"
+    if {[catch {
+        set fd [open [list | curl -s --max-time 10 -H {Accept: */*} $url] r]
+        fconfigure $fd -blocking 0 -buffering full
+        variable pendingFd
+        variable queryBuf
+        set pendingFd $fd
+        set queryBuf ""
+        fileevent $fd readable [list ::lichess_eval::onAsyncData_ $fd $fen]
+    } err]} {
+        ::lichess_eval::handleAsyncResponse $fen "" "curl not available: $err"
+    }
+}
+
+# ::lichess_eval::onAsyncData_
+#   Internal: handles readable event from the async curl pipe.
+#   Accumulates data and invokes handleAsyncResponse on EOF.
+#
+proc ::lichess_eval::onAsyncData_ {fd fen} {
+    variable pendingFd
+    variable queryBuf
+
+    if {$pendingFd ne $fd} {
+        catch { close $fd }
         return
     }
-    catch {package require tls}
-    catch {::http::register https 443 ::tls::socket}
 
-    # Start async HTTP request
-    if {[catch {
-        ::http::geturl $url -timeout 10000 -command [list ::lichess_eval::handleAsyncResponse $fen]
-    } err]} {
-        ::lichess_eval::handleAsyncResponse $fen 0 "" "HTTP request failed: $err"
+    if {[catch { append queryBuf [read $fd] }]} {
+        catch { close $fd }
+        set pendingFd ""
+        set queryBuf ""
+        return
+    }
+
+    if {[eof $fd]} {
+        set data $queryBuf
+        catch { close $fd }
+        set pendingFd ""
+        set queryBuf ""
+
+        if {[string match "*error*" $data] && ![regexp {"pvs"} $data]} {
+            ::lichess_eval::handleAsyncResponse $fen "" "Position not found in Lichess cloud eval database."
+            return
+        }
+
+        ::lichess_eval::handleAsyncResponse $fen $data
     }
 }
 
 # ::lichess_eval::handleAsyncResponse
-#   Callback for async HTTP response.
+#   Callback for async responses (from curl pipe or errors).
 #   Only updates display if FEN still matches latest request and window exists.
 #
-proc ::lichess_eval::handleAsyncResponse {requestedFen token {errMsg ""}} {
+proc ::lichess_eval::handleAsyncResponse {requestedFen data {errMsg ""}} {
     set w .lichessEvalResult
 
-    # Only process if window still exists
-    if {![winfo exists $w]} {
-        if {$token ne "0"} {
-            catch {::http::cleanup $token}
-        }
-        return
-    }
+    if {![winfo exists $w]} { return }
 
-    # Discard stale responses - only process if this FEN is still the latest
     if {$requestedFen ne $::lichess_eval::latestFen} {
-        if {$token ne "0"} {
-            catch {::http::cleanup $token}
-        }
-        destroy $w.content.loading
+        if {[winfo exists $w.content.loading]} { destroy $w.content.loading }
         return
     }
 
-    # Update lastFen to track what we've displayed
     set ::lichess_eval::lastFen $requestedFen
 
-    # Handle error case (token is "0" for errors)
-    if {$token eq "0"} {
-        destroy $w.content.loading
+    if {$data eq ""} {
+        if {[winfo exists $w.content.loading]} { destroy $w.content.loading }
         ::lichess_eval::showError $w "Failed to query Lichess cloud eval: $errMsg"
         return
     }
 
-    # Extract response
-    set ok 0
-    set result ""
-    set err ""
+    if {[winfo exists $w.content.loading]} { destroy $w.content.loading }
 
-    if {[catch {
-        set status [::http::status $token]
-        if {$status eq "ok"} {
-            set result [::http::data $token]
-            set ok 1
-        } else {
-            set err "HTTP status: $status"
-        }
-        ::http::cleanup $token
-    } cleanupErr]} {
-        set err "HTTP error: $cleanupErr"
-    }
-
-    destroy $w.content.loading
-
-    if {!$ok} {
-        ::lichess_eval::showError $w "Failed to query Lichess cloud eval: $err"
-        return
-    }
-
-    if {[string match "*error*" $result] && ![regexp {"pvs"} $result]} {
+    if {[string match "*error*" $data] && ![regexp {"pvs"} $data]} {
         ::lichess_eval::showError $w "Position not found in Lichess cloud eval database.\n\nThis position may not have been analyzed by Lichess users yet."
         return
     }
 
-    ::lichess_eval::displayResult $w $result $requestedFen
+    ::lichess_eval::displayResult $w $data $requestedFen
 }
 
 # ::lichess_eval::displayResult
@@ -493,9 +503,16 @@ proc ::lichess_eval::handleClick {w x y} {
 #
 proc ::lichess_eval::cleanupPvData {toplevel} {
     variable pvData
+    variable pendingFd
+    variable queryBuf
     foreach key [array names pvData "$toplevel.*"] {
         unset pvData($key)
     }
+    if {$pendingFd ne ""} {
+        catch { close $pendingFd }
+        set pendingFd ""
+    }
+    set queryBuf ""
 }
 
 # ::lichess_eval::showError

--- a/tcl/tools/lichess_eval.tcl
+++ b/tcl/tools/lichess_eval.tcl
@@ -96,7 +96,7 @@ proc ::lichess_eval::formatLine {fen sanMoves} {
 #   Used by both lookupPosition (new window) and refresh (existing window).
 #
 proc ::lichess_eval::queryCloudEval {fen variant} {
-    set urlFen [string map {" " "%20"} $fen]
+    set urlFen [string map {" " "%20" "/" "%2F" "+" "%2B" "?" "%3F" "&" "%26" "=" "%3D" "#" "%23" "%" "%25"} $fen]
     set url "$::lichess_eval::apiUrl?fen=$urlFen&multiPv=$::lichess_eval::multiPv&variant=$variant"
 
     set result ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click the first move in a principal variation to play it on the board.
  * Open evaluation results now refresh automatically when the displayed position changes.
  * Evaluation lines provide clearer visual feedback when they are clickable.

* **Bug Fixes**
  * Improved reliability when retrieving cloud evaluations.
  * Refreshed evaluation windows now correctly show updated analysis for the current position.
  * Prevented outdated evaluation responses from replacing results for newer positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->