### PR TITLE
Enable search for games with a specific NAG from a board position usi…

### DIFF
--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -651,6 +651,7 @@ menuText J TreeOptAutosave "Ауто-Саве Цацхе Филе" 0 \
 menuText J TreeHelp "Помоћ" 0
 menuText J TreeHelpTree "Трее Хелп" 0
 menuText J TreeHelpIndex "Индекс помоћи" 0
+menuText J TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate J SaveCache {Сачувај кеш}
 translate J Training {Обука}
 translate J LockTree {Закључај}
@@ -658,6 +659,8 @@ translate J TreeDepth {Дубина стабла (половине):}
 translate J TreeLocked {закључано}
 translate J TreeBest {Најбољи}
 translate J TreeBestGames {Најбоље игре са дрветом}
+translate J TreeFindAnyAnn {any annotation}
+translate J TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate J TreeTitleRow \

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -610,6 +610,7 @@ menuText b TreeOptAutosave "অটো-সেভ ক্যাশে ফাইল"
 menuText b TreeHelp "সাহায্য" 0
 menuText b TreeHelpTree "গাছ সাহায্য" 0
 menuText b TreeHelpIndex "সাহায্য সূচক" 0
+menuText b TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate b SaveCache {ক্যাশে সংরক্ষণ করুন}
 translate b Training {প্রশিক্ষণ}
 translate b LockTree {তালা}
@@ -617,6 +618,8 @@ translate b TreeDepth {গাছের গভীরতা (অর্ধেক �
 translate b TreeLocked {তালাবদ্ধ}
 translate b TreeBest {সেরা}
 translate b TreeBestGames {সেরা গাছ গেম}
+translate b TreeFindAnyAnn {any annotation}
+translate b TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate b TreeTitleRow \

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -651,6 +651,7 @@ menuText g TreeOptAutosave "Автоматично запазване на ке�
 menuText g TreeHelp "Помощ" 0
 menuText g TreeHelpTree "Помощ за дърво" 0
 menuText g TreeHelpIndex "Помощен индекс" 0
+menuText g TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate g SaveCache {Запазване на кеша}
 translate g Training {обучение}
 translate g LockTree {Заключване}
@@ -658,6 +659,8 @@ translate g TreeDepth {Дълбочина на дървото (половина 
 translate g TreeLocked {заключено}
 translate g TreeBest {Най-доброто}
 translate g TreeBestGames {Най-добрите игри с дървета}
+translate g TreeFindAnyAnn {any annotation}
+translate g TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate g TreeTitleRow \

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -636,6 +636,7 @@ menuText K TreeOptAutosave "Autoguardar arxiu memòria cau" 0 \
 menuText K TreeHelp "Ajut" 1
 menuText K TreeHelpTree "Ajut de l'arbre" 4
 menuText K TreeHelpIndex "Índex del fitxer d'ajuda" 0
+menuText K TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate K SaveCache {Desar memòria cau}
 translate K Training {Entrenament}
 translate K LockTree {Bloquejar}
@@ -643,6 +644,8 @@ translate K TreeDepth {Profunditat de l'arbre (meitat de moviments):}
 translate K TreeLocked {Bloquejat}
 translate K TreeBest {Millor}
 translate K TreeBestGames {Millors partides de l'arbre}
+translate K TreeFindAnyAnn {any annotation}
+translate K TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate K TreeTitleRow \

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -586,6 +586,7 @@ menuText M TreeOptAutosave "Auto-Save Cache File" 0 \
 menuText M TreeHelp "帮助" 0
 menuText M TreeHelpTree "Tree Help" 0
 menuText M TreeHelpIndex "Help Index" 0
+menuText M TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate M SaveCache {Save Cache}
 translate M Training {训练}
 translate M LockTree {锁定}
@@ -593,6 +594,8 @@ translate M TreeDepth {树深度（半步）：}
 translate M TreeLocked {locked}
 translate M TreeBest {最佳}
 translate M TreeBestGames {Best Tree Games}
+translate M TreeFindAnyAnn {any annotation}
+translate M TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate M TreeTitleRow \

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -615,6 +615,7 @@ menuText C TreeOptAutosave "Automatick ukldn cache souboru" 0 \
 menuText C TreeHelp "Npovda" 0
 menuText C TreeHelpTree "Npovda - Strom" 11
 menuText C TreeHelpIndex "Index npovdy" 0
+menuText C TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate C SaveCache {Uloit cache}
 translate C Training {Trnink}
 translate C LockTree {Zamknout}
@@ -622,6 +623,8 @@ translate C TreeDepth {Hloubka stromu (pl tahu):}
 translate C TreeLocked {Zamknuto}
 translate C TreeBest {Nejlep}
 translate C TreeBestGames {Nejlep partie stromu}
+translate C TreeFindAnyAnn {any annotation}
+translate C TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate C TreeTitleRow \

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -650,6 +650,7 @@ menuText D TreeOptAutosave "Autom. Cache-Datei sichern" 4 \
 menuText D TreeHelp "Hilfe" 0
 menuText D TreeHelpTree "Zugbaumhilfe" 0
 menuText D TreeHelpIndex "Index" 0
+menuText D TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate D SaveCache {Cache sichern}
 translate D Training {Training}
 translate D LockTree {Anbinden}
@@ -657,6 +658,8 @@ translate D TreeDepth {Baumtiefe (halbe Züge):}
 translate D TreeLocked {angebunden}
 translate D TreeBest {Beste}
 translate D TreeBestGames {Beste Zugbaumpartien}
+translate D TreeFindAnyAnn {any annotation}
+translate D TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate D TreeTitleRow \

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -650,6 +650,7 @@ menuText E TreeOptAutosave "Auto-Save Cache File" 0 \
 menuText E TreeHelp "Help" 0
 menuText E TreeHelpTree "Tree Help" 0
 menuText E TreeHelpIndex "Help Index" 0
+menuText E TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate E SaveCache {Save Cache}
 translate E Training {Training}
 translate E LockTree {Lock}
@@ -657,6 +658,8 @@ translate E TreeDepth {Plies:}
 translate E TreeLocked {locked}
 translate E TreeBest {Best}
 translate E TreeBestGames {Best Tree Games}
+translate E TreeFindAnyAnn {any annotation}
+translate E TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate E TreeTitleRow \

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -623,6 +623,7 @@ menuText F TreeOptAutosave "Enregistrer le cache automatiquement" 0
 menuText F TreeHelp "Aide" 0
 menuText F TreeHelpTree "Aide Arbre" 0
 menuText F TreeHelpIndex "Index" 0
+menuText F TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate F SaveCache {Enregistrer le cache}
 translate F Training {Entraînement}
 translate F LockTree {Verrouiller}
@@ -630,6 +631,8 @@ translate F TreeDepth {Profondeur de l'arbre (demi-mouvements) :}
 translate F TreeLocked {verrouillé}
 translate F TreeBest {Meilleur}
 translate F TreeBestGames {Arbre des meilleures parties}
+translate F TreeFindAnyAnn {any annotation}
+translate F TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate F TreeTitleRow \

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -642,6 +642,7 @@ menuText G TreeOptAutosave "Αυτόματη αποθήκευση του αρχ�
 menuText G TreeHelp "Βοήθεια" 0
 menuText G TreeHelpTree "Δένδρο βοήθειας" 0
 menuText G TreeHelpIndex "Κατάλογος βοήθειας" 0
+menuText G TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate G SaveCache {Αποθήκευση προσωρινής μνήμης Cache}
 translate G Training {Προπόνηση}
 translate G LockTree {Κλείδωμα}
@@ -649,6 +650,8 @@ translate G TreeDepth {Βάθος δέντρου (μισές κινήσεις):}
 translate G TreeLocked {κλειδωμένο}
 translate G TreeBest {Καλύτερο}
 translate G TreeBestGames {Οι καλύτερες παρτίδες του δένδρου}
+translate G TreeFindAnyAnn {any annotation}
+translate G TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate G TreeTitleRow \

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -611,6 +611,7 @@ menuText V TreeOptAutosave "שמירה אוטומטית של קובץ מטמון
 menuText V TreeHelp "עֶזרָה" 0
 menuText V TreeHelpTree "עזרה לעץ" 0
 menuText V TreeHelpIndex "אינדקס עזרה" 0
+menuText V TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate V SaveCache {שמור מטמון}
 translate V Training {הַדְרָכָה}
 translate V LockTree {לִנְעוֹל}
@@ -618,6 +619,8 @@ translate V TreeDepth {עומק עץ (חצי מהלכים):}
 translate V TreeLocked {נָעוּל}
 translate V TreeBest {טוֹב בִּיוֹתֵר}
 translate V TreeBestGames {משחקי העץ הטובים ביותר}
+translate V TreeFindAnyAnn {any annotation}
+translate V TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate V TreeTitleRow \

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -610,6 +610,7 @@ menuText h TreeOptAutosave "कैश फ़ाइल को स्वतः स
 menuText h TreeHelp "मदद" 0
 menuText h TreeHelpTree "वृक्ष सहायता" 0
 menuText h TreeHelpIndex "सहायता सूचकांक" 0
+menuText h TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate h SaveCache {कैश सहेजें}
 translate h Training {प्रशिक्षण}
 translate h LockTree {ताला}
@@ -617,6 +618,8 @@ translate h TreeDepth {पेड़ की गहराई (आधी चाल)
 translate h TreeLocked {बंद}
 translate h TreeBest {श्रेष्ठ}
 translate h TreeBestGames {सर्वश्रेष्ठ वृक्ष खेल}
+translate h TreeFindAnyAnn {any annotation}
+translate h TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate h TreeTitleRow \

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -618,6 +618,7 @@ menuText H TreeOptAutosave "Cache-fájl automatikus mentése" 11 \
 menuText H TreeHelp "Segítség" 0
 menuText H TreeHelpTree "Segítség a fához" 0
 menuText H TreeHelpIndex "Tartalom" 0
+menuText H TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate H SaveCache {Cache mentése}
 translate H Training {Edzés}
 translate H LockTree {Rögzítés}
@@ -625,6 +626,8 @@ translate H TreeDepth {Fa mélysége (fél mozgás):}
 translate H TreeLocked {rögzítve}
 translate H TreeBest {Legjobb}
 translate H TreeBestGames {A fa legjobb játszmái}
+translate H TreeFindAnyAnn {any annotation}
+translate H TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate H TreeTitleRow \

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -621,6 +621,7 @@ menuText I TreeOptAutosave "File di cache per il salvataggio automatico" 0 \
 menuText I TreeHelp "Aiuto" 0
 menuText I TreeHelpTree "Aiuto per l'albero" 0
 menuText I TreeHelpIndex "Indice" 0
+menuText I TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate I SaveCache {Salva cache}
 translate I Training {Esercizio}
 translate I LockTree {Blocca}
@@ -628,6 +629,8 @@ translate I TreeDepth {Profondità dell'albero (metà mosse):}
 translate I TreeLocked {Bloccato}
 translate I TreeBest {Migliore}
 translate I TreeBestGames {Migliori partite}
+translate I TreeFindAnyAnn {any annotation}
+translate I TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate I TreeTitleRow \

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -651,6 +651,7 @@ menuText A TreeOptAutosave "キャッシュファイルの自動保存" 0 \
 menuText A TreeHelp "ヘルプ" 0
 menuText A TreeHelpTree "ツリーヘルプ" 0
 menuText A TreeHelpIndex "ヘルプインデックス" 0
+menuText A TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate A SaveCache {キャッシュの保存}
 translate A Training {トレーニング}
 translate A LockTree {ロック}
@@ -658,6 +659,8 @@ translate A TreeDepth {ツリーの深さ (半分の移動):}
 translate A TreeLocked {ロックされた}
 translate A TreeBest {最高}
 translate A TreeBestGames {ベストツリーゲーム}
+translate A TreeFindAnyAnn {any annotation}
+translate A TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate A TreeTitleRow \

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -651,6 +651,7 @@ menuText k TreeOptAutosave "자동 저장 파일" 0 \
 menuText k TreeHelp "돕다" 0
 menuText k TreeHelpTree "나무 도움말" 0
 menuText k TreeHelpIndex "도움말 색인" 0
+menuText k TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate k SaveCache {쿠키 저장}
 translate k Training {훈련}
 translate k LockTree {잠그다}
@@ -658,6 +659,8 @@ translate k TreeDepth {트리(반쯤 이동):}
 translate k TreeLocked {잠긴}
 translate k TreeBest {의}
 translate k TreeBestGames {최고의 나무 게임}
+translate k TreeFindAnyAnn {any annotation}
+translate k TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate k TreeTitleRow \

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -640,6 +640,7 @@ menuText N TreeOptAutosave "Autom.cache-data Bewaren" 4 \
 menuText N TreeHelp "Help" 0
 menuText N TreeHelpTree "Hulp bij zoekboom" 0
 menuText N TreeHelpIndex "Index" 0
+menuText N TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate N SaveCache {Cache Bewaren}
 translate N Training {Training}
 translate N LockTree {Boom Vergrendelen}
@@ -647,6 +648,8 @@ translate N TreeDepth {Boomdiepte (halve zetten):}
 translate N TreeLocked {Vergrendeld}
 translate N TreeBest {Beste}
 translate N TreeBestGames {Boom Beste partijen}
+translate N TreeFindAnyAnn {any annotation}
+translate N TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate N TreeTitleRow \

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -620,6 +620,7 @@ menuText O TreeOptAutosave "Autolagre hurtigbuffer" 0 \
 menuText O TreeHelp "Hjelp" 0
 menuText O TreeHelpTree "Tre hjelp" 0
 menuText O TreeHelpIndex "Innholdsfortegnelse" 0
+menuText O TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate O SaveCache {Lagre hurtigbuffer}
 translate O Training {Trening}
 translate O LockTree {Lås}
@@ -627,6 +628,8 @@ translate O TreeDepth {Tredybde (halve bevegelser):}
 translate O TreeLocked {låst}
 translate O TreeBest {Beste}
 translate O TreeBestGames {Idealtrepartier}
+translate O TreeFindAnyAnn {any annotation}
+translate O TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate O TreeTitleRow \

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -549,6 +549,7 @@ menuText P TreeOptAutosave {Automatycznie zapisuj pamięć podręczną} 0 {Autom
 menuText P TreeHelp {Pomoc} 0
 menuText P TreeHelpTree {Pomoc drzewa} 0
 menuText P TreeHelpIndex {Indeks pomocy} 0
+menuText P TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate P SaveCache {Zapisz pamięć podręczną}
 translate P Training {Trening}
 translate P LockTree {Zablokuj}
@@ -556,6 +557,8 @@ translate P TreeDepth {Półposunięcia:}
 translate P TreeLocked {zablokowane}
 translate P TreeBest {Najlepsze}
 translate P TreeBestGames {Najlepsze partie z drzewa}
+translate P TreeFindAnyAnn {any annotation}
+translate P TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate P TreeTitleRow {    Posunięcie/a              ECO       Częstość     Wynik  ŚrElo Perf śrDług ŚrRok  %Remisów   %Wygr.}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -623,6 +623,7 @@ menuText B TreeOptAutosave "Salvar automaticamente arquivo de cache" 0 \
 menuText B TreeHelp "Ajuda" 0
 menuText B TreeHelpTree "Ajuda para árvore" 0
 menuText B TreeHelpIndex "Índice da Ajuda" 0
+menuText B TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate B SaveCache {Salvar Cache}
 translate B Training {Treinamento}
 translate B LockTree {Travamento}
@@ -630,6 +631,8 @@ translate B TreeDepth {Profundidade da árvore (meio movimento):}
 translate B TreeLocked {Travada} 
 translate B TreeBest {Melhor}
 translate B TreeBestGames {Melhores jogos da árvore}
+translate B TreeFindAnyAnn {any annotation}
+translate B TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate B TreeTitleRow \

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -651,6 +651,7 @@ menuText L TreeOptAutosave "Salvare automată a fișierului cache" 0 \
 menuText L TreeHelp "Ajutor" 0
 menuText L TreeHelpTree "Tree Help" 0
 menuText L TreeHelpIndex "Index de ajutor" 0
+menuText L TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate L SaveCache {Salvați cache}
 translate L Training {Antrenamentul}
 translate L LockTree {Blocare}
@@ -658,6 +659,8 @@ translate L TreeDepth {Adâncimea copacului (jumătate de mișcări):}
 translate L TreeLocked {încuiat}
 translate L TreeBest {Cel mai bun}
 translate L TreeBestGames {Cele mai bune jocuri cu copaci}
+translate L TreeFindAnyAnn {any annotation}
+translate L TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate L TreeTitleRow \

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -617,6 +617,7 @@ menuText R TreeOptAutosave "Автосохранение файла кеша" 0 
 menuText R TreeHelp "Помощь" 0
 menuText R TreeHelpTree "Помощь по дереву" 0
 menuText R TreeHelpIndex "Индекс помощи" 0
+menuText R TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate R SaveCache {Сохранить кеш}
 translate R Training {Тренировка}
 translate R LockTree {Блокировка}
@@ -624,6 +625,8 @@ translate R TreeDepth {Глубина дерева (половина хода):}
 translate R TreeLocked {Заблокировано}
 translate R TreeBest {Лучший}
 translate R TreeBestGames {Дерево лучших партий}
+translate R TreeFindAnyAnn {any annotation}
+translate R TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate R TreeTitleRow \

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -935,6 +935,8 @@ menuText Y TreeHelpTree "Tree Help" 0
 # ====== TODO To be translated ======
 menuText Y TreeHelpIndex "Help Index" 0
 # ====== TODO To be translated ======
+menuText Y TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
+# ====== TODO To be translated ======
 translate Y SaveCache {Save Cache}
 # ====== TODO To be translated ======
 translate Y Training {Training}
@@ -948,6 +950,10 @@ translate Y TreeLocked {locked}
 translate Y TreeBest {Best}
 # ====== TODO To be translated ======
 translate Y TreeBestGames {Best Tree Games}
+# ====== TODO To be translated ======
+translate Y TreeFindAnyAnn {any annotation}
+# ====== TODO To be translated ======
+translate Y TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # ====== TODO To be translated ======
 translate Y TreeTitleRow \
   {    Move(s)                   ECO       Frequency    Score  AvElo Perf avLen AvYear %Draws     %Win}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -667,6 +667,7 @@ menuText S TreeOptAutosave "Autoguardar archivo caché" 0 \
 menuText S TreeHelp "Ayuda" 1
 menuText S TreeHelpTree "Ayuda del árbol" 4
 menuText S TreeHelpIndex "Índice de la ayuda" 0
+menuText S TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate S SaveCache {Guardar caché}
 translate S Training {Entrenamiento}
 translate S LockTree {Bloquear}
@@ -674,6 +675,8 @@ translate S TreeDepth {Profundidad del árbol (medios movimientos):}
 translate S TreeLocked {Bloqueado}
 translate S TreeBest {Mejor}
 translate S TreeBestGames {Mejores partidas del árbol}
+translate S TreeFindAnyAnn {any annotation}
+translate S TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate S TreeTitleRow \

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -649,6 +649,7 @@ menuText U TreeOptAutosave "Tallenna välimuisti automaattisesti" 0 \
 menuText U TreeHelp "Ohje" 0
 menuText U TreeHelpTree "Puun ohje" 0
 menuText U TreeHelpIndex "Aakkosellinen ohje" 0
+menuText U TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate U SaveCache {Tallenna välimuisti}
 translate U Training {Valmennus}
 translate U LockTree {Lukitse}
@@ -656,6 +657,8 @@ translate U TreeDepth {Puun syvyys (puolet liikkeet):}
 translate U TreeLocked {lukittu}
 translate U TreeBest {Paras}
 translate U TreeBestGames {Parhaat pelit}
+translate U TreeFindAnyAnn {any annotation}
+translate U TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate U TreeTitleRow \

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -610,6 +610,7 @@ menuText Z TreeOptAutosave "Hifadhi Faili ya Cache kiotomatiki" 0 \
 menuText Z TreeHelp "Msaada" 0
 menuText Z TreeHelpTree "Msaada wa Mti" 0
 menuText Z TreeHelpIndex "Msaada Index" 0
+menuText Z TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate Z SaveCache {Hifadhi Cache}
 translate Z Training {Mafunzo}
 translate Z LockTree {Funga}
@@ -617,6 +618,8 @@ translate Z TreeDepth {Kina cha mti (nusu hatua):}
 translate Z TreeLocked {imefungwa}
 translate Z TreeBest {Bora zaidi}
 translate Z TreeBestGames {Michezo Bora ya Miti}
+translate Z TreeFindAnyAnn {any annotation}
+translate Z TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate Z TreeTitleRow \

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -621,6 +621,7 @@ menuText W TreeOptAutosave "Spara cache filen automatiskt" 0 \
 menuText W TreeHelp "Hjälp" 0
 menuText W TreeHelpTree "Trädhjälp" 0
 menuText W TreeHelpIndex "Hjälpindex" 0
+menuText W TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate W SaveCache {Spara cache}
 translate W Training {Träna}
 translate W LockTree {Lås}
@@ -628,6 +629,8 @@ translate W TreeDepth {Träddjup (halva rörelser):}
 translate W TreeLocked {Låst}
 translate W TreeBest {Bäst}
 translate W TreeBestGames {Bästa partier i trädet}
+translate W TreeFindAnyAnn {any annotation}
+translate W TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate W TreeTitleRow \

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -614,6 +614,7 @@ menuText T TreeOptAutosave "Önbellek Dosyasını Otomatik Kaydet" 0 \
 menuText T TreeHelp "Yardım" 0
 menuText T TreeHelpTree "Ağaç Yardımı" 0
 menuText T TreeHelpIndex "Yardım Dizini" 0
+menuText T TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate T SaveCache {Önbelleği Kaydet}
 translate T Training {Eğitim}
 translate T LockTree {Kilit}
@@ -621,6 +622,8 @@ translate T TreeDepth {Ağaç derinliği (yarım hamle):}
 translate T TreeLocked {kilitli}
 translate T TreeBest {En iyi}
 translate T TreeBestGames {En İyi Ağaç Oyunları}
+translate T TreeFindAnyAnn {any annotation}
+translate T TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate T TreeTitleRow \

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -611,6 +611,7 @@ menuText Q TreeOptAutosave "Автоматичне збереження файл
 menuText Q TreeHelp "Довідка" 0
 menuText Q TreeHelpTree "Дерево Довідка" 0
 menuText Q TreeHelpIndex "Індекс довідки" 0
+menuText Q TreeFindGames "Find games with annotation" 0 {Build the list of the games where this move was played with an annotation}
 translate Q SaveCache {Зберегти кеш}
 translate Q Training {Навчання}
 translate Q LockTree {Замок}
@@ -618,6 +619,8 @@ translate Q TreeDepth {Глибина дерева (половина ходу):}
 translate Q TreeLocked {заблокований}
 translate Q TreeBest {Найкращий}
 translate Q TreeBestGames {Найкращі ігри про дерева}
+translate Q TreeFindAnyAnn {any annotation}
+translate Q TreeFindStalePos {The current position no longer matches the annotated tree position.\nGo back to it and try again.}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate Q TreeTitleRow \

--- a/tcl/windows/tree.tcl
+++ b/tcl/windows/tree.tcl
@@ -665,7 +665,10 @@ proc ::tree::findAnnotatedGames { baseNumber move nag } {
     ::windows::gamelist::SetBase $lw $baseNumber $res
     ::win::makeVisible $lw
   } else {
-    if { ! [::win::createWindow $lw ""] } { return }
+    if { ! [::win::createWindow $lw ""] } {
+      catch { sc_filter release $baseNumber $res }
+      return
+    }
     ::windows::gamelist::createWin_ $lw $baseNumber $res
   }
 }

--- a/tcl/windows/tree.tcl
+++ b/tcl/windows/tree.tcl
@@ -418,14 +418,23 @@ proc ::tree::dorefresh { baseNumber {filter "tree"}} {
     foreach key [array names ::tree::autoNag "$baseNumber,*"] {
       unset ::tree::autoNag($key)
     }
+    # Clear stale NAG histograms (used by "Find games with annotation")
+    foreach key [array names tree "nagHist$baseNumber,*"] {
+      unset tree($key)
+    }
     unset -nocomplain tree(nagsError$baseNumber)
     if { [catch {
       set nagsData [sc_tree nags $baseNumber $filter 0]
+      # Remember the position these data refer to
+      if { $baseNumber == [sc_base current] } {
+        set tree(lastFen$baseNumber) [sc_pos fen]
+      }
       if { $::tree::mask::maskFile != "" } {
         ::tree::mask::setCacheFenIndex
       }
       foreach entry $nagsData {
         set moveSAN [lindex $entry 0]
+        set tree(nagHist$baseNumber,$moveSAN) [lrange $entry 1 end]
         set bestNag ""
         set bestCount 0
         foreach {nag count} [lrange $entry 1 end] {
@@ -457,6 +466,206 @@ proc ::tree::dorefresh { baseNumber {filter "tree"}} {
 
   if {$::tree::trainingBase != 0 && $::tree::trainingColor == [sc_pos side]} {
     ::tree::doTraining
+  }
+}
+
+################################################################################
+# ::tree::getMoveNags
+#   Returns the list {nag count ...} of the annotations recorded (during the
+#   last tree refresh with the Annotations option enabled) for <move> in the
+#   displayed position, or {} if unknown.
+################################################################################
+proc ::tree::getMoveNags { baseNumber move } {
+  global tree
+  if { [info exists tree(nagHist$baseNumber,$move)] } {
+    return $tree(nagHist$baseNumber,$move)
+  }
+  return {}
+}
+
+################################################################################
+# ::tree::contextMenu
+#   Right-button menu on a move of the Tree window: offers to build the list
+#   of the games where this move was played, in the displayed position, with
+#   one of the recorded annotations.
+################################################################################
+proc ::tree::contextMenu { win baseNumber move x y xc yc } {
+  global tree
+  update idletasks
+
+  set mctxt $win.ctxtMenu
+  if { [winfo exists $mctxt] } {
+    destroy $mctxt
+  }
+
+  set raw {}
+  # The search needs a position snapshot from the last refresh; it is only
+  # available when this base was the current one at that time
+  if { [info exists tree(lastFen$baseNumber)] } {
+    set raw [::tree::getMoveNags $baseNumber $move]
+  }
+  set hists {}
+  foreach {nag count} $raw {
+    lappend hists [list $count $nag]
+  }
+  set hists [lsort -integer -decreasing -index 0 $hists]
+
+  menu $mctxt
+  if { [llength $hists] == 0 } {
+    $mctxt add command -label "[tr TreeFindGames]" -state disabled
+  } else {
+    menu $mctxt.find
+    $mctxt add cascade -label "[tr TreeFindGames]:" -menu $mctxt.find
+    foreach elt $hists {
+      lassign $elt count nag
+      $mctxt.find add command -label "$nag  ($count)" \
+          -command "::tree::findAnnotatedGames $baseNumber [list $move] [list $nag]"
+    }
+    $mctxt.find add separator
+    $mctxt.find add command -label "[tr TreeFindAnyAnn]" \
+        -command "::tree::findAnnotatedGames $baseNumber [list $move] any"
+  }
+  $mctxt post [winfo pointerx .] [winfo pointery .]
+}
+
+################################################################################
+# ::tree::gameHasNag
+#   Scans the main line of a game (as returned by [sc_base getGame]) and
+#   returns 1 if, immediately after reaching the position <fenPrefix> (the
+#   first four FEN fields), the move <move> was played with the annotation
+#   <nag> ("any" and "none" are also accepted).
+#
+#   Note: this does not rely on the ply stored in the search filter, since
+#   that value has a different meaning depending on whether the position
+#   searched for was the one before or after <move>.
+################################################################################
+proc ::tree::gameHasNag { positions fenPrefix move nag } {
+  set prevFen ""
+  foreach p $positions {
+    if { [lindex $p 0] != 0 } { continue } ;# skip variations
+    if { $prevFen ne ""
+         && [join [lrange [split $prevFen " "] 0 3] " "] eq $fenPrefix
+         && [lindex $p 5] eq $move } {
+      set nags [lindex $p 3]
+      switch -- $nag {
+        any  { if { $nags ne "" } { return 1 } }
+        none { if { $nags eq "" } { return 1 } }
+        default {
+          foreach n [split $nags " "] {
+            if { $n eq $nag } { return 1 }
+          }
+        }
+      }
+    }
+    set prevFen [lindex $p 2]
+  }
+  return 0
+}
+
+################################################################################
+# ::tree::findAnnotatedGames
+#   Builds the list of the games where, in the position displayed by the Tree
+#   window, the move <move> was played with the annotation <nag> and opens it
+#   in a game list window.
+#
+#   To keep the scan small, the move is first played on a scratch copy of the
+#   current game (push/addSan/pop) and a native position search is run on the
+#   resulting position: only the few games that actually played this move are
+#   then decoded to check their annotations.
+################################################################################
+proc ::tree::findAnnotatedGames { baseNumber move nag } {
+  global tree
+  if { [info exists ::tree::nagSearchBusy] && $::tree::nagSearchBusy } { return }
+
+  if { ! [info exists tree(lastFen$baseNumber)] } { return }
+  set fenPrefix [join [lrange [split $tree(lastFen$baseNumber) " "] 0 3] " "]
+
+  # The scratch navigation and the position search below operate on the
+  # current base and its current game
+  if { $baseNumber != [sc_base current] } {
+    tk_messageBox -title scidCommunity -icon warning -type ok \
+        -message [tr TreeFindStalePos]
+    return
+  }
+  # If the board has moved on since the last tree refresh, ask to go back
+  if { [join [lrange [split [sc_pos fen] " "] 0 3] " "] ne $fenPrefix } {
+    tk_messageBox -title scidCommunity -icon warning -type ok \
+        -message [tr TreeFindStalePos]
+    return
+  }
+
+  # Candidates: games that reached the position AFTER this move.
+  # The annotations are verified afterwards by scanning each candidate game
+  # for the move played from the displayed position.
+  set cand ""
+  set nCand 0
+  if { [catch { sc_game push copyfast }] } {
+    ERROR::MessageBox
+    return
+  }
+  set innerErr [catch {
+    sc_move addSan $move
+    set cand [sc_filter new $baseNumber]
+    sc_filter reset $baseNumber $cand full
+    sc_filter search $baseNumber $cand board Exact 0 0 -filter AND
+    if { $tree(allgames$baseNumber) == 0 } {
+      sc_filter and $baseNumber $cand dbfilter
+    }
+    set nCand [sc_filter count $baseNumber $cand]
+  }]
+  # Always restore the current game (pop also restores its altered flag)
+  sc_game pop
+
+  if { $innerErr || $nCand == 0 } {
+    if { $cand ne "" } { catch { sc_filter release $baseNumber $cand } }
+    ::tree::status "" $baseNumber
+    if { $innerErr && $::errorCode != $::ERROR::UserCancel } {
+      ERROR::MessageBox
+    }
+    return
+  }
+
+  # Working copy of the filter; non-matching games will be removed from it
+  set res [sc_filter new $baseNumber]
+  sc_filter copy $baseNumber $res $cand
+
+  set ::tree::nagSearchBusy 1
+  set scanned 0
+  set err [catch {
+    foreach {idx line deleted} [sc_base gameslist $baseNumber 0 $nCand $cand N+] {
+      set gnum [lindex [split $idx "_"] 0]
+      incr scanned
+      if { ($scanned % 100) == 0 } {
+        ::tree::status "[tr TreeFindGames]: $scanned / $nCand" $baseNumber
+        update idletasks
+      }
+      if { ! [::tree::gameHasNag [sc_base getGame $baseNumber $gnum] \
+                  $fenPrefix $move $nag] } {
+        sc_filter remove $baseNumber $res $gnum
+      }
+    }
+  }]
+  set ::tree::nagSearchBusy 0
+
+  catch { sc_filter release $baseNumber $cand }
+
+  ::tree::status "" $baseNumber
+  if { $err } {
+    catch { sc_filter release $baseNumber $res }
+    if { $::errorCode != $::ERROR::UserCancel } { ERROR::MessageBox }
+    return
+  }
+
+  # Open (or update) the game list window showing the result
+  set lw .treeNagList$baseNumber
+  set nagTxt [expr { $nag eq "any" ? "" : $nag }]
+  set ::gamelistTitle($lw) "[tr TreeFindGames]: $move$nagTxt"
+  if { [lsearch -exact $::windows::gamelist::wins $lw] != -1 } {
+    ::windows::gamelist::SetBase $lw $baseNumber $res
+    ::win::makeVisible $lw
+  } else {
+    if { ! [::win::createWindow $lw ""] } { return }
+    ::windows::gamelist::createWin_ $lw $baseNumber $res
   }
 }
 
@@ -615,6 +824,12 @@ proc ::tree::displayLines { baseNumber moves } {
     if { $maskFile != "" } {
       # Bind right button to popup a contextual menu:
       $w.f.tl tag bind tagclick$i <ButtonPress-$::MB3> "::tree::mask::contextMenu $w.f.tl $move %x %y %X %Y ; break"
+    } elseif { $tree(nagsAutopopulate$baseNumber) == 1
+               && $move != "" && $move != "---" && $move != "\[end\]" } {
+      # Bind right button to search games by annotation:
+      set lookMove [lindex [split $move " "] 0]
+      $w.f.tl tag bind tagclick$i <ButtonPress-$::MB3> \
+          "::tree::contextMenu $w.f.tl $baseNumber [list $lookMove] %x %y %X %Y ; break"
     }
     $w.f.tl tag add tagclick$i [expr $i +1 + $hasPositionComment].0 [expr $i + 1 + $hasPositionComment].end
 

--- a/tcl/windows/tree.tcl
+++ b/tcl/windows/tree.tcl
@@ -423,6 +423,7 @@ proc ::tree::dorefresh { baseNumber {filter "tree"}} {
       unset tree($key)
     }
     unset -nocomplain tree(nagsError$baseNumber)
+    unset -nocomplain tree(lastFen$baseNumber)
     if { [catch {
       set nagsData [sc_tree nags $baseNumber $filter 0]
       # Remember the position these data refer to


### PR DESCRIPTION
…ng the Tree Window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tree-window option to find games in which a selected move includes a chosen annotation.
  * Added an “any annotation” filter and displayed matching games in a results list.
  * Added a warning when the current position no longer matches the annotated tree position.
  * Added supporting labels and messages across available languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->