### PR TITLE
Fix for MacOS DND error

### DIFF
--- a/tcl/dnd/tkdnd.tcl
+++ b/tcl/dnd/tkdnd.tcl
@@ -41,7 +41,9 @@
 # ======================================================================
 
 package require Tk
-package require tkDND 3.0
+if {[tk windowingsystem] ne "aqua"} {
+  package require tkDND 3.0
+}
 
 namespace eval tkdnd {
   variable _topw ".drag"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility on Aqua-based systems by preventing an unnecessary TkDND package load when it is not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->