### PR TITLE
Fix batch annotate feature for Windows users

### DIFF
--- a/tcl/tools/batch_annotate.tcl
+++ b/tcl/tools/batch_annotate.tcl
@@ -236,7 +236,11 @@ proc ::batch_annotate::start_engines {{num_instances ""}} {
     
     if {[catch {
         for {set i 0} {$i < $num_instances} {incr i} {
-            set pipe [open "| \"[file nativename $cmd]\" $args" r+]
+            if {$::windowsOS} {
+                set pipe [open [list | $cmd {*}$args] r+]
+            } else {
+                set pipe [open "| \"[file nativename $cmd]\" $args" r+]
+            }
             lappend pipes $pipe
             fconfigure $pipe -buffering line -blocking 0
             


### PR DESCRIPTION
batch annotate feature was stripping `/` path separators from engine name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UCI engine launching across Windows and non-Windows platforms.
  * Engine commands and arguments are now passed using platform-appropriate process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->