### PR TITLE
Add option for auto-theming for Omarchy Quattro desktops

### DIFF
--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -338,6 +338,7 @@ menuText J OptionsBooksDir "Именик књига" 0 {Поставља дир�
 menuText J OptionsTacticsBasesDir "База података" 0 {Поставља директоријум база тактике (тренинга).}
 menuText J OptionsPhotosDir "Директоријум фотографија" 0 {Поставља директоријум база фотографија}
 menuText J OptionsThemeDir "Тема(е) Филе"  0 {Учитајте датотеку пакета ГУИ теме}
+translate J OptionsThemeOmarchy {Пратите тему Омарцхи}
 menuText J OptionsSave "Саве Оптионс" 0 "Save all settable options to the file $::optionsFile"
 menuText J OptionsAutoSave "Опције аутоматског чувања на излазу" 0 \
   {Аутоматски сачувајте све опције када изађете из Сцида}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -297,6 +297,7 @@ menuText b OptionsBooksDir "বই ডিরেক্টরি" 0 {খোলা�
 menuText b OptionsTacticsBasesDir "বেস ডিরেক্টরি" 0 {কৌশল (প্রশিক্ষণ) বেস ডিরেক্টরি সেট করে}
 menuText b OptionsPhotosDir "ফটো ডিরেক্টরি" 0 {ফটো বেস ডিরেক্টরি সেট করে}
 menuText b OptionsThemeDir "থিম(গুলি) ফাইল"  0 {একটি GUI থিম প্যাকেজ ফাইল লোড করুন}
+translate b OptionsThemeOmarchy {Omarchy থিম অনুসরণ করুন}
 menuText b OptionsSave "সেভ অপশন" 0 "Save all settable options to the file $::optionsFile"
 menuText b OptionsAutoSave "প্রস্থান করার সময় স্বয়ংক্রিয় সংরক্ষণ বিকল্প" 0 \
   {Scid থেকে প্রস্থান করার সময় সমস্ত বিকল্প স্বয়ংক্রিয়ভাবে সংরক্ষণ করুন}
@@ -620,7 +621,6 @@ translate b TreeBest {সেরা}
 translate b TreeBestGames {সেরা গাছ গেম}
 translate b TreeFindAnyAnn {যেকোনো টীকা}
 translate b TreeFindStalePos {বর্তমান অবস্থানটি টীকাযুক্ত ট্রি অবস্থানের সাথে আর মিলছে না।\nসেটিতে ফিরে যান এবং আবার চেষ্টা করুন।}
-সেটিতে ফিরে যান এবং আবার চেষ্টা করুন।}
 # Note: the next message is the tree window title row. After editing it,
 # check the tree window to make sure it lines up with the actual columns.
 translate b TreeTitleRow \

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -338,6 +338,7 @@ menuText g OptionsBooksDir "Указател с книги" 0 {Задава ди
 menuText g OptionsTacticsBasesDir "Бази директория" 0 {Задава директорията на тактическите (тренировъчни) бази}
 menuText g OptionsPhotosDir "Директория със снимки" 0 {Задава директорията с бази за снимки}
 menuText g OptionsThemeDir "Файл с тема(и)."  0 {Заредете пакетен файл с GUI тема}
+translate g OptionsThemeOmarchy {Следвайте темата Omarchy}
 menuText g OptionsSave "Опции за запазване" 0 "Save all settable options to the file $::optionsFile"
 menuText g OptionsAutoSave "Опции за автоматично запазване при излизане" 0 \
   {Автоматично запазване на всички опции при излизане от Scid}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -318,6 +318,7 @@ menuText K OptionsBooksDir "Carpeta de llibres d'obertures..." 0 {Fixa la carpet
 menuText K OptionsTacticsBasesDir "Carpeta de bases de dades..." 0 {Fixa la carpeta de la base d'entrenament tàctic}
 menuText K OptionsPhotosDir "Directori d'imatges..." 0 {Configura el directori base per a imatges}
 menuText K OptionsThemeDir "Fitxer(s) d'aspecte:"  0 { Carrega un fitxer d'aspecte de la interfície }
+translate K OptionsThemeOmarchy {Seguiu el tema Omarchy}
 menuText K OptionsSave "Desar opcions" 0 \
   {Desa totes les opcions a l'arxiu $::optionsFile}
 menuText K OptionsAutoSave "Autoguardar opcions en sortir" 0 \

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -273,6 +273,7 @@ menuText M OptionsBooksDir "开局库目录" 0 {设置开局库目录}
 menuText M OptionsTacticsBasesDir "数据库目录" 0 {设置战术（训练）数据库目录}
 menuText M OptionsPhotosDir "照片目录" 0 {设置照片数据库目录}
 menuText M OptionsThemeDir "主题文件"  0 {加载GUI主题包文件}
+translate M OptionsThemeOmarchy {遵循 Omarchy 主题}
 menuText M OptionsSave "保存选项" 0 "将所有可设置选项保存到文件$::optionsFile"
 menuText M OptionsAutoSave "退出时自动保存选项" 0 \
   {退出Scid时自动保存所有选项}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -300,6 +300,7 @@ menuText C OptionsBooksDir "Adres knihoven zahjen" 0 {Nastaven adrese knihoven z
 menuText C OptionsTacticsBasesDir "Adres databz" 0 {Nastaven adres taktickch (trninkovch) databz}
 menuText C OptionsPhotosDir "Adres fotografi" 0 {Nastav adres fotografi}
 menuText C OptionsThemeDir "Soubor motiv:"  0 {Natte soubor balku motivu GUI}
+translate C OptionsThemeOmarchy {Sledujte téma Omarchy}
 menuText C OptionsSave "Uloit volby" 0 \
   "Uloit vechny nastaviteln volby do souboru $::optionsFile"
 menuText C OptionsAutoSave "Automaticky ukldat volby pi ukonen" 20 \

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -330,6 +330,7 @@ menuText D OptionsBooksDir "Verzeichnis für Eröffnungsbücher" 0 {Eröffnungsb
 menuText D OptionsTacticsBasesDir "Verzeichnis für Taktikdatenbanken" 0 {Verzeichnis für taktische Trainingsdatenbanken einstellen}
 menuText D OptionsPhotosDir "Verzeichnis für Spielerbilder" 0 {Verzeichnis für Bilder einstellen}
 menuText D OptionsThemeDir "Datei mit Design(s)"  0 { Packetdatei für GUI Design Themen einstellen }
+translate D OptionsThemeOmarchy {Folgen Sie dem Omarchy-Thema}
 menuText D OptionsSave "Optionen speichern" 0 \
   "Alle einstellbaren Optionen in der Datei $::optionsFile sichern"
 menuText D OptionsAutoSave "Speichern beim Beenden" 0 \

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -337,6 +337,7 @@ menuText E OptionsBooksDir "Books directory" 0 {Sets the opening books directory
 menuText E OptionsTacticsBasesDir "Bases directory" 0 {Sets the tactics (training) bases directory}
 menuText E OptionsPhotosDir "Photos directory" 0 {Sets the photos bases directory}
 menuText E OptionsThemeDir "Theme(s) File"  0 { Load a GUI theme package file }
+translate E OptionsThemeOmarchy {Follow Omarchy theme}
 menuText E OptionsSave "Save Options" 0 "Save all settable options to the file $::optionsFile"
 menuText E OptionsAutoSave "Auto-Save Options on Exit" 0 \
   {Auto-save all options when exiting Scid}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -313,6 +313,7 @@ menuText F OptionsBooksDir "Répertoire des bibliothèques" 15 {Répertoire des 
 menuText F OptionsTacticsBasesDir "Répertoire des bases d'entraînement" 11 {Répertoire des bases pour l'entraînement tactique}
 menuText F OptionsPhotosDir "Répertoire des images" 16 {Répertoire des bases pour les images}
 menuText F OptionsThemeDir "Charger thème(s)"  0 { Charger un fichier de thèmes pour l'interface graphique }
+translate F OptionsThemeOmarchy {Suivre le thème Omarchie}
 menuText F OptionsSave "Enregistrer les options" 0 "Enregistrer les options dans le fichier $::optionsFile"
 menuText F OptionsAutoSave "Sauvegarde automatique des options" 0 \
   {Sauvegarder automatiquement toutes les options en quittant Scid}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -329,6 +329,7 @@ menuText G OptionsBooksDir "Κατάλογος βιβλίων" 0 {Καθορίζ
 menuText G OptionsTacticsBasesDir "Bases directory" 0 {Sets the tactics (training) bases directory}
 menuText G OptionsPhotosDir "Κατάλογος φωτογραφιών" 0 {Ορίζει τον κατάλογο βάσεων φωτογραφιών}
 menuText G OptionsThemeDir "Αρχείο θεμάτων:"  0 {Φορτώστε ένα αρχείο πακέτου θέματος GUI}
+translate G OptionsThemeOmarchy {Ακολουθήστε το θέμα Omarchy}
 menuText G OptionsSave "Αποθήκευση επιλογών" 0 "Αποθηκεύστε όλες τις μεταβολές ρυθμίσεων στο αρχείο $::optionsFile"
 menuText G OptionsAutoSave "Αυτόματη αποθήκευση επιλογών κατά την έξοδο" 0 \
   {Να αποθηκεύονται αυτόματα οι επιλογές κατά την έξοδο από το Scid}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -298,6 +298,7 @@ menuText V OptionsBooksDir "ספריית ספרים" 0 {מגדיר את ספרי
 menuText V OptionsTacticsBasesDir "ספריית בסיסים" 0 {מגדיר את ספריית הבסיסים של הטקטיקה (אימון).}
 menuText V OptionsPhotosDir "ספריית תמונות" 0 {מגדיר את ספריית בסיסי התמונות}
 menuText V OptionsThemeDir "קובץ ערכות נושא"  0 {טען קובץ חבילת ערכת נושא של GUI}
+translate V OptionsThemeOmarchy {עקוב אחר נושא Omarchy}
 menuText V OptionsSave "שמור אפשרויות" 0 "Save all settable options to the file $::optionsFile"
 menuText V OptionsAutoSave "אפשרויות שמירה אוטומטית ביציאה" 0 \
   {שמור אוטומטית את כל האפשרויות בעת יציאה מ-Scid}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -297,7 +297,7 @@ menuText h OptionsBooksDir "पुस्तकें निर्देशिक
 menuText h OptionsTacticsBasesDir "आधार निर्देशिका" 0 {रणनीति (प्रशिक्षण) आधार निर्देशिका सेट करता है}
 menuText h OptionsPhotosDir "फ़ोटो निर्देशिका" 0 {फ़ोटो आधार निर्देशिका सेट करता है}
 menuText h OptionsThemeDir "थीम फ़ाइल"  0 {GUI थीम पैकेज फ़ाइल लोड करें}
-translate h OptionsThemeOmarchy {उमर्की थीम का पालन करें}
+translate h OptionsThemeOmarchy {Omarchy थीम का पालन करें}
 menuText h OptionsSave "विकल्प सहेजें" 0 "Save all settable options to the file $::optionsFile"
 menuText h OptionsAutoSave "बाहर निकलने पर ऑटो-सेव विकल्प" 0 \
   {स्किड से बाहर निकलने पर सभी विकल्प स्वतः सहेजें}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -297,6 +297,7 @@ menuText h OptionsBooksDir "पुस्तकें निर्देशिक
 menuText h OptionsTacticsBasesDir "आधार निर्देशिका" 0 {रणनीति (प्रशिक्षण) आधार निर्देशिका सेट करता है}
 menuText h OptionsPhotosDir "फ़ोटो निर्देशिका" 0 {फ़ोटो आधार निर्देशिका सेट करता है}
 menuText h OptionsThemeDir "थीम फ़ाइल"  0 {GUI थीम पैकेज फ़ाइल लोड करें}
+translate h OptionsThemeOmarchy {उमर्की थीम का पालन करें}
 menuText h OptionsSave "विकल्प सहेजें" 0 "Save all settable options to the file $::optionsFile"
 menuText h OptionsAutoSave "बाहर निकलने पर ऑटो-सेव विकल्प" 0 \
   {स्किड से बाहर निकलने पर सभी विकल्प स्वतः सहेजें}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -304,6 +304,7 @@ menuText H OptionsBooksDir "A megnyitástár könyvtára" 6 {Kijelöli a megnyit
 menuText H OptionsTacticsBasesDir "Az adatbázisok könyvtára" 4 {Kijelöli a taktikai (edzés) adatbázisok könyvtárát.}
 menuText H OptionsPhotosDir "Fotók könyvtár" 0 {Beállítja a fényképek alapkönyvtárát}
 menuText H OptionsThemeDir "Téma(k) Fájl:"  0 {Töltsön be egy GUI-témacsomag fájlt}
+translate H OptionsThemeOmarchy {Kövesse az Omarchy témát}
 menuText H OptionsSave "Beállítások mentése" 12 \
   "Minden beállítható értéket elment a $::optionsFile fájlba."
 menuText H OptionsAutoSave "Beállítások automatikus mentése kilépéskor." 0 \

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -304,7 +304,7 @@ menuText I OptionsBooksDir "Directory del libro di aperture" 0 {Configura la dir
 menuText I OptionsTacticsBasesDir "Directory dei database" 15 {Configura la directory per i database di allenamento}
 menuText I OptionsPhotosDir "Directory delle foto" 0 {Imposta la directory delle basi delle foto}
 menuText I OptionsThemeDir "File dei temi:"  0 {Carica un file del pacchetto del tema della GUI}
-translate I OptionsThemeOmarchy {Segui il tema Omarchia}
+translate I OptionsThemeOmarchy {Segui il tema Omarchy}
 menuText I OptionsSave "Salva opzioni" 3 \
   "Salva tutte le opzioni definibili nel file $::optionsFile"
 menuText I OptionsAutoSave "Salva opzioni all'uscita" 17 \

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -304,6 +304,7 @@ menuText I OptionsBooksDir "Directory del libro di aperture" 0 {Configura la dir
 menuText I OptionsTacticsBasesDir "Directory dei database" 15 {Configura la directory per i database di allenamento}
 menuText I OptionsPhotosDir "Directory delle foto" 0 {Imposta la directory delle basi delle foto}
 menuText I OptionsThemeDir "File dei temi:"  0 {Carica un file del pacchetto del tema della GUI}
+translate I OptionsThemeOmarchy {Segui il tema Omarchia}
 menuText I OptionsSave "Salva opzioni" 3 \
   "Salva tutte le opzioni definibili nel file $::optionsFile"
 menuText I OptionsAutoSave "Salva opzioni all'uscita" 17 \

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -338,6 +338,7 @@ menuText A OptionsBooksDir "書籍ディレクトリ" 0 {オープニングブ�
 menuText A OptionsTacticsBasesDir "ベースディレクトリ" 0 {戦術（トレーニング）ベースディレクトリを設定します}
 menuText A OptionsPhotosDir "写真ディレクトリ" 0 {写真のベースディレクトリを設定します}
 menuText A OptionsThemeDir "テーマファイル"  0 {GUIテーマパッケージファイルをロードする}
+translate A OptionsThemeOmarchy {オマーキーのテーマをフォローする}
 menuText A OptionsSave "保存オプション" 0 "Save all settable options to the file $::optionsFile"
 menuText A OptionsAutoSave "終了時の自動保存オプション" 0 \
   {Scid を終了するときにすべてのオプションを自動保存します}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -338,6 +338,7 @@ menuText k OptionsBooksDir "책장" 0 {여는 책을 설정합니다}
 menuText k OptionsTacticsBasesDir "키예프" 0 {훈련소에서 훈련을 시작합니다.}
 menuText k OptionsPhotosDir "사진의" 0 {기본적으로 사용자를 설정합니다.}
 menuText k OptionsThemeDir "주제 파일"  0 {GUI 테마 패키지 파일 로드}
+translate k OptionsThemeOmarchy {Omarchy 테마 따르기}
 menuText k OptionsSave "저장 옵션" 0 "Save all settable options to the file $::optionsFile"
 menuText k OptionsAutoSave "종료 시 자동 절약 옵션" 0 \
   {Scid 종료 시 모든 옵션 자동 저장}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -325,6 +325,7 @@ menuText N OptionsBooksDir "Boeken map" 0 {Stel de map met openingsboeken in}
 menuText N OptionsTacticsBasesDir "Databases map" 0 {Stel de map met de  taktiek (training) databases in}
 menuText N OptionsPhotosDir "Foto's map" 0 {Stelt de fotobasismap in}
 menuText N OptionsThemeDir "Thema(s) Bestand:"  0 {Laad een GUI-themapakketbestand}
+translate N OptionsThemeOmarchy {Volg het Omarchy-thema}
 menuText N OptionsSave "Opties bewaren" 0 \
   "Bewaar alle instellingen in het bestand $::optionsFile"
 menuText N OptionsAutoSave "Automatisch bewaren opties tijdens afsluiten" 0 \

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -306,6 +306,7 @@ menuText O OptionsBooksDir "Bøker katalog" 0 {Angir åpningsbokkatalogen}
 menuText O OptionsTacticsBasesDir "Baser katalog" 0 {Angir taktikk (trening) basekatalogen}
 menuText O OptionsPhotosDir "Fotokatalog" 0 {Stiller inn fotobasekatalogen}
 menuText O OptionsThemeDir "Temafil:"  0 {Last inn en GUI-temapakkefil}
+translate O OptionsThemeOmarchy {Følg Omarchy-temaet}
 menuText O OptionsSave "Lagre innstillinger" 0 \
   "Lagre alle instillinger til $::optionsFile"
 menuText O OptionsAutoSave "Autolagre innstillinger ved avslutning" 0 \

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -63,7 +63,6 @@ menuText P EditCopyBoard {Kopiuj pozycję jako FEN} 0 {Kopiuj bieżącą pozycj�
 menuText P EditPasteBoard {Wklej pozycję jako FEN} 0 {Ustaw pozycję początkową z bieżącego zaznaczenia tekstowego (schowka)}
 menuText P ConfigureScid {Preferencje...} 0 {Skonfiguruj wszystkie opcje Scid}
 
-
 # Game menu:
 menuText P Game {Partia} 0
 menuText P GameNew {Nowa partia} 0 {Zacznij nową partię}
@@ -90,7 +89,6 @@ menuText P SearchCurrent {Bieżąca pozycja...} 0 {Szukaj bieżącej pozycji na 
 menuText P SearchHeader {Nagłówek...} 0 {Szukaj według informacji z nagłówka (zawodnik, turniej itd.)}
 menuText P SearchMaterial {Materiał/wzorzec...} 0 {Szukaj według materiału lub wzorców pozycji}
 menuText P SearchUsing {Użyj pliku wyszukiwania...} 0 {Szukaj przy użyciu pliku SearchOptions}
-
 
 # Windows menu:
 menuText P Windows {Okna} 0
@@ -158,6 +156,7 @@ menuText P ToolsConnectHardware {Podłącz urządzenia} 0 {Podłącz zewnętrzne
 menuText P ToolsConnectHardwareConfigure {Konfiguruj...} 0 {Konfiguruj zewnętrzne urządzenie i połączenie}
 menuText P ToolsConnectHardwareNovagCitrineConnect {Podłącz Novag Citrine} 0 {Połącz Novag Citrine ze Scid}
 menuText P ToolsConnectHardwareInputEngineConnect {Podłącz silnik wejściowy} 0 {Połącz silnik wejściowy (np. szachownicę DGT) ze Scid}
+
 menuText P ToolsPInfo {Informacje o zawodniku} 0 {Otwórz/odśwież okno informacji o zawodniku}
 menuText P ToolsPlayerReport {Raport o zawodniku...} 0 {Wygeneruj raport zawodnika}
 menuText P ToolsRating {Wykres rankingu} 0 {Pokaż wykres historii rankingów zawodników z bieżącej partii}
@@ -175,11 +174,9 @@ menuText P ToolsStartEngine1 {Uruchom silnik 1} 0 {Uruchom silnik 1}
 menuText P ToolsStartEngine2 {Uruchom silnik 2} 0 {Uruchom silnik 2}
 menuText P ToolsCaptureBoard {Przechwyć bieżącą szachownicę...} 0 {Zapisz bieżącą szachownicę jako obraz.}
 
-
 # Play menu
 menuText P Play {Graj} 0
 menuText P LichessPuzzles {Zadania Lichess} 0 {Rozwiązuj interaktywne zadania Lichess}
-
 
 # --- Correspondence Chess
 menuText P CCResign {Poddaj się} 0 {Poddaj się (nie przez e-mail)}
@@ -188,7 +185,6 @@ menuText P CCClaimDraw {Reklamuj remis} 0 {Wyślij posunięcie i reklamuj remis 
 # menu in cc window:
 
 #  B    GHiJKL    Q  TUV XYZ
-
 
 # Options menu:
 menuText P Options {Opcje} 0
@@ -244,9 +240,9 @@ menuText P OptionsBooksDir {Katalog ksiąg} 0 {Ustawia katalog ksiąg debiutowyc
 menuText P OptionsTacticsBasesDir {Katalog baz} 0 {Ustawia katalog baz taktycznych (treningowych)}
 menuText P OptionsPhotosDir {Katalog zdjęć} 0 {Ustawia katalog baz zdjęć}
 menuText P OptionsThemeDir {Plik motywu/motywów} 0 { Wczytaj plik pakietu motywu GUI }
+translate P OptionsThemeOmarchy {Postępuj zgodnie z motywem Omarchy}
 menuText P OptionsSave {Zapisz opcje} 0 {Zapisz wszystkie ustawialne opcje do pliku konfiguracyjnego}
 menuText P OptionsAutoSave {Automatycznie zapisuj opcje przy wyjściu} 0 {Automatycznie zapisuj wszystkie opcje przy zamykaniu Scid}
-
 
 # Help menu:
 menuText P Help {Pomoc} 0
@@ -259,10 +255,8 @@ menuText P HelpTip {Porada dnia} 0 {Pokaż przydatną poradę Scid}
 menuText P HelpStartup {Okno startowe} 0 {Pokaż okno startowe}
 menuText P HelpAbout {O programie} 0 {Informacje o ScidCommunity}
 
-
 # Toolbar tooltips:
 menuText P RotateBoard {Obróć szachownicę} 0 {Obróć szachownicę}
-
 
 # Game info box popup menu:
 menuText P GInfoHideNext {Ukryj następne posunięcie} 0
@@ -278,7 +272,6 @@ menuText P GInfoTBAll {Tablice końcówek: wynik i najlepsze posunięcia} 0
 menuText P GInfoDelete {Usuń/przywróć tę partię} 0
 menuText P GInfoMark {Zaznacz/odznacz tę partię} 0
 menuText P GInfoInformant {Konfiguruj wartości Informatora} 0
-
 
 # General buttons:
 translate P LichessOpenExplore {Eksplorator debiutów Lichess}
@@ -334,7 +327,6 @@ translate P LichessFetchGameFailed {Nie udało się pobrać partii %s:\n%s}
 translate P LichessGameNotFound {Nie znaleziono partii %s na Lichess.}
 translate P LichessImportFailed {Nie udało się zaimportować partii:\n%s}
 translate P LichessGameLoaded {Partia została pomyślnie wczytana do bazy schowka.}
-
 
 # Lichess Puzzles
 translate P LichessPuzzlesTitle {Zadania Lichess}
@@ -412,7 +404,6 @@ translate P First {Pierwsza}
 translate P Current {Bieżąca}
 translate P Last {Ostatnia}
 
-
 # General messages:
 translate P game {partia}
 translate P games {partie}
@@ -466,7 +457,6 @@ translate P StartPos {Pozycja początkowa}
 translate P Total {Razem}
 translate P readonly {tylko do odczytu}
 
-
 # Standard error messages:
 translate P ErrNotOpen {To nie jest otwarta baza.}
 translate P ErrReadOnly {Ta baza jest tylko do odczytu; nie można jej zmieniać.}
@@ -482,6 +472,9 @@ translate P DndUriRejectedDetail {Bazy danych Scid (.si5, .si4, .si3) lub pliki 
 translate P DndEmptyUriList {Nie znaleziono plików na usuniętej liście URI}
 translate P DndOwnerDidntRespond {Upuszczenie nie powiodło się: właściciel wyboru nie odpowiedział}
 
+
+
+
 # Game information:
 translate P twin {duplikat}
 translate P deleted {usunięta}
@@ -494,7 +487,6 @@ translate P LineStart {Początek wariantu}
 translate P GameEnd {Koniec partii}
 translate P LineEnd {Koniec wariantu}
 
-
 # Player information:
 translate P PInfoAll {Wyniki dla <b>wszystkich</b> partii}
 translate P PInfoFilter {Wyniki dla partii z <b>filtra</b>}
@@ -506,7 +498,6 @@ translate P PInfoBio {Biografia}
 translate P PInfoEditRatings {Edytuj rankingi}
 translate P PInfoEloFile {Plik}
 
-
 # Tablebase information:
 translate P Draw {Remis}
 translate P with {z}
@@ -514,12 +505,10 @@ translate P only {tylko}
 translate P lose {przegrywa}
 translate P loses {przegrywa}
 
-
 # Tip of the day:
 translate P Tip {Porada}
 translate P TipAtStartup {Porada przy starcie}
 translate P TipConvertPGN {Możesz uzyskać lepszą wydajność, konwertując pliki PGN}
-
 
 # Tree window menus:
 menuText P TreeFile {Plik} 0
@@ -569,14 +558,10 @@ translate P TreeDepth {Półposunięcia:}
 translate P TreeLocked {zablokowane}
 translate P TreeBest {Najlepsze}
 translate P TreeBestGames {Najlepsze partie z drzewa}
-
 translate P TreeFindAnyAnn {dowolna adnotacja}
 translate P TreeFindStalePos {Bieżąca pozycja nie odpowiada pozycji w drzewie, dla której zapisano adnotację.\nWróć do tej pozycji i spróbuj ponownie.}
-
-# Uwaga: następny komunikat zawiera wiersz nagłówka okna drzewa.
-# Po wprowadzeniu zmian sprawdź okno drzewa i upewnij się, że nagłówki
-# odpowiadają właściwym kolumnom.
-
+# Note: the next message is the tree window title row. After editing it,
+# check the tree window to make sure it lines up with the actual columns.
 translate P TreeTitleRow {    Posunięcie/a              ECO       Częstość     Wynik  ŚrElo Perf śrDług ŚrRok  %Remisów   %Wygr.}
 translate P TreeTotal {RAZEM}
 translate P DoYouWantToSaveFirst {Czy najpierw chcesz zapisać}
@@ -610,7 +595,6 @@ translate P OpenAMaskFileFirst {Najpierw otwórz plik maski}
 translate P Positions {Pozycje}
 translate P Moves {Posunięcia}
 
-
 # Finder window:
 menuText P FinderFile {Plik} 0
 menuText P FinderFileSubdirs {Szukaj w podkatalogach} 0
@@ -641,7 +625,6 @@ translate P FinderCtxCopy {Kopiuj}
 translate P FinderCtxMove {Przenieś}
 translate P FinderCtxDelete {Usuń}
 
-
 # Player finder:
 menuText P PListFile {Plik} 0
 menuText P PListFileUpdate {Odśwież} 0
@@ -652,7 +635,6 @@ menuText P PListSortElo {Elo} 0
 menuText P PListSortGames {Partie} 0
 menuText P PListSortOldest {Najstarsze} 0
 menuText P PListSortNewest {Najnowsze} 0
-
 
 # Tournament finder:
 menuText P TmtFile {Plik} 0
@@ -669,7 +651,6 @@ menuText P TmtSortWinner {Zwycięzca} 0
 translate P TmtLimit {Limit listy}
 translate P TmtMeanElo {Średnie Elo}
 translate P TmtNone {Nie znaleziono pasujących turniejów.}
-
 
 # Graph windows:
 menuText P GraphFile {Plik} 0
@@ -705,7 +686,6 @@ translate P PgnOptColumn {Układ kolumnowy (jedno posunięcie w wierszu)}
 translate P PgnOptSpace {Spacja po numerach posunięć}
 translate P PgnOptStripMarks {Usuń kody kolorowych pól/strzałek}
 translate P PgnOptBoldMainLine {Pogrubiaj posunięcia linii głównej}
-
 
 # Analysis window:
 translate P AddVariation {Dodaj wariant}
@@ -755,7 +735,6 @@ translate P Book {Księga debiutowa}
 translate P OtherBookMoves {Księga przeciwnika}
 translate P OtherBookMovesTooltip {Posunięcia, na które przeciwnik ma odpowiedź}
 
-
 # Analysis Engine open dialog:
 translate P EngineList {Lista silników analizy}
 translate P EngineName {Nazwa}
@@ -779,7 +758,6 @@ translate P EngineReload {Przeładuj bieżący silnik}
 translate P EngineClone {Utwórz kopię bieżącego silnika}
 translate P EngineDelete {Usuń bieżący silnik}
 translate P EngineOpenAnalysis {Otwórz analizę}
-
 
 # PGN window menus:
 menuText P PgnFile {Plik} 0
@@ -808,7 +786,6 @@ menuText P PgnHelp {Pomoc} 0
 menuText P PgnHelpPgn {Pomoc PGN} 0
 menuText P PgnHelpIndex {Indeks} 0
 translate P PgnWindowTitle {Okno PGN - partia %u}
-
 
 # Crosstable window menus:
 menuText P CrosstabFile {Plik} 0
@@ -848,7 +825,6 @@ translate P AddToFilter {Dodaj do filtra}
 translate P Swiss {System szwajcarski}
 translate P Category {Kategoria}
 
-
 # Opening report window menus:
 menuText P OprepFile {Plik} 0
 menuText P OprepFileText {Drukuj do pliku tekstowego...} 0
@@ -862,7 +838,6 @@ menuText P OprepFavoritesGenerate {Generuj raporty...} 0
 menuText P OprepHelp {Pomoc} 0
 menuText P OprepHelpReport {Pomoc raportu debiutowego} 0
 menuText P OprepHelpIndex {Indeks pomocy} 0
-
 
 # Header search:
 translate P HeaderSearch {Wyszukiwanie nagłówków}
@@ -894,7 +869,6 @@ translate P TagContains {zawiera}
 translate P Variant {Wariant}
 translate P Annotator {Komentator}
 translate P Cmnts {Tylko partie z komentarzami}
-
 
 # Game list window:
 translate P GlistNumber {Numer}
@@ -939,7 +913,6 @@ translate P GlistCurrentSep {-- Bieżące --}
 translate P GlistNewSort {Nowa}
 translate P GlistAddToSort {Dodaj}
 
-
 # base sorting
 translate P GsortSort {Sortuj...}
 translate P GsortDate {Data}
@@ -967,7 +940,6 @@ translate P GsortAdd {Dodaj}
 translate P GsortStore {Zapisz}
 translate P GsortLoad {Wczytaj}
 
-
 # menu shown with right mouse button down on game list.
 translate P GlistRemoveThisGameFromFilter {Usuń tę partię z filtra}
 translate P GlistRemoveGameAndAboveFromFilter {Usuń tę partię i wszystkie powyżej z filtra}
@@ -976,7 +948,6 @@ translate P GlistDeleteGame {Usuń/przywróć tę partię}
 translate P GlistDeleteAllGames {Usuń wszystkie partie w filtrze}
 translate P GlistUndeleteAllGames {Przywróć wszystkie partie w filtrze}
 translate P GlistMergeGameInBase {Scal partię z bazą}
-
 
 # Maintenance window:
 translate P DatabaseName {Nazwa bazy:}
@@ -1028,8 +999,6 @@ W dużej bazie może to potrwać długo, zależnie od wybranych funkcji i ich bi
 
 Czy na pewno chcesz rozpocząć wybrane zadania?
 }
-
-
 # Twinchecker
 translate P TwinCheckUndelete {aby przełączyć; "u" przywraca obie)}
 translate P TwinCheckprevPair {Poprzednia para}
@@ -1054,9 +1023,9 @@ translate P RatingOverride {Nadpisz istniejące niezerowe rankingi}
 translate P AddRatings {Dodaj rankingi do:}
 translate P AddedRatings {Scid dodał $r rankingów Elo w $g partiach.}
 
-
 #Bookmark editor
 translate P NewSubmenu {Nowe podmenu}
+
 # Comment editor:
 translate P AnnotationSymbols {Symbole komentarzy:}
 translate P Comment {Komentarz:}
@@ -1065,7 +1034,6 @@ translate P InsertMarkHelp {
 Wstaw/usuń znacznik: wybierz kolor, typ i pole.
 Wstaw/usuń strzałkę: kliknij prawym przyciskiem dwa pola.
 }
-
 
 # Nag buttons in comment editor:
 translate P GoodMove {Dobre posunięcie}
@@ -1086,7 +1054,6 @@ translate P Equality {Równość}
 translate P Unclear {Niejasne}
 translate P Diagram {Diagram}
 
-
 # Board search:
 translate P BoardSearch {Wyszukiwanie wg pozycji}
 translate P FilterOperation {Operacja na bieżącym filtrze:}
@@ -1100,7 +1067,6 @@ translate P SearchBoardFiles {Kolumny (ten sam materiał, wszystkie piony na tyc
 translate P SearchBoardAny {Dowolnie (ten sam materiał, piony i figury gdziekolwiek)}
 translate P SearchInRefDatabase { Szukaj w bazie referencyjnej }
 translate P LookInVars {Szukaj w wariantach}
-
 
 # Material search:
 translate P MaterialSearch {Wyszukiwanie materiału}
@@ -1120,7 +1086,6 @@ translate P MoveNumberRange {Zakres nr posunięć}
 translate P MatchForAtLeast {Dopasuj przez co najmniej}
 translate P HalfMoves {półposunięć}
 
-
 # Common endings in material search:
 translate P EndingPawns {Końcówki pionowe}
 translate P EndingRookVsPawns {Wieża przeciwko pionom}
@@ -1135,7 +1100,6 @@ translate P EndingKnights {Końcówki skoczkowe}
 translate P EndingQueens {Końcówki hetmańskie}
 translate P EndingQueenPawnVsQueen {Hetman i 1 pion przeciwko hetmanowi}
 translate P BishopPairVsKnightPair {Para gońców przeciwko parze skoczków w grze środkowej}
-
 
 # Common patterns in material search:
 translate P PatternWhiteIQP {Izolowany pion hetmański białych}
@@ -1153,11 +1117,9 @@ translate P PatternLightFian {Fianchetta po białych polach (goniec g2 przeciwko
 translate P PatternDarkFian {Fianchetta po czarnych polach (goniec b2 przeciwko gońcowi g7)}
 translate P PatternFourFian {Cztery fianchetta (gońce na b2, g2, b7, g7)}
 
-
 # Game saving:
 translate P Today {Dzisiaj}
 translate P ClassifyGame {Klasyfikuj partię}
-
 
 # Setup position:
 translate P EmptyBoard {Pusta szachownica}
@@ -1168,10 +1130,10 @@ translate P Castling {Roszada}
 translate P EnPassantFile {Kolumna bicia w przelocie}
 translate P ClearFen {Wyczyść FEN}
 translate P PasteFen {Wklej FEN}
+
 translate P SaveAndContinue {Zapisz i kontynuuj}
 translate P DiscardChangesAndContinue {Odrzuć zmiany i kontynuuj}
 translate P GoBack {Wróć}
-
 
 # Replace move dialog:
 translate P ReplaceMove {Zastąp posunięcie}
@@ -1183,7 +1145,6 @@ Możesz je zastąpić, odrzucając wszystkie późniejsze posunięcia, albo doda
 
 (Możesz uniknąć tego komunikatu w przyszłości, wyłączając opcję "Pytaj przed zastąpieniem posunięć" w menu Opcje: Posunięcia.)}
 
-
 # Make database read-only dialog:
 translate P ReadOnlyDialog {Jeśli ustawisz tę bazę jako tylko do odczytu, żadne zmiany nie będą dozwolone.
 Nie będzie można zapisywać ani zastępować partii, ani zmieniać flag usunięcia.
@@ -1193,18 +1154,15 @@ Możesz łatwo przywrócić możliwość zapisu, zamykając i ponownie otwieraj�
 
 Czy na pewno chcesz ustawić tę bazę jako tylko do odczytu?}
 
-
 # Clear game dialog:
 translate P ClearGameDialog {Ta partia została zmieniona.
 
 Czy na pewno chcesz kontynuować i odrzucić wprowadzone zmiany?
 }
 
-
 # Exit dialog:
 translate P ExitDialog {Czy na pewno chcesz zakończyć Scid?}
 translate P ExitUnsaved {W następujących bazach są niezapisane zmiany partii. Jeśli teraz zakończysz program, zmiany zostaną utracone.}
-
 
 # Import window:
 translate P PasteCurrentGame {Wklej bieżącą partię}
@@ -1212,13 +1170,11 @@ translate P ImportHelp1 {Wpisz lub wklej partię w formacie PGN w polu powyżej.
 translate P ImportHelp2 {Tutaj zostaną wyświetlone błędy importu partii.}
 translate P OverwriteExistingMoves {Nadpisać istniejące posunięcia?}
 
-
 # ECO Browser:
 translate P ECOAllSections {wszystkie sekcje ECO}
 translate P ECOSection {sekcja ECO}
 translate P ECOSummary {Podsumowanie dla}
 translate P ECOFrequency {Częstotliwość podkodów dla}
-
 
 # Opening Report:
 translate P OprepReportFor {Raport dla}
@@ -1291,7 +1247,6 @@ translate P OprepMergeMoves {Limit posunięć dla scalonych partii}
 translate P OprepMergeUnique {Scalaj tylko unikalne partie}
 translate P OprepViewHTML {Pokaż HTML}
 
-
 # Player Report:
 translate P PReportTitle {Raport o zawodniku}
 translate P PReportColorWhite {białymi bierkami}
@@ -1299,7 +1254,6 @@ translate P PReportColorBlack {czarnymi bierkami}
 translate P PReportMoves {po %s}
 translate P PReportOpenings {Debiuty}
 translate P PReportClipbase {Opróżnij schowek i skopiuj do niego pasujące partie}
-
 
 # Piece Tracker window:
 translate P TrackerSelectSingle {Lewy przycisk myszy wybiera tę bierkę.}
@@ -1312,13 +1266,11 @@ translate P TrackerMoves {Posunięcia}
 translate P TrackerMovesStart {Wprowadź nr posunięcia, od którego ma się rozpocząć śledzenie.}
 translate P TrackerMovesStop {Wprowadź nr posunięcia, przy którym śledzenie ma się zakończyć.}
 
-
 # Game selection dialogs:
 translate P SelectAllGames {Wszystkie partie w bazie}
 translate P SelectFilterGames {Tylko partie w filtrze}
 translate P SelectTournamentGames {Tylko partie z bieżącego turnieju}
 translate P SelectOlderGames {Tylko starsze partie}
-
 
 # Delete Twins window:
 translate P TwinsNote {Aby dwie partie były uznane za duplikaty, muszą mieć co najmniej tych samych dwóch zawodników oraz spełniać kryteria ustawiane poniżej. Po znalezieniu pary duplikatów usuwana jest krótsza partia. Wskazówka: przed usuwaniem duplikatów najlepiej sprawdzić pisownię w bazie, ponieważ poprawia to ich wykrywanie. }
@@ -1349,7 +1301,6 @@ translate P TwinsDeleteOlder {Partię o mniejszym numerze}
 translate P TwinsDeleteNewer {Partię o większym numerze}
 translate P TwinsDelete {Usuń partie}
 
-
 # Name editor window:
 translate P NameEditType {Typ nazwy do edycji}
 translate P NameEditSelect {Partie do edycji}
@@ -1357,13 +1308,11 @@ translate P NameEditReplace {Zastąp}
 translate P NameEditWith {z}
 translate P NameEditMatches {Dopasowania: naciśnij Ctrl+1 do Ctrl+9, aby wybrać}
 
-
 # Check games window:
 translate P CheckGames {Sprawdź partie}
 translate P CheckGamesWhich {Sprawdź partie}
 translate P CheckAll {Wszystkie partie}
 translate P CheckSelectFilterGames {Tylko partie w filtrze}
-
 
 # Classify window:
 translate P Classify {Klasyfikuj}
@@ -1376,7 +1325,6 @@ translate P ClassifyCodes {Kody ECO do użycia}
 translate P ClassifyBasic {Tylko podstawowe kody ("B12", ...)}
 translate P ClassifyExtended {Rozszerzenia Scid ("B12j", ...)}
 translate P ClassifyResult {Klasyfikacja ECO zakończona: zaktualizowano $result partii.}
-
 
 # Compaction:
 translate P NameFile {Plik nazw}
@@ -1392,13 +1340,11 @@ translate P NoUnusedNames {Nie ma nieużywanych nazw, więc plik nazw jest już 
 translate P NoUnusedGames {Plik partii jest już w pełni uporządkowany.}
 translate P GameFileCompacted {Plik partii bazy został uporządkowany.}
 
-
 # Sorting:
 translate P SortCriteria {Kryteria}
 translate P AddCriteria {Dodaj kryterium}
 translate P CommonSorts {Typowe sortowania}
 translate P Sort {Sortuj}
-
 
 # Exporting:
 translate P AddToExistingFile {Dodaj partie do istniejącego pliku}
@@ -1410,11 +1356,9 @@ translate P ExportColumnStyle {Układ kolumnowy (jedno posunięcie w wierszu)}
 translate P ExportSymbolStyle {Styl symboli komentarzy:}
 translate P ExportStripMarks {Usuń z komentarzy kody znaczników\npól/strzałek}
 
-
 # Goto game/move dialogs:
 translate P LoadGameNumber {Podaj nr partii do wczytania:}
 translate P GotoMoveNumber {Przejdź do nr posunięcia:}
-
 
 # Copy games dialog:
 translate P CopyAllGames {Kopiuj wszystkie partie do}
@@ -1432,7 +1376,6 @@ translate P CopyErrNoGames {nie ma partii w filtrze}
 translate P CopyErrReadOnly {jest tylko do odczytu}
 translate P CopyErrNotOpen {nie jest otwarta}
 
-
 # Colors:
 translate P LightSquares {Jasne pola}
 translate P DarkSquares {Ciemne pola}
@@ -1443,14 +1386,12 @@ translate P BlackPieces {Czarne bierki}
 translate P WhiteBorder {Biała ramka}
 translate P BlackBorder {Czarna ramka}
 
-
 # Novelty window:
 translate P FindNovelty {Znajdź nowinkę}
 translate P Novelty {Nowinka}
 translate P NoveltyInterrupt {Wyszukiwanie nowinki przerwane}
 translate P NoveltyNone {Nie znaleziono nowinki w tej partii}
 translate P NoveltyHelp {Scid znajdzie pierwsze posunięcie bieżącej partii prowadzące do pozycji, której nie ma w wybranej bazie ani w księdze debiutów ECO.}
-
 
 # Sounds configuration:
 translate P SoundsFolder {Folder plików dźwiękowych}
@@ -1462,10 +1403,8 @@ translate P SoundsAnnounceForward {Zapowiadaj posunięcia przy przejściu o jedn
 translate P SoundsAnnounceBack {Zapowiadaj przy cofaniu lub przejściu o jedno posunięcie wstecz}
 translate P SoundsSoundDisabled {Scid nie znalazł pakietu audio Snack przy starcie;\ndźwięk jest wyłączony.}
 
-
 # Upgrading databases:
 translate P Upgrading {Aktualizowanie}
-
 translate P ConfirmOpenNew {
 To baza w starym formacie (Scid 3), której nie można otworzyć w Scid 4, ale wersja w nowym formacie (Scid 4) została już utworzona.
 
@@ -1481,17 +1420,14 @@ Może to potrwać, ale trzeba zrobić to tylko raz. Możesz anulować, jeśli po
 Czy chcesz teraz zaktualizować tę bazę?
 }
 
-
 # Recent files options:
 translate P RecentFilesMenu {Liczba ostatnich plików w menu Plik}
 translate P RecentFilesExtra {Liczba ostatnich plików w dodatkowym podmenu}
-
 
 # My Player Names options:
 translate P MyPlayerNamesDescription {Wprowadź poniżej listę preferowanych nazwisk zawodników, po jednym w wierszu. Dozwolone są symbole wieloznaczne (np. "?" dla dowolnego pojedynczego znaku, "*" dla dowolnego ciągu znaków).
 Za każdym razem, gdy zostanie wczytana partia zawodnika z listy, szachownica w głównym oknie zostanie w razie potrzeby obrócona tak, aby pokazywać partię z perspektywy tego zawodnika.
 }
-
 
 # Computer Tournament:
 translate P configComp {Konfiguruj turniej}
@@ -1526,13 +1462,11 @@ translate P compScoreLess {Ocena <:}
 translate P compScoreGreater {Ocena >:}
 translate P compRepeatReverse {Powtórz z odwróconymi kolorami}
 
-
 #Coach
 translate P showblunderexists {pokaż, że istnieje poważny błąd}
 translate P showblundervalue {pokaż wartość poważnego błędu}
 translate P showscore {pokaż ocenę}
 translate P coachgame {partia z trenerem}
-
 translate P white {białymi}
 translate P black {czarnymi}
 translate P both {obie strony}
@@ -1542,7 +1476,6 @@ translate P Play {Graj}
 translate P Noblunder {Brak poważnego błędu}
 translate P blunder {poważny błąd}
 translate P Noinfo {-- Brak informacji --}
-
 translate P moveblunderthreshold {posunięcie jest poważnym błędem, jeśli strata jest większa niż}
 translate P limitanalysis {ogranicz czas analizy silnika}
 translate P seconds {sekundy}
@@ -1643,7 +1576,6 @@ translate P Export {Eksportuj}
 translate P BookPartiallyLoaded {Księga częściowo wczytana}
 translate P Calvar {Liczenie wariantów}
 translate P ConfigureCalvar {Konfiguracja}
-
 # Opening names used in tacgame.tcl
 translate P Reti {Réti}
 translate P English {Partia angielska}
@@ -1702,7 +1634,6 @@ translate P KingsIndian {Obrona królewsko-indyjska}
 translate P KingsIndianSamisch {Królewsko-indyjska, wariant Sämischa}
 translate P KingsIndianMainLine {Królewsko-indyjska, wariant główny}
 
-
 # FICS
 translate P ConfigureFics {Konfiguruj FICS}
 translate P FICSGuest {Zaloguj jako gość}
@@ -1748,7 +1679,6 @@ translate P OptionsFICS {FICS}
 translate P FICSTerminalColor {Kolor terminala}
 translate P FICSTextColor {Kolor tekstu}
 
-
 # Game review
 translate P GameReview {Przegląd partii}
 translate P GameReviewTimeExtended {Czas rozszerzony}
@@ -1770,13 +1700,11 @@ translate P GameReviewMoveNotGood {To posunięcie nie jest dobre, ocena wynosi}
 translate P GameReviewMovesPlayedLike {Posunięcia zagrane jak}
 translate P GameReviewMovesPlayedEngine {Posunięcia zagrane jak silnik}
 
-
 # Correspondence Chess Dialogs:
 translate P CCDlgCGeneraloptions {Opcje ogólne}
 translate P CCDlgLoginName {Login:}
 translate P CCDlgPassword {Hasło:}
 translate P CCDlgShowPassword {Pokaż hasło}
-
 
 # Connect Hardware dialogs
 translate P ExtHWConfigConnection {Konfiguruj urządzenie zewnętrzne}
@@ -1790,14 +1718,12 @@ translate P ExtHWInputEngine {Silnik wejściowy}
 translate P ExtHWNoBoard {Brak szachownicy}
 translate P NovagReferee {Sędzia}
 
-
 # Input Engine dialogs
 translate P IEConsole {Konsola silnika wejściowego}
 translate P IESending {Posunięcia wysłane dla}
 translate P IESynchronise {Synchronizuj}
 translate P IERotate {Obróć}
 translate P IEUnableToStart {Nie można uruchomić silnika wejściowego:}
-
 
 # Calculation of Variations
 translate P DoneWithPosition {Koniec pracy z pozycją}
@@ -1810,7 +1736,6 @@ translate P DockBottom {Przenieś na dół}
 translate P DockLeft {Przenieś w lewo}
 translate P DockRight {Przenieś w prawo}
 translate P Undock {Oddokuj}
-
 translate P Dock {Dokuj}
 
 # Switcher window
@@ -1818,7 +1743,6 @@ translate P AboutDatabase {O tej bazie}
 translate P ChangeIcon {Wybierz ikonę bazy...}
 translate P NewGameListWindow {Nowe okno listy partii}
 translate P LoadatStartup {Wczytaj przy starcie}
-
 
 # Gamelist window
 translate P ShowHideDB {Pokaż/ukryj bazy}
@@ -1866,7 +1790,6 @@ translate P MakeCorrections {Wprowadź poprawki}
 translate P Surnames {Nazwiska}
 translate P Ambiguous {Niejednoznaczne}
 
-
 #Preferences Dialog
 translate P OptionsToolbar {Pasek narzędzi}
 translate P OptionsBoard {Szachownica}
@@ -1875,11 +1798,9 @@ translate P OptionsBoardPieces {Styl bierek}
 translate P OptionsInternationalization {Ustawienia językowe}
 translate P OptionsTablebaseDir {Wybierz do 4 folderów tablic końcówek:}
 
-
 # Evaluation bar
 translate P BestMoveArrow {Strzałka najlepszego posunięcia}
 translate P NewLocalEngine {+ Nowy silnik...}
-
 
 # Batch Annotate
 translate P BatchAnnotate {Analiza wsadowa}
@@ -1921,7 +1842,6 @@ translate P TBCategory {Kategoria pozycji:}
 translate P TBTrainingHidden {(Tryb treningu; wyniki są ukryte)}
 
 # ICCF (International Correspondence Chess Federation)
-
 menuText P ToolsTrainICCF "Graj na ICCF" 0 {Zagraj w ICCF}
 translate P ICCFTitle {Graj na ICCF}
 translate P ICCFLogin {Nazwa użytkownika}
@@ -1955,9 +1875,7 @@ translate P ICCFNoDatabase {Żadna baza danych nie jest obecnie otwarta. Najpier
 translate P ICCFMyTime {Mój zegar}
 translate P ICCFOppTime {Zegar przeciwnika}
 translate P ICCFDrawOffered {Zaproponowano remis}
-
 # LSS (Lechenicher SchachServer)
-
 menuText P ToolsTrainLSS "Graj na LSS" 0 {Graj na Lechenicher SchachServer}
 translate P LSSTitle {Graj na LSS - Lechenicher SchachServer}
 translate P LSSConfigure {Konfiguruj LSS}
@@ -1999,11 +1917,8 @@ translate P LSSGameNumber {LSS}
 translate P LSSMyTime {Mój zegar}
 translate P LSSOppTime {Zegar przeciwnika}
 translate P LSSDrawOffered {Zaproponowano remis}
-
 }
-# end of polish.tcl
-
-
+# end of english.tcl
 
 
 ############################################################

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -305,6 +305,7 @@ menuText B OptionsBooksDir "Diretório de Livros" 0 {Define o diretório para os
 menuText B OptionsTacticsBasesDir "Diretório de bases" 0 {Define o diretório para as bases de treinamento de táticas}
 menuText B OptionsPhotosDir "Diretório de Fotos" 0 {Define o diretório base de fotos}
 menuText B OptionsThemeDir "Carregar Tema(s)"  0 {Carrega arquivo de tema para a tela}
+translate B OptionsThemeOmarchy {Siga o tema Omarchy}
 menuText B OptionsSave "Salvar Configuração" 0 \
   "Salva a configuração no arquivo $::optionsFile"
 menuText B OptionsAutoSave "Salva Opções ao sair" 0 \

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -338,6 +338,7 @@ menuText L OptionsBooksDir "Directorul cărților" 0 {Setează directorul cărț
 menuText L OptionsTacticsBasesDir "Directorul bazelor" 0 {Setează directorul bazelor de tactici (antrenament).}
 menuText L OptionsPhotosDir "Director de fotografii" 0 {Setează directorul bazelor de fotografii}
 menuText L OptionsThemeDir "Fișierul temei(e)."  0 {Încărcați un fișier de pachet temă GUI}
+translate L OptionsThemeOmarchy {Urmăriți tema Omarchy}
 menuText L OptionsSave "Opțiuni de salvare" 0 "Save all settable options to the file $::optionsFile"
 menuText L OptionsAutoSave "Opțiuni de salvare automată la ieșire" 0 \
   {Salvați automat toate opțiunile când ieșiți din Scid}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -304,6 +304,7 @@ menuText R OptionsBooksDir "Директория книг" 0 {Установит
 menuText R OptionsTacticsBasesDir "Директория баз" 0 {Установить директорию баз тактик (тренировок)}
 menuText R OptionsPhotosDir "Директория фото" 0 {Установить директорию фото}
 menuText R OptionsThemeDir "Файл/ы тем:"  0 { Загрузить файл темы интерфейса }
+translate R OptionsThemeOmarchy {Следуйте теме Омархии}
 menuText R OptionsSave "Сохранить установки" 0 "Сохранить все установки в файл $::optionsFile"
 menuText R OptionsAutoSave "Автосохранение установок при выходе" 0 \
   {Автосохранение всех установок при выходе из программы}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -390,6 +390,8 @@ menuText Y OptionsTacticsBasesDir "Bases directory" 0 {Sets the tactics (trainin
 menuText Y OptionsPhotosDir "Photos directory" 0 {Sets the photos bases directory}
 # ====== TODO To be translated ======
 menuText Y OptionsThemeDir "Theme(s) File:"  0 { Load a GUI theme package file }
+# ====== TODO To be translated ======
+translate Y OptionsThemeOmarchy {Follow Omarchy theme}
 menuText Y OptionsSave "Sauvaj opcije" 0 \
   "Sauvaj sve opcije u fajl $::optionsFile"
 menuText Y OptionsAutoSave "Auto-sauvaj opcije na izlasku" 0 \

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -336,6 +336,7 @@ menuText S OptionsTacticsBasesDir "Carpeta de bases de datos" 0 \
   {Fija la carpeta de la base de entrenamiento táctico}
 menuText S OptionsPhotosDir "Directorio de fotos" 0 {Establece el directorio de bases de fotos.}
 menuText S OptionsThemeDir "Archivo de tema(s):"  0 {Cargue un archivo de paquete de tema GUI}
+translate S OptionsThemeOmarchy {Sigue el tema de Omarquia}
 menuText S OptionsSave "Guardar opciones" 0 \
   "Guarda todas las opciones en el fichero $::optionsFile"
 menuText S OptionsAutoSave "Autoguardar opciones al salir" 0 \

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -336,6 +336,7 @@ menuText U OptionsBooksDir "Avauskirjat" 0 {Hakemisto, jossa avauskirjat sijaits
 menuText U OptionsTacticsBasesDir "Taktiikkakannat" 0 {Hakemisto, jossa taktiikka (harjoitus) tietokannat sijaitsevat}
 menuText U OptionsPhotosDir "Valokuvahakemisto" 0 {Asettaa valokuvien perushakemiston}
 menuText U OptionsThemeDir "Teema(t) Tiedosto:"  0 {Lataa GUI-teeman pakettitiedosto}
+translate U OptionsThemeOmarchy {Seuraa Omarchy-teemaa}
 menuText U OptionsSave "Tallenna asetukset" 0 "Tallenna kaikki asetukset tiedostoon $::optionsFile"
 menuText U OptionsAutoSave "Automaattinen asetusten tallennus" 0 \
   {Tallenna asetukset automaattisesti ohjelmasta poistuttaessa}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -297,6 +297,7 @@ menuText Z OptionsBooksDir "Orodha ya vitabu" 0 {Inaweka saraka ya vitabu vya uf
 menuText Z OptionsTacticsBasesDir "Saraka ya misingi" 0 {Huweka saraka ya misingi ya mbinu (mafunzo).}
 menuText Z OptionsPhotosDir "Saraka ya picha" 0 {Huweka saraka ya misingi ya picha}
 menuText Z OptionsThemeDir "Faili ya Mandhari"  0 {Pakia faili ya kifurushi cha mandhari ya GUI}
+translate Z OptionsThemeOmarchy {Fuata mandhari ya Omarchy}
 menuText Z OptionsSave "Hifadhi Chaguo" 0 "Save all settable options to the file $::optionsFile"
 menuText Z OptionsAutoSave "Chaguo za Hifadhi Kiotomatiki unapotoka" 0 \
   {Hifadhi chaguo zote kiotomatiki unapoondoka kwenye Scid}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -307,6 +307,7 @@ menuText W OptionsBooksDir "Öppningsbokskatalog" 0 {Anger Öppningsbokskataloge
 menuText W OptionsTacticsBasesDir "Taktikbaskatalog" 0 {Anger Taktikbaskatalog (för träning)}
 menuText W OptionsPhotosDir "Fotokatalog" 0 {Ställer in fotobaskatalogen}
 menuText W OptionsThemeDir "Temafil:"  0 {Ladda en GUI-temapaketfil}
+translate W OptionsThemeOmarchy {Följ temat Omarchy}
 menuText W OptionsSave "Spara alternativ" 7 \
   "Spara alla alternativ till en inställningsfil"
 menuText W OptionsAutoSave "Autospara vid avslut" 1 \

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -301,6 +301,7 @@ menuText T OptionsBooksDir "Kitap dizini" 0 {Açılış kitapları dizinini ayar
 menuText T OptionsTacticsBasesDir "Baz dizini" 0 {Taktik (eğitim) temel dizinini ayarlar}
 menuText T OptionsPhotosDir "Fotoğraflar dizini" 0 {Fotoğraf tabanları dizinini ayarlar}
 menuText T OptionsThemeDir "Tema(lar) Dosyası"  0 {GUI tema paketi dosyasını yükleyin}
+translate T OptionsThemeOmarchy {Omarchy temasını takip edin}
 menuText T OptionsSave "Kaydetme Seçenekleri" 0 "Save all settable options to the file $::optionsFile"
 menuText T OptionsAutoSave "Çıkışta Otomatik Kaydetme Seçenekleri" 0 \
   {Scid'den çıkarken tüm seçenekleri otomatik kaydet}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -298,6 +298,7 @@ menuText Q OptionsBooksDir "Каталог книг" 0 {Встановлює к�
 menuText Q OptionsTacticsBasesDir "Довідник баз" 0 {Задає тактику (підготовку) довідника баз}
 menuText Q OptionsPhotosDir "Каталог фотографій" 0 {Встановлює каталог баз фотографій}
 menuText Q OptionsThemeDir "Файл тем(и)."  0 {Завантажте файл пакета теми GUI}
+translate Q OptionsThemeOmarchy {Дотримуйтесь теми Omarchy}
 menuText Q OptionsSave "Параметри збереження" 0 "Save all settable options to the file $::optionsFile"
 menuText Q OptionsAutoSave "Параметри автоматичного збереження під час виходу" 0 \
   {Автоматичне збереження всіх параметрів під час виходу зі Scid}

--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -575,6 +575,7 @@ proc menuUpdateThemes {} {
   if {[info commands ::omarchyTheme::isOmarchy] ne "" && [::omarchyTheme::isOmarchy]} {
       $m add separator
       $m add checkbutton -label [tr OptionsThemeOmarchy] -variable ::omarchyAutoTheme
+      set ::MenuLabels($m,[$m index end]) OptionsThemeOmarchy
   }
 }
 

--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -567,7 +567,14 @@ proc menuUpdateThemes {} {
       # Skip alt and clam themes as they are essentially duplicates of classic
       if {$i eq "alt" || $i eq "clam"} { continue }
       $m add radiobutton -label "$i" -value $i -variable ::lookTheme \
-      -command {::loadDeferredTheme $::lookTheme; ttk::style theme use $::lookTheme; configure_menus}
+      -command {::loadDeferredTheme $::lookTheme; set ::omarchyAutoTheme 0; ttk::style theme use $::lookTheme; configure_menus}
+  }
+
+  # Omarchy-only toggle: whether to keep following the Omarchy color theme
+  # automatically. Selecting a theme above turns this off.
+  if {[info commands ::omarchyTheme::isOmarchy] ne "" && [::omarchyTheme::isOmarchy]} {
+      $m add separator
+      $m add checkbutton -label [tr OptionsThemeOmarchy] -variable ::omarchyAutoTheme
   }
 }
 

--- a/tcl/omarchy-theme.tcl
+++ b/tcl/omarchy-theme.tcl
@@ -1,0 +1,223 @@
+###
+### omarchy-theme.tcl: part of scidCommunity.
+### Copyright (C) 2026 Hugh Whelan
+### SPDX-License-Identifier: GPL-2.0-or-later
+###
+### Auto-generate a scidCommunity ttk theme from the active Omarchy color
+### theme (colors.toml). This is only active on Omarchy Linux systems;
+### everywhere else (other distros, Windows, macOS) it is a no-op.
+###
+### The generated theme is cached under scidDataDir and only rebuilt when the
+### Omarchy theme actually changes, detected by fingerprinting colors.toml.
+###
+
+namespace eval ::omarchyTheme {
+
+  variable themeName "omarchy"
+
+  # --- Detection -----------------------------------------------------------
+  proc isOmarchy {} {
+    if {$::windowsOS || $::macOS} { return 0 }
+    if {![info exists ::env(HOME)] || $::env(HOME) eq ""} { return 0 }
+    if {[info exists ::env(DESKTOP_SESSION)] && $::env(DESKTOP_SESSION) eq "omarchy"} {
+      return 1
+    }
+    if {[colorsFile] ne ""} { return 1 }
+    return 0
+  }
+
+  proc currentThemeDir {} {
+    return [file join $::env(HOME) ".local" "state" "omarchy" "current" "theme"]
+  }
+
+  proc colorsFile {} {
+    set f [file join [currentThemeDir] "colors.toml"]
+    if {![file readable $f]} { return "" }
+    return $f
+  }
+
+  proc themeNameFile {} {
+    return [file join $::env(HOME) ".local" "state" "omarchy" "current" "theme.name"]
+  }
+
+  # --- Fingerprint ---------------------------------------------------------
+  # 32-bit FNV-1a over the combined theme name + colors.toml content. No
+  # external packages required. Deterministic, so the same palette always
+  # yields the same fingerprint.
+  proc hashString {s} {
+    set h 2166136261
+    foreach c [split $s ""] {
+      set h [expr {($h ^ [scan $c %c]) * 16777619}]
+      set h [expr {$h & 0xffffffff}]
+    }
+    return [format %08x $h]
+  }
+
+  proc readFile {f} {
+    if {![file readable $f]} { return "" }
+    if {[catch {set fd [open $f r]; set c [read $fd]; close $fd}]} {
+      return ""
+    }
+    return $c
+  }
+
+  proc fingerprint {} {
+    set cf [colorsFile]
+    if {$cf eq ""} { return "" }
+    set colors [readFile $cf]
+    if {$colors eq ""} { return "" }
+    set name [string trim [readFile [themeNameFile]]]
+    return [hashString "$name\n$colors"]
+  }
+
+  # --- Cache ---------------------------------------------------------------
+  proc cacheFile {} {
+    return [file nativename [file join $::scidDataDir "omarchy-theme.tcl"]]
+  }
+
+  proc cacheValid {file fp} {
+    if {$fp eq "" || ![file readable $file]} { return 0 }
+    if {[catch {set fd [open $file r]; set line [gets $fd]; close $fd}]} {
+      return 0
+    }
+    if {![regexp {^#\s*OmarchyTheme\s+([0-9a-fA-F]{8})} $line -> stored]} {
+      return 0
+    }
+    return [expr {[string tolower $stored] eq [string tolower $fp]}]
+  }
+
+  # --- colors.toml parsing -------------------------------------------------
+  proc readColors {} {
+    set cf [colorsFile]
+    if {$cf eq ""} { return "" }
+    set content [readFile $cf]
+    if {$content eq ""} { return "" }
+    set colors [dict create]
+    foreach line [split $content "\n"] {
+      set line [string trim $line]
+      if {$line eq "" || [string index $line 0] eq "#"} { continue }
+      if {![regexp {^(\w+)\s*=\s*"?([^"]*)"?} $line -> key val]} { continue }
+      dict set colors $key [string trim $val]
+    }
+    return $colors
+  }
+
+  # Resolve a palette key, with a fallback value. Returns a valid #rrggbb or "".
+  proc color {colors key {fallback ""}} {
+    if {[dict exists $colors $key]} {
+      set v [dict get $colors $key]
+      if {[regexp {^#[0-9a-fA-F]{6}$} $v]} { return [string tolower $v] }
+    }
+    return $fallback
+  }
+
+  # --- Theme generation ----------------------------------------------------
+  proc generateScript {colors fp} {
+    set bg  [color $colors background          "#1e1e2e"]
+    set fg  [color $colors foreground          "#cdd6f4"]
+    set acc [color $colors accent              [color $colors blue "#7aa2f7"]]
+    set mut [color $colors muted               "#45475a"]
+    set lbr [color $colors lighter_background  "#313244"]
+    set dbr [color $colors dark_background     "#181825"]
+
+    set dark 1
+    if {[dict exists $colors mode]} {
+      if {[string tolower [dict get $colors mode]] eq "light"} { set dark 0 }
+    }
+    set darkReg {registerDarkTheme "omarchy"}
+    if {!$dark} { set darkReg "" }
+
+    # Button/surface backgrounds use lighter_background (a surface color) rather
+    # than selection, which some themes (e.g. Aether-generated ones) set to a
+    # light text-selection color. Toolbutton and the other control styles are
+    # configured explicitly so they don't fall back to the parent's gray.
+    set template {# OmarchyTheme @FP@
+@DARKREG@
+if {[lsearch -exact [ttk::style theme names] omarchy] == -1} {
+  ttk::style theme create omarchy -parent classic -settings {
+    ttk::style configure . -background @BG@ -fieldbackground @LBR@ -foreground @FG@ -selectbackground @ACC@ -selectforeground @BG@ -insertcolor @FG@ -insertbackground @FG@ -troughcolor @DBR@
+    ttk::style configure TFrame -background @BG@
+    ttk::style configure TLabel -background @BG@ -foreground @FG@
+    ttk::style configure TNotebook -background @BG@
+    ttk::style configure TNotebook.Tab -background @BG@ -foreground @FG@
+    ttk::style map TNotebook.Tab -background [list selected @LBR@]
+    ttk::style configure Treeview -background @DBR@ -fieldbackground @DBR@ -foreground @FG@
+    ttk::style map Treeview -background [list selected @ACC@] -foreground [list selected @BG@]
+    ttk::style configure Heading -background @LBR@ -foreground @FG@ -relief flat
+    ttk::style map Heading -background [list active @MUT@]
+    ttk::style configure TEntry -fieldbackground @LBR@ -foreground @FG@
+    ttk::style configure TCombobox -fieldbackground @LBR@ -foreground @FG@
+    ttk::style configure TSpinbox -fieldbackground @LBR@ -foreground @FG@
+    ttk::style configure TButton -background @LBR@ -foreground @FG@ -borderwidth 1 -relief raised -padding {6 2}
+    ttk::style map TButton -background [list active @MUT@ pressed @DBR@] -relief [list pressed sunken]
+    ttk::style configure TMenubutton -background @LBR@ -foreground @FG@ -borderwidth 1 -relief raised
+    ttk::style map TMenubutton -background [list active @MUT@ pressed @DBR@]
+    ttk::style configure Toolbutton -background @LBR@ -foreground @FG@ -relief flat -padding 2
+    ttk::style map Toolbutton -background [list active @MUT@ pressed @ACC@ selected @ACC@] -relief [list {active !selected} raised]
+    ttk::style configure TCheckbutton -background @BG@ -foreground @FG@ -indicatorcolor @LBR@
+    ttk::style map TCheckbutton -background [list active @BG@] -indicatorcolor [list pressed @MUT@ selected @ACC@ alternate @ACC@]
+    ttk::style configure TRadiobutton -background @BG@ -foreground @FG@ -indicatorcolor @LBR@
+    ttk::style map TRadiobutton -background [list active @BG@] -indicatorcolor [list pressed @MUT@ selected @ACC@ alternate @ACC@]
+    ttk::style configure TScale -troughcolor @DBR@ -background @BG@
+    ttk::style configure TProgressbar -troughcolor @DBR@ -background @ACC@
+    ttk::style configure TScrollbar -troughcolor @DBR@ -background @MUT@
+    ttk::style map TScrollbar -background [list active @ACC@ pressed @ACC@]
+    ttk::style configure TLabelframe -background @BG@ -bordercolor @MUT@
+  }
+}
+}
+    return [string map [list \
+        @FP@     $fp \
+        @DARKREG@ $darkReg \
+        @BG@     $bg \
+        @FG@     $fg \
+        @ACC@    $acc \
+        @MUT@    $mut \
+        @LBR@    $lbr \
+        @DBR@    $dbr \
+      ] $template]
+  }
+
+  proc writeCache {file script} {
+    file mkdir [file dirname $file]
+    set tmp "$file.tmp.[pid]"
+    set fd ""
+    if {[catch {
+      set fd [open $tmp w]
+      puts -nonewline $fd $script
+      close $fd
+      set fd ""
+      file rename -force -- $tmp $file
+    }]} {
+      catch { close $fd }
+      catch { file delete -force -- $tmp }
+      return 0
+    }
+    return 1
+  }
+
+  # --- Entry point ---------------------------------------------------------
+  # Ensures the "omarchy" ttk theme exists, rebuilding it from colors.toml only
+  # when necessary. Returns the theme name, or "" if this is not an Omarchy
+  # system or the palette could not be read.
+  proc ensure {} {
+    variable themeName
+    if {![isOmarchy]} { return "" }
+    set fp [fingerprint]
+    if {$fp eq ""} { return "" }
+
+    set cache [cacheFile]
+    if {![cacheValid $cache $fp]} {
+      set colors [readColors]
+      if {$colors eq ""} { return "" }
+      set script [generateScript $colors $fp]
+      if {![writeCache $cache $script]} { return "" }
+    }
+
+    catch { safeSourceStyle $cache }
+    if {[lsearch -exact [ttk::style theme names] $themeName] == -1} {
+      return ""
+    }
+    return $themeName
+  }
+}

--- a/tcl/options.tcl
+++ b/tcl/options.tcl
@@ -197,6 +197,9 @@ set language E
 set ::lookTheme "sand"
 set ::ThemePackageFile ""
 
+# Auto-apply the Omarchy-derived theme on Omarchy systems (no-op elsewhere)
+set ::omarchyAutoTheme 1
+
 # Auto-save options when exiting:
 set optionsAutoSave 1
 
@@ -679,7 +682,7 @@ proc options.write {} {
           ::uci::uciInfo(fixeddepth1) ::uci::uciInfo(fixednodes1) ::uci::uciInfo(movetime1) \
           boardfile_lite boardfile_dark \
           FilterMaxMoves FilterMinMoves FilterStepMoves FilterMaxElo FilterMinElo FilterStepElo \
-          FilterMaxYear FilterMinYear FilterStepYear FilterGuessELO lookTheme ThemePackageFile autoResizeBoard \
+          FilterMaxYear FilterMinYear FilterStepYear FilterGuessELO lookTheme ThemePackageFile omarchyAutoTheme autoResizeBoard \
           isBatchOpening isBatchOpeningMoves isBatch \
           markTacticalExercises scoreAllMoves \
           useAnalysisBook annotateWhiteMoves annotateBlackMoves annotationVariationLength \

--- a/tcl/start.tcl
+++ b/tcl/start.tcl
@@ -718,6 +718,9 @@ if { [file exists $::ThemePackageFile] } {
   catch { ::safeSourceStyle $::ThemePackageFile }
 }
 
+# Auto-generate a theme from the active Omarchy color theme (no-op elsewhere).
+catch { source [file nativename [file join $::scidTclDir "omarchy-theme.tcl"]] }
+
 # The font for ttkEntry.c widgets cannot be set with ttk::style
 option add *TCombobox*font font_Regular
 option add *TEntry.font font_Regular
@@ -871,6 +874,15 @@ proc configure_style {} {
   }
 }
 bind . <<ThemeChanged>> { if {"%W" eq "."} { configure_style } }
+
+# On Omarchy systems the Omarchy-derived theme is made available regardless,
+# so it shows up in the Theme menu; it is auto-selected only if enabled.
+if {[info commands ::omarchyTheme::ensure] ne ""} {
+  set ::omarchyThemeName [::omarchyTheme::ensure]
+  if {$::omarchyThemeName ne "" && $::omarchyAutoTheme} {
+    set ::lookTheme $::omarchyThemeName
+  }
+}
 
 catch { ttk::style theme use $::lookTheme }
 configure_style


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Omarchy theme detection and application on supported systems.
  * Added an Options menu toggle to follow the Omarchy theme automatically.
  * Manual theme selection disables automatic theme following.
  * Added localized labels for the new option across supported languages.
  * Theme preferences are now saved and restored between sessions.

* **Bug Fixes**
  * Removed a duplicated Bengali translation continuation line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->