### PR TITLE
Add strip command on selected games

### DIFF
--- a/tcl/game.tcl
+++ b/tcl/game.tcl
@@ -29,6 +29,51 @@ proc ::game::Strip {type} {
   updateTitle
 }
 
+# ::game::StripSelected
+#
+#   Strips comments, variations or both from a list of selected games.
+#   <type> is "comments", "variations" or "all".
+#
+proc ::game::StripSelected {db games_list type} {
+  if {$db eq "" || ![sc_base inUse]} { return }
+  set count 0
+  foreach s $games_list {
+    lassign [split [string trim $s] "_"] idx ply
+    if {$idx eq "" || ![string is integer -strict $idx] || $idx <= 0} { continue }
+    incr count
+  }
+  if {$count == 0} { return }
+  set answer [tk_messageBox -parent . -type yesno -icon question \
+    -title "scidCommunity" -message [format $::tr(ConfirmStripGames) $count]]
+  if {$answer ne "yes"} { return }
+
+  set prev_base [sc_base current]
+  if {$prev_base != $db} {
+    if {[catch {sc_base switch $db} result]} {
+      tk_messageBox -parent . -type ok -icon info -title "scidCommunity" -message $result
+      return
+    }
+  }
+  foreach s $games_list {
+    lassign [split [string trim $s] "_"] idx ply
+    if {$idx eq "" || ![string is integer -strict $idx] || $idx <= 0} { continue }
+    if {[catch {sc_game push copy}]} { continue }
+    if {[catch {sc_game load $idx}]} {
+      catch {sc_game pop}
+      continue
+    }
+    if {$type eq "all"} {
+      catch {sc_game strip comments}
+      catch {sc_game strip variations}
+    } else {
+      catch {sc_game strip $type}
+    }
+    catch {sc_game save $idx}
+    catch {sc_game pop}
+  }
+  ::notify::DatabaseModified $db
+}
+
 # ::game::TruncateBegin
 #
 proc ::game::TruncateBegin {} {

--- a/tcl/game.tcl
+++ b/tcl/game.tcl
@@ -35,7 +35,7 @@ proc ::game::Strip {type} {
 #   <type> is "comments", "variations" or "all".
 #
 proc ::game::StripSelected {db games_list type} {
-  if {$db eq "" || ![sc_base inUse]} { return }
+  if {$db eq "" || ![sc_base inUse $db]} { return }
   set count 0
   foreach s $games_list {
     lassign [split [string trim $s] "_"] idx ply
@@ -43,6 +43,11 @@ proc ::game::StripSelected {db games_list type} {
     incr count
   }
   if {$count == 0} { return }
+  if {[sc_base isReadOnly $db]} {
+    tk_messageBox -parent . -type ok -icon info -title "scidCommunity" \
+      -message $::tr(ErrReadOnly)
+    return
+  }
   set answer [tk_messageBox -parent . -type yesno -icon question \
     -title "scidCommunity" -message [format $::tr(ConfirmStripGames) $count]]
   if {$answer ne "yes"} { return }
@@ -70,6 +75,9 @@ proc ::game::StripSelected {db games_list type} {
     }
     catch {sc_game save $idx}
     catch {sc_game pop}
+  }
+  if {$prev_base != $db} {
+    catch {sc_base switch $prev_base}
   }
   ::notify::DatabaseModified $db
 }

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -110,6 +110,8 @@ menuText J EditRedo "Понови" 0 {Понови последњу промен
 menuText J EditStripComments "Коментари" 0 \
   {Уклоните све коментаре и белешке из ове игре}
 menuText J EditStripVars "Варијације" 0 {Скините све варијације из ове игре}
+menuText J EditStripAll "Коментари и варијације" 0 \
+  {Уклоните све коментаре, напомене и варијације из ове игре}
 menuText J EditStripBegin "Креће се од почетка" 1 \
   {Стрип потези од почетка игре}
 menuText J EditStripEnd "Креће се до краја" 0 \
@@ -1849,6 +1851,7 @@ translate J UndeleteGame {Поништи брисање игре}
 translate J ResetSort {Ресетуј сортирање}
 translate J LayoutExists {Распоред '%s' већ постоји.}
 translate J ConfirmDeleteLayout {Да ли сте сигурни да желите да избришете изглед „%s"?}
+translate J ConfirmStripGames {Уклонити напомене из %д изабраних игара)?}
 
 translate J ConvertNullMove {Претворите нулте потезе у коментаре}
 translate J SetupBoard {Сетуп Боард}

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -1851,7 +1851,7 @@ translate J UndeleteGame {Поништи брисање игре}
 translate J ResetSort {Ресетуј сортирање}
 translate J LayoutExists {Распоред '%s' већ постоји.}
 translate J ConfirmDeleteLayout {Да ли сте сигурни да желите да избришете изглед „%s"?}
-translate J ConfirmStripGames {Уклонити напомене из %д изабраних игара)?}
+translate J ConfirmStripGames {Уклонити напомене из %d изабраних игара?}
 
 translate J ConvertNullMove {Претворите нулте потезе у коментаре}
 translate J SetupBoard {Сетуп Боард}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -69,6 +69,8 @@ menuText b EditRedo "আবার করুন" 0 {শেষ খেলা পর
 menuText b EditStripComments "মন্তব্য" 0 \
   {এই গেম থেকে সমস্ত মন্তব্য এবং টীকা ছিনিয়ে নিন}
 menuText b EditStripVars "বৈচিত্র" 0 {এই গেম থেকে সমস্ত বৈচিত্র বাদ দিন}
+menuText b EditStripAll "মন্তব্য এবং বৈচিত্র" 0 \
+  {এই গেম থেকে সমস্ত মন্তব্য, টীকা এবং বৈচিত্র বাদ দিন}
 menuText b EditStripBegin "শুরু থেকেই চলে" 1 \
   {খেলার শুরু থেকেই স্ট্রিপ মুভ করে}
 menuText b EditStripEnd "শেষ পর্যন্ত চলে" 0 \
@@ -1808,6 +1810,7 @@ translate b UndeleteGame {খেলা অপসারণ}
 translate b ResetSort {সাজানোর রিসেট করুন}
 translate b LayoutExists {লেআউট '%s' ইতিমধ্যেই বিদ্যমান।}
 translate b ConfirmDeleteLayout {আপনি কি '%s' লেআউট মুছে ফেলার বিষয়ে নিশ্চিত?}
+translate b ConfirmStripGames {%dটি নির্বাচিত গেমগুলি থেকে স্ট্রিপ টীকা)?}
 
 translate b ConvertNullMove {নাল চালগুলিকে মন্তব্যে রূপান্তর করুন}
 translate b SetupBoard {সেটআপ বোর্ড}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -1810,7 +1810,7 @@ translate b UndeleteGame {খেলা অপসারণ}
 translate b ResetSort {সাজানোর রিসেট করুন}
 translate b LayoutExists {লেআউট '%s' ইতিমধ্যেই বিদ্যমান।}
 translate b ConfirmDeleteLayout {আপনি কি '%s' লেআউট মুছে ফেলার বিষয়ে নিশ্চিত?}
-translate b ConfirmStripGames {%dটি নির্বাচিত গেমগুলি থেকে স্ট্রিপ টীকা)?}
+translate b ConfirmStripGames {%dটি নির্বাচিত গেমগুলি থেকে স্ট্রিপ টীকা?}
 
 translate b ConvertNullMove {নাল চালগুলিকে মন্তব্যে রূপান্তর করুন}
 translate b SetupBoard {সেটআপ বোর্ড}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -110,6 +110,8 @@ menuText g EditRedo "Повторете" 0 {Повторете последна�
 menuText g EditStripComments "Коментари" 0 \
   {Премахнете всички коментари и анотации от тази игра}
 menuText g EditStripVars "Вариации" 0 {Отстранете всички варианти от тази игра}
+menuText g EditStripAll "Коментари и вариации" 0 \
+  {Премахнете всички коментари, анотации и вариации от тази игра}
 menuText g EditStripBegin "Движи се от самото начало" 1 \
   {Стрип се движи от началото на играта}
 menuText g EditStripEnd "Придвижва се до края" 0 \
@@ -1849,6 +1851,7 @@ translate g UndeleteGame {Отмяна на изтритата игра}
 translate g ResetSort {Нулиране на сортирането}
 translate g LayoutExists {Оформлението „%s“ вече съществува.}
 translate g ConfirmDeleteLayout {Сигурни ли сте, че искате да изтриете оформлението „%s“?}
+translate g ConfirmStripGames {Премахване на анотации от %d избрани игри)?}
 
 translate g ConvertNullMove {Преобразуване на нулеви ходове в коментари}
 translate g SetupBoard {Табло за настройка}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -1851,7 +1851,7 @@ translate g UndeleteGame {Отмяна на изтритата игра}
 translate g ResetSort {Нулиране на сортирането}
 translate g LayoutExists {Оформлението „%s“ вече съществува.}
 translate g ConfirmDeleteLayout {Сигурни ли сте, че искате да изтриете оформлението „%s“?}
-translate g ConfirmStripGames {Премахване на анотации от %d избрани игри)?}
+translate g ConfirmStripGames {Премахване на анотации от %d избрани игри?}
 
 translate g ConvertNullMove {Преобразуване на нулеви ходове в коментари}
 translate g SetupBoard {Табло за настройка}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -76,6 +76,8 @@ menuText K EditRedo "Refés" 0 {Refés l'últim canvi de la partida}
 menuText K EditStripComments "Comentaris" 0 \
   {Esborra tots els comentaris i variants d'aquesta partida}
 menuText K EditStripVars "Variants" 0 {Esborra totes les variants d'aquesta partida}
+menuText K EditStripAll "Comentaris i variacions" 0 \
+  {Elimina tots els comentaris, anotacions i variacions d'aquest joc}
 menuText K EditStripBegin "Jugades des del començament" 1 \
   {Treu els moviments des del començament de la partida}
 menuText K EditStripEnd "Jugades fins el final" 0 \
@@ -1852,6 +1854,7 @@ translate K UndeleteGame {Desfés esborrar partida}
 translate K ResetSort {Neteja criteri d'ordre}
 translate K LayoutExists {El disseny '%s' ja existeix.}
 translate K ConfirmDeleteLayout {Esteu segur que voleu suprimir el disseny '%s'?}
+translate K ConfirmStripGames {Eliminar les anotacions de %d jocs seleccionats)?}
 
 translate K ConvertNullMove {Converteix jugades nul·les en comentaris}
 translate K SetupBoard {Configura posició}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -1854,7 +1854,7 @@ translate K UndeleteGame {Desfés esborrar partida}
 translate K ResetSort {Neteja criteri d'ordre}
 translate K LayoutExists {El disseny '%s' ja existeix.}
 translate K ConfirmDeleteLayout {Esteu segur que voleu suprimir el disseny '%s'?}
-translate K ConfirmStripGames {Eliminar les anotacions de %d jocs seleccionats)?}
+translate K ConfirmStripGames {Eliminar les anotacions de %d jocs seleccionats?}
 
 translate K ConvertNullMove {Converteix jugades nul·les en comentaris}
 translate K SetupBoard {Configura posició}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -66,6 +66,8 @@ menuText M EditUndo "撤销" 0 {撤销上次游戏更改}
 menuText M EditRedo "重做" 0 {重做上次游戏更改}
 menuText M EditStripComments "注释" 0 {从此游戏中删除所有注释和标注}
 menuText M EditStripVars "变化" 0 {从此游戏中删除所有变化}
+menuText M EditStripAll "评论和变化" 0 \
+  {删除该游戏的所有评论、注释和变体}
 menuText M EditStripBegin "从开始到这里的着法" 0 {从开始到当前位置删除着法}
 menuText M EditStripEnd "从这里到结束的着法" 0 {从当前位置到结束删除着法}
 menuText M EditReset "清空剪贴板" 0 {将剪贴板完全清空}
@@ -1784,6 +1786,7 @@ translate M UndeleteGame {恢复删除游戏}
 translate M ResetSort {重置排序}
 translate M LayoutExists {布局“%s”已存在。}
 translate M ConfirmDeleteLayout {您确定要删除布局“%s”吗？}
+translate M ConfirmStripGames {从 %d 个选定的游戏中删除注释）？}
 
 translate M ConvertNullMove {将空动作转换为评论}
 translate M SetupBoard {设置板}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -1786,7 +1786,7 @@ translate M UndeleteGame {恢复删除游戏}
 translate M ResetSort {重置排序}
 translate M LayoutExists {布局“%s”已存在。}
 translate M ConfirmDeleteLayout {您确定要删除布局“%s”吗？}
-translate M ConfirmStripGames {从 %d 个选定的游戏中删除注释）？}
+translate M ConfirmStripGames {从 %d 个选定的游戏中删除注释？}
 
 translate M ConvertNullMove {将空动作转换为评论}
 translate M SetupBoard {设置板}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -71,6 +71,8 @@ menuText C EditRedo "Pedlat" 0 {Opakujte posledn zmnu hry}
 menuText C EditStripComments "Komente" 0 \
   {Odstranit vechny poznmky a anotace z tto partie}
 menuText C EditStripVars "Varianty" 0 {Odstranit vechny varianty z tto partie}
+menuText C EditStripAll "Komentáře a variace" 0 \
+  {Odstraňte z této hry všechny komentáře, anotace a variace}
 menuText C EditStripBegin "Tahy ze zatku" 5 \
   {Odstranit tahy ze zatku partie}
 menuText C EditStripEnd "Tahy do konce" 5 \
@@ -1830,6 +1832,7 @@ translate C UndeleteGame {Obnovit hru}
 translate C ResetSort {Obnovit azen}
 translate C LayoutExists {Rozložení '%s' již existuje.}
 translate C ConfirmDeleteLayout {Opravdu chcete smazat rozvržení '%s'?}
+translate C ConfirmStripGames {Odebrat anotace z %d vybraných her)?}
 
 translate C ConvertNullMove {Pevst nulov pohyby na komente}
 translate C SetupBoard {Instalan deska}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -1832,7 +1832,7 @@ translate C UndeleteGame {Obnovit hru}
 translate C ResetSort {Obnovit azen}
 translate C LayoutExists {Rozložení '%s' již existuje.}
 translate C ConfirmDeleteLayout {Opravdu chcete smazat rozvržení '%s'?}
-translate C ConfirmStripGames {Odebrat anotace z %d vybraných her)?}
+translate C ConfirmStripGames {Odebrat anotace z %d vybraných her?}
 
 translate C ConvertNullMove {Pevst nulov pohyby na komente}
 translate C SetupBoard {Instalan deska}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -91,6 +91,8 @@ menuText D EditStripComments "Kommentare" 0 \
   {Alle Kommentare und Kommentarzeichen aus dieser Partie entfernen}
 menuText D EditStripVars "Varianten" 0 \
   {Alle Varianten aus der Partie entfernen}
+menuText D EditStripAll "Kommentare und Variationen" 0 \
+  {Entfernen Sie alle Kommentare, Anmerkungen und Variationen aus diesem Spiel}
 menuText D EditStripBegin "Züge ab Anfang" 8 \
   {Entferne Züge ab Partieanfang}
 menuText D EditStripEnd "Züge bis Ende" 9 \
@@ -1880,6 +1882,7 @@ translate D UndeleteGame {Partie wiederherstellen}
 translate D ResetSort {Sortierung zurücksetzten}
 translate D LayoutExists {Layout „%s“ existiert bereits.}
 translate D ConfirmDeleteLayout {Sind Sie sicher, dass Sie das Layout „%s“ löschen möchten?}
+translate D ConfirmStripGames {Anmerkungen von %d ausgewählten Spielen entfernen)?}
 
 translate D ConvertNullMove {Null-Züge in Kommentare umwandeln}
 translate D SetupBoard {Stellung eingeben}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -1882,7 +1882,7 @@ translate D UndeleteGame {Partie wiederherstellen}
 translate D ResetSort {Sortierung zurücksetzten}
 translate D LayoutExists {Layout „%s“ existiert bereits.}
 translate D ConfirmDeleteLayout {Sind Sie sicher, dass Sie das Layout „%s“ löschen möchten?}
-translate D ConfirmStripGames {Anmerkungen von %d ausgewählten Spielen entfernen)?}
+translate D ConfirmStripGames {Anmerkungen von %d ausgewählten Spielen entfernen?}
 
 translate D ConvertNullMove {Null-Züge in Kommentare umwandeln}
 translate D SetupBoard {Stellung eingeben}

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -109,6 +109,8 @@ menuText E EditRedo "Redo" 0 {Redo last game change}
 menuText E EditStripComments "Comments" 0 \
   {Strip all comments and annotations from this game}
 menuText E EditStripVars "Variations" 0 {Strip all variations from this game}
+menuText E EditStripAll "Comments and Variations" 0 \
+  {Strip all comments, annotations and variations from this game}
 menuText E EditStripBegin "Moves from the beginning" 1 \
   {Strip moves from the beginning of the game}
 menuText E EditStripEnd "Moves to the end" 0 \
@@ -1862,6 +1864,7 @@ translate E UndeleteGame {Undelete game}
 translate E ResetSort {Reset sort}
 translate E LayoutExists {Layout '%s' already exists.}
 translate E ConfirmDeleteLayout {Are you sure you want to delete the layout '%s'?}
+translate E ConfirmStripGames {Strip annotations from %d selected game(s)?}
 
 translate E ConvertNullMove {Convert null moves to comments}
 translate E SetupBoard {Setup Board}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -73,6 +73,8 @@ menuText F EditRedo "Rétablir" 0 {Refaire la dernière modification de cette pa
 menuText F EditStripComments "Commentaires" 0 \
   {Épurer cette partie de tous les commentaires et annotations}
 menuText F EditStripVars "Variantes" 0 {Épurer cette partie des variantes}
+menuText F EditStripAll "Commentaires et variantes" 0 \
+  {Supprimez tous les commentaires, annotations et variantes de ce jeu}
 menuText F EditStripBegin "Coups depuis le début" 1 \
   {Épurer cette partie des coups depuis le début}
 menuText F EditStripEnd "Coups jusqu'à la fin" 0 \
@@ -1836,6 +1838,7 @@ translate F UndeleteGame {Restaurer le jeu}
 translate F ResetSort {Réinitialiser le tri}
 translate F LayoutExists {La mise en page '%s' existe déjà.}
 translate F ConfirmDeleteLayout {Êtes-vous sûr de vouloir supprimer la mise en page '%s' ?}
+translate F ConfirmStripGames {Supprimer les annotations de %d jeux sélectionnés ?}
 
 translate F ConvertNullMove {Convertir les mouvements nuls en commentaires}
 translate F SetupBoard {Définir la position de départ}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -1859,7 +1859,7 @@ translate G UndeleteGame {Αναίρεση διαγραφής παιχνιδιο
 translate G ResetSort {Επαναφορά ταξινόμησης}
 translate G LayoutExists {Η διάταξη '%s' υπάρχει ήδη.}
 translate G ConfirmDeleteLayout {Είστε βέβαιοι ότι θέλετε να διαγράψετε τη διάταξη '%s';}
-translate G ConfirmStripGames {Αφαίρεση σχολιασμών από %d επιλεγμένα παιχνίδια);}
+translate G ConfirmStripGames {Αφαίρεση σχολιασμών από %d επιλεγμένα παιχνίδια;}
 
 translate G ConvertNullMove {Μετατροπή μηδενικών κινήσεων σε σχόλια}
 translate G SetupBoard {Πίνακας εγκατάστασης}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -100,6 +100,8 @@ menuText G EditRedo "Ξανακάνω" 0 {Επαναλάβετε την τελε
 menuText G EditStripComments "Σχόλια" 0 \
   {Απομακρύνετε όλα τα σχόλια και τον υπομνηματισμό από αυτή τη παρτίδα}
 menuText G EditStripVars "Βαριάντες" 0 {Απομακρύνετε όλες τις βαριάντες από αυτή τη παρτίδα}
+menuText G EditStripAll "Σχόλια και παραλλαγές" 0 \
+  {Αφαιρέστε όλα τα σχόλια, τους σχολιασμούς και τις παραλλαγές από αυτό το παιχνίδι}
 menuText G EditStripBegin "Κινήσεις από την έναρξη" 1 \
   {Απομακρύνετε τις κινήσεις από την έναρξη της παρτίδας}
 menuText G EditStripEnd "Κινήσεις από το φινάλε" 0 \
@@ -1857,6 +1859,7 @@ translate G UndeleteGame {Αναίρεση διαγραφής παιχνιδιο
 translate G ResetSort {Επαναφορά ταξινόμησης}
 translate G LayoutExists {Η διάταξη '%s' υπάρχει ήδη.}
 translate G ConfirmDeleteLayout {Είστε βέβαιοι ότι θέλετε να διαγράψετε τη διάταξη '%s';}
+translate G ConfirmStripGames {Αφαίρεση σχολιασμών από %d επιλεγμένα παιχνίδια);}
 
 translate G ConvertNullMove {Μετατροπή μηδενικών κινήσεων σε σχόλια}
 translate G SetupBoard {Πίνακας εγκατάστασης}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -1811,7 +1811,7 @@ translate V UndeleteGame {בטל מחיקת משחק}
 translate V ResetSort {אפס מיון}
 translate V LayoutExists {הפריסה '%s' כבר קיימת.}
 translate V ConfirmDeleteLayout {האם אתה בטוח שברצונך למחוק את הפריסה '%s'?}
-translate V ConfirmStripGames {להסיר הערות מ-%d משחקים נבחרים)?}
+translate V ConfirmStripGames {להסיר הערות מ-%d משחקים נבחרים?}
 
 translate V ConvertNullMove {המר מהלכים אפסים להערות}
 translate V SetupBoard {לוח התקנה}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -70,6 +70,8 @@ menuText V EditRedo "לַעֲשׂוֹת שׁוּב" 0 {בצע מחדש את הש
 menuText V EditStripComments "הערות" 0 \
   {הסר את כל ההערות וההערות מהמשחק הזה}
 menuText V EditStripVars "וריאציות" 0 {הסר את כל הווריאציות מהמשחק הזה}
+menuText V EditStripAll "הערות וגיוונים" 0 \
+  {הסר את כל ההערות, ההערות והווריאציות מהמשחק הזה}
 menuText V EditStripBegin "נע מההתחלה" 1 \
   {רצועת מהלכים מתחילת המשחק}
 menuText V EditStripEnd "נע עד הסוף" 0 \
@@ -1809,6 +1811,7 @@ translate V UndeleteGame {בטל מחיקת משחק}
 translate V ResetSort {אפס מיון}
 translate V LayoutExists {הפריסה '%s' כבר קיימת.}
 translate V ConfirmDeleteLayout {האם אתה בטוח שברצונך למחוק את הפריסה '%s'?}
+translate V ConfirmStripGames {להסיר הערות מ-%d משחקים נבחרים)?}
 
 translate V ConvertNullMove {המר מהלכים אפסים להערות}
 translate V SetupBoard {לוח התקנה}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -69,6 +69,8 @@ menuText h EditRedo "फिर से करना" 0 {अंतिम गेम
 menuText h EditStripComments "टिप्पणियाँ" 0 \
   {इस गेम से सभी टिप्पणियाँ और टिप्पणियाँ हटा दें}
 menuText h EditStripVars "बदलाव" 0 {इस खेल से सभी विविधताएँ हटाएँ}
+menuText h EditStripAll "टिप्पणियाँ और विविधताएँ" 0 \
+  {इस गेम से सभी टिप्पणियाँ, टिप्पणियाँ और विविधताएँ हटा दें}
 menuText h EditStripBegin "प्रारंभ से चलता है" 1 \
   {खेल की शुरुआत से ही स्ट्रिप चलती रहती है}
 menuText h EditStripEnd "अंत की ओर बढ़ता है" 0 \
@@ -1808,6 +1810,7 @@ translate h UndeleteGame {गेम को अनडिलीट करें}
 translate h ResetSort {सॉर्ट रीसेट करें}
 translate h LayoutExists {लेआउट '%s' पहले से मौजूद है.}
 translate h ConfirmDeleteLayout {क्या आप वाकई '%s' लेआउट को हटाना चाहते हैं?}
+translate h ConfirmStripGames {%d चयनित गेम से एनोटेशन स्ट्रिप करें)?}
 
 translate h ConvertNullMove {शून्य चालों को टिप्पणियों में बदलें}
 translate h SetupBoard {सेटअप बोर्ड}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -70,7 +70,7 @@ menuText h EditStripComments "टिप्पणियाँ" 0 \
   {इस गेम से सभी टिप्पणियाँ और टिप्पणियाँ हटा दें}
 menuText h EditStripVars "बदलाव" 0 {इस खेल से सभी विविधताएँ हटाएँ}
 menuText h EditStripAll "टिप्पणियाँ और विविधताएँ" 0 \
-  {इस गेम से सभी टिप्पणियाँ, टिप्पणियाँ और विविधताएँ हटा दें}
+  {इस गेम से सभी टिप्पणियाँ और विविधताएँ हटा दें}
 menuText h EditStripBegin "प्रारंभ से चलता है" 1 \
   {खेल की शुरुआत से ही स्ट्रिप चलती रहती है}
 menuText h EditStripEnd "अंत की ओर बढ़ता है" 0 \
@@ -1810,7 +1810,7 @@ translate h UndeleteGame {गेम को अनडिलीट करें}
 translate h ResetSort {सॉर्ट रीसेट करें}
 translate h LayoutExists {लेआउट '%s' पहले से मौजूद है.}
 translate h ConfirmDeleteLayout {क्या आप वाकई '%s' लेआउट को हटाना चाहते हैं?}
-translate h ConfirmStripGames {%d चयनित गेम से एनोटेशन स्ट्रिप करें)?}
+translate h ConfirmStripGames {%d चयनित गेम से एनोटेशन स्ट्रिप करें?}
 
 translate h ConvertNullMove {शून्य चालों को टिप्पणियों में बदलें}
 translate h SetupBoard {सेटअप बोर्ड}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -71,6 +71,8 @@ menuText H EditRedo "Újra" 0 {Hajtsa végre a legutóbbi játékmódosítást}
 menuText H EditStripComments "Megjegyzések" 0 \
   {Eltávolítja az összes megjegyzést és elemzést ebbõl a játszmából.}
 menuText H EditStripVars "Változatok" 0 {Eltávolítja az összes változatot ebbõl a játszmából.}
+menuText H EditStripAll "Megjegyzések és variációk" 0 \
+  {Távolíts el minden megjegyzést, megjegyzést és változatot ebből a játékból}
 menuText H EditStripBegin "Az elejétõl" 3 \
   {Levágja a játszma elejét}
 menuText H EditStripEnd "A végéig" 2 \
@@ -1831,6 +1833,7 @@ translate H UndeleteGame {Játék törlésének visszavonása}
 translate H ResetSort {Rendezés visszaállítása}
 translate H LayoutExists {A „%s” elrendezés már létezik.}
 translate H ConfirmDeleteLayout {Biztos, hogy törölni szeretné a(z) '%s' elrendezést?}
+translate H ConfirmStripGames {Töröljük %d kiválasztott játék megjegyzéseit)?}
 
 translate H ConvertNullMove {Konvertálja a null mozgásokat megjegyzésekké}
 translate H SetupBoard {Beállítási tábla}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -72,7 +72,7 @@ menuText H EditStripComments "Megjegyzések" 0 \
   {Eltávolítja az összes megjegyzést és elemzést ebbõl a játszmából.}
 menuText H EditStripVars "Változatok" 0 {Eltávolítja az összes változatot ebbõl a játszmából.}
 menuText H EditStripAll "Megjegyzések és variációk" 0 \
-  {Távolíts el minden megjegyzést, megjegyzést és változatot ebből a játékból}
+  {Távolíts el minden megjegyzést és változatot ebből a játékból}
 menuText H EditStripBegin "Az elejétõl" 3 \
   {Levágja a játszma elejét}
 menuText H EditStripEnd "A végéig" 2 \
@@ -1833,7 +1833,7 @@ translate H UndeleteGame {Játék törlésének visszavonása}
 translate H ResetSort {Rendezés visszaállítása}
 translate H LayoutExists {A „%s” elrendezés már létezik.}
 translate H ConfirmDeleteLayout {Biztos, hogy törölni szeretné a(z) '%s' elrendezést?}
-translate H ConfirmStripGames {Töröljük %d kiválasztott játék megjegyzéseit)?}
+translate H ConfirmStripGames {Töröljük %d kiválasztott játék megjegyzéseit és változatait?}
 
 translate H ConvertNullMove {Konvertálja a null mozgásokat megjegyzésekké}
 translate H SetupBoard {Beállítási tábla}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -75,6 +75,8 @@ menuText I EditRedo "Ripeti" 0 {Ripete l'ultima modifica della partita}
 menuText I EditStripComments "Commenti" 0 \
   {Elimina tutti i commenti e le annotazioni dalla parita corrente}
 menuText I EditStripVars "Varianti" 0 {Elimina tutte le varianti dalla partita corrente}
+menuText I EditStripAll "Commenti e variazioni" 0 \
+  {Elimina tutti i commenti, le annotazioni e le variazioni da questo gioco}
 menuText I EditStripBegin "Mosse dall'inizio" 1 \
   {Elimina le mosse dall'inizio della partita}
 menuText I EditStripEnd "Mosse rimanenti" 0 \
@@ -1832,6 +1834,7 @@ translate I UndeleteGame {Annulla l'eliminazione del gioco}
 translate I ResetSort {Reimposta ordinamento}
 translate I LayoutExists {Il layout '%s' esiste già.}
 translate I ConfirmDeleteLayout {Sei sicuro di voler eliminare il layout '%s'?}
+translate I ConfirmStripGames {Rimuovere le annotazioni da %d giochi selezionati)?}
 
 translate I ConvertNullMove {Converti mosse nulle in commenti}
 translate I SetupBoard {Scheda di installazione}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -1834,7 +1834,7 @@ translate I UndeleteGame {Annulla l'eliminazione del gioco}
 translate I ResetSort {Reimposta ordinamento}
 translate I LayoutExists {Il layout '%s' esiste già.}
 translate I ConfirmDeleteLayout {Sei sicuro di voler eliminare il layout '%s'?}
-translate I ConfirmStripGames {Rimuovere le annotazioni da %d giochi selezionati)?}
+translate I ConfirmStripGames {Rimuovere le annotazioni da %d giochi selezionati?}
 
 translate I ConvertNullMove {Converti mosse nulle in commenti}
 translate I SetupBoard {Scheda di installazione}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -1851,7 +1851,7 @@ translate A UndeleteGame {ゲームの削除を取り消す}
 translate A ResetSort {並べ替えをリセット}
 translate A LayoutExists {レイアウト '%s' はすでに存在します。}
 translate A ConfirmDeleteLayout {レイアウト '%s' を削除してもよろしいですか?}
-translate A ConfirmStripGames {選択した %d ゲームから注釈を削除します)?}
+translate A ConfirmStripGames {選択した %d ゲームから注釈を削除します?}
 
 translate A ConvertNullMove {null 移動をコメントに変換する}
 translate A SetupBoard {セットアップボード}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -110,6 +110,8 @@ menuText A EditRedo "やり直し" 0 {最後のゲーム変更をやり直す}
 menuText A EditStripComments "コメント" 0 \
   {このゲームからすべてのコメントと注釈を削除します}
 menuText A EditStripVars "バリエーション" 0 {このゲームからすべてのバリエーションを削除}
+menuText A EditStripAll "コメントとバリエーション" 0 \
+  {このゲームからすべてのコメント、注釈、バリエーションを削除します}
 menuText A EditStripBegin "最初から動く" 1 \
   {ゲーム開始時からストリップが動きます}
 menuText A EditStripEnd "最後に移動します" 0 \
@@ -1849,6 +1851,7 @@ translate A UndeleteGame {ゲームの削除を取り消す}
 translate A ResetSort {並べ替えをリセット}
 translate A LayoutExists {レイアウト '%s' はすでに存在します。}
 translate A ConfirmDeleteLayout {レイアウト '%s' を削除してもよろしいですか?}
+translate A ConfirmStripGames {選択した %d ゲームから注釈を削除します)?}
 
 translate A ConvertNullMove {null 移動をコメントに変換する}
 translate A SetupBoard {セットアップボード}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -110,6 +110,8 @@ menuText k EditRedo "다시 실행" 0 {마지막 게임 변경 다시 실행}
 menuText k EditStripComments "댓글" 0 \
   {이 게임의 모든 댓글과 설명을 제거합니다.}
 menuText k EditStripVars "변형" 0 {이 게임의 모든 변형 제거}
+menuText k EditStripAll "의견 및 변형" 0 \
+  {이 게임의 모든 댓글, 주석 및 변형을 제거합니다.}
 menuText k EditStripBegin "처음부터 포맷인다" 1 \
   {게임시작부터 Strip입니다.}
 menuText k EditStripEnd "끝으로 이동합니다" 0 \
@@ -1849,6 +1851,7 @@ translate k UndeleteGame {게임 삭제 취소}
 translate k ResetSort {대신에}
 translate k LayoutExists {'%s'이(가) 이미 존재합니다.}
 translate k ConfirmDeleteLayout {정말 '%s' 입력을 삭제하시겠습니까?}
+translate k ConfirmStripGames {선택한 %d개의 게임에서 주석을 제거하시겠습니까?}
 
 translate k ConvertNullMove {null 이동을 댓글로 변환}
 translate k SetupBoard {설정 보드}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -1851,7 +1851,7 @@ translate k UndeleteGame {게임 삭제 취소}
 translate k ResetSort {대신에}
 translate k LayoutExists {'%s'이(가) 이미 존재합니다.}
 translate k ConfirmDeleteLayout {정말 '%s' 입력을 삭제하시겠습니까?}
-translate k ConfirmStripGames {선택한 %d개의 게임에서 주석을 제거하시겠습니까?}
+translate k ConfirmStripGames {선택한 %d개의 게임에서 주석과 변형을 제거하시겠습니까?}
 
 translate k ConvertNullMove {null 이동을 댓글로 변환}
 translate k SetupBoard {설정 보드}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -78,6 +78,8 @@ menuText N EditRedo "Opnieuw uitvoeren" 0 {Voer de laatste spelwijziging opnieuw
 menuText N EditStripComments "Commentaar" 0 \
   {Verwijder alle commentaar en annotaties uit deze partij}
 menuText N EditStripVars "Varianten" 0 {Verwijder alle varianten uit deze partij}
+menuText N EditStripAll "Opmerkingen en variaties" 0 \
+  {Verwijder alle opmerkingen, annotaties en variaties uit dit spel}
 menuText N EditStripBegin " Zetten vanaf begin " 1 \
   {Verwijder alle zetten vanaf begin van de partij} ;
 menuText N EditStripEnd " Zetten tot het einde  " 0 \
@@ -1855,6 +1857,7 @@ translate N UndeleteGame {Spel ongedaan maken}
 translate N ResetSort {Sortering opnieuw instellen}
 translate N LayoutExists {Lay-out '%s' bestaat al.}
 translate N ConfirmDeleteLayout {Weet u zeker dat u de lay-out '%s' wilt verwijderen?}
+translate N ConfirmStripGames {Annotaties van %d geselecteerde games verwijderen)?}
 
 translate N ConvertNullMove {Converteer nulbewegingen naar opmerkingen}
 translate N SetupBoard {Opstellingsbord}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -1857,7 +1857,7 @@ translate N UndeleteGame {Spel ongedaan maken}
 translate N ResetSort {Sortering opnieuw instellen}
 translate N LayoutExists {Lay-out '%s' bestaat al.}
 translate N ConfirmDeleteLayout {Weet u zeker dat u de lay-out '%s' wilt verwijderen?}
-translate N ConfirmStripGames {Annotaties van %d geselecteerde games verwijderen)?}
+translate N ConfirmStripGames {Annotaties van %d geselecteerde games verwijderen?}
 
 translate N ConvertNullMove {Converteer nulbewegingen naar opmerkingen}
 translate N SetupBoard {Opstellingsbord}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -73,6 +73,8 @@ menuText O EditRedo "Gjenta" 0 {Gjenta siste spillendring}
 menuText O EditStripComments "Kommentarer" 0 \
   {Fjern alle kommentarer og annotasjoner fra dette partiet}
 menuText O EditStripVars "Variasjoner" 0 {Fjern alle variasjoner fra dette partiet}
+menuText O EditStripAll "Kommentarer og varianter" 0 \
+  {Fjern alle kommentarer, merknader og varianter fra dette spillet}
 menuText O EditStripBegin "Moves from the beginning" 1 \
   {Strip moves from the beginning of the game} ;# ***
 menuText O EditStripEnd "Moves to the end" 0 \
@@ -1830,6 +1832,7 @@ translate O UndeleteGame {Angre sletting av spill}
 translate O ResetSort {Tilbakestill sortering}
 translate O LayoutExists {Layout '%s' eksisterer allerede.}
 translate O ConfirmDeleteLayout {Er du sikker på at du vil slette layouten '%s'?}
+translate O ConfirmStripGames {Vil du fjerne kommentarer fra %d valgte spill)?}
 
 translate O ConvertNullMove {Konverter null-trekk til kommentarer}
 translate O SetupBoard {Oppsettbrett}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -1832,7 +1832,7 @@ translate O UndeleteGame {Angre sletting av spill}
 translate O ResetSort {Tilbakestill sortering}
 translate O LayoutExists {Layout '%s' eksisterer allerede.}
 translate O ConfirmDeleteLayout {Er du sikker på at du vil slette layouten '%s'?}
-translate O ConfirmStripGames {Vil du fjerne kommentarer fra %d valgte spill)?}
+translate O ConfirmStripGames {Vil du fjerne kommentarer og varianter fra %d valgte spill?}
 
 translate O ConvertNullMove {Konverter null-trekk til kommentarer}
 translate O SetupBoard {Oppsettbrett}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -52,6 +52,8 @@ menuText P EditUndo {Cofnij} 0 {Cofnij ostatnią zmianę w partii}
 menuText P EditRedo {Ponów} 0 {Ponów ostatnią zmianę w partii}
 menuText P EditStripComments {Komentarze} 0 {Usuń wszystkie komentarze i adnotacje z tej partii}
 menuText P EditStripVars {Warianty} 0 {Usuń wszystkie warianty z tej partii}
+menuText P EditStripAll "Komentarze i zmiany" 0 \
+  {Usuń wszystkie komentarze, adnotacje i odmiany tej gry}
 menuText P EditStripBegin {Posunięcia od początku} 0 {Usuń posunięcia od początku partii}
 menuText P EditStripEnd {Posunięcia do końca} 0 {Usuń posunięcia do końca partii}
 menuText P EditReset {Opróżnij schowek} 0 {Całkowicie opróżnij bazę schowka}
@@ -1760,6 +1762,7 @@ translate P UndeleteGame {Przywróć partię}
 translate P ResetSort {Resetuj sortowanie}
 translate P LayoutExists {Układ '%s' już istnieje.}
 translate P ConfirmDeleteLayout {Czy na pewno chcesz usunąć układ '%s'?}
+translate P ConfirmStripGames {Usunąć adnotacje z %d wybranych gier)?}
 
 translate P ConvertNullMove {Zamień posunięcia zerowe na komentarze}
 translate P SetupBoard {Ustaw szachownicę}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -52,8 +52,8 @@ menuText P EditUndo {Cofnij} 0 {Cofnij ostatnią zmianę w partii}
 menuText P EditRedo {Ponów} 0 {Ponów ostatnią zmianę w partii}
 menuText P EditStripComments {Komentarze} 0 {Usuń wszystkie komentarze i adnotacje z tej partii}
 menuText P EditStripVars {Warianty} 0 {Usuń wszystkie warianty z tej partii}
-menuText P EditStripAll "Komentarze i zmiany" 0 \
-  {Usuń wszystkie komentarze, adnotacje i odmiany tej gry}
+menuText P EditStripAll "Komentarze i warianty" 0 \
+  {Usuń wszystkie komentarze, adnotacje i warianty tej gry}
 menuText P EditStripBegin {Posunięcia od początku} 0 {Usuń posunięcia od początku partii}
 menuText P EditStripEnd {Posunięcia do końca} 0 {Usuń posunięcia do końca partii}
 menuText P EditReset {Opróżnij schowek} 0 {Całkowicie opróżnij bazę schowka}
@@ -1762,7 +1762,7 @@ translate P UndeleteGame {Przywróć partię}
 translate P ResetSort {Resetuj sortowanie}
 translate P LayoutExists {Układ '%s' już istnieje.}
 translate P ConfirmDeleteLayout {Czy na pewno chcesz usunąć układ '%s'?}
-translate P ConfirmStripGames {Usunąć adnotacje z %d wybranych gier)?}
+translate P ConfirmStripGames {Usunąć adnotacje z %d wybranych gier?}
 
 translate P ConvertNullMove {Zamień posunięcia zerowe na komentarze}
 translate P SetupBoard {Ustaw szachownicę}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -1840,7 +1840,7 @@ translate B UndeleteGame {Recuperar jogo deletado}
 translate B ResetSort {Reiniciar ordenação}
 translate B LayoutExists {O layout '%s' já existe.}
 translate B ConfirmDeleteLayout {Tem certeza de que deseja excluir o layout '%s'?}
-translate B ConfirmStripGames {Remover anotações de %d jogos selecionados)?}
+translate B ConfirmStripGames {Remover anotações de %d jogos selecionados?}
 
 translate B ConvertNullMove {Converter movimentos nulos para comentários}
 translate B SetupBoard {Definir tabuleiro}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -72,6 +72,8 @@ menuText B EditStripComments "Limpar Comentários" 0 \
   {Limpa comentários e anotações no jogo atual}
 menuText B EditStripVars "Limpar Variantes" 0 \
   {Limpa todas as variantes no jogo atual}
+menuText B EditStripAll "Comentários e variações" 0 \
+  {Retire todos os comentários, anotações e variações deste jogo}
 menuText B EditStripBegin "Movimentos a partir do incio" 1 \
   {Remove movimentos a partir do início do jogo} 
 menuText B EditStripEnd "Movimentos até o final do jogo" 0 \
@@ -1838,6 +1840,7 @@ translate B UndeleteGame {Recuperar jogo deletado}
 translate B ResetSort {Reiniciar ordenação}
 translate B LayoutExists {O layout '%s' já existe.}
 translate B ConfirmDeleteLayout {Tem certeza de que deseja excluir o layout '%s'?}
+translate B ConfirmStripGames {Remover anotações de %d jogos selecionados)?}
 
 translate B ConvertNullMove {Converter movimentos nulos para comentários}
 translate B SetupBoard {Definir tabuleiro}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -1851,7 +1851,7 @@ translate L UndeleteGame {Anulați ștergerea jocului}
 translate L ResetSort {Resetează sortarea}
 translate L LayoutExists {Aspectul „%s” există deja.}
 translate L ConfirmDeleteLayout {Sigur doriți să ștergeți aspectul „%s”?}
-translate L ConfirmStripGames {Eliminați adnotările din %d jocuri selectate)?}
+translate L ConfirmStripGames {Eliminați adnotările din %d jocuri selectate?}
 
 translate L ConvertNullMove {Convertiți mișcările nule în comentarii}
 translate L SetupBoard {Placă de configurare}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -110,6 +110,8 @@ menuText L EditRedo "Reface" 0 {Reface ultima schimbare de joc}
 menuText L EditStripComments "Comentarii" 0 \
   {Eliminați toate comentariile și adnotările din acest joc}
 menuText L EditStripVars "Variante" 0 {Eliminați toate variantele din acest joc}
+menuText L EditStripAll "Comentarii și variații" 0 \
+  {Eliminați toate comentariile, adnotările și variațiile din acest joc}
 menuText L EditStripBegin "Se mișcă de la început" 1 \
   {Strip se mișcă de la începutul jocului}
 menuText L EditStripEnd "Se mută până la capăt" 0 \
@@ -1849,6 +1851,7 @@ translate L UndeleteGame {Anulați ștergerea jocului}
 translate L ResetSort {Resetează sortarea}
 translate L LayoutExists {Aspectul „%s” există deja.}
 translate L ConfirmDeleteLayout {Sigur doriți să ștergeți aspectul „%s”?}
+translate L ConfirmStripGames {Eliminați adnotările din %d jocuri selectate)?}
 
 translate L ConvertNullMove {Convertiți mișcările nule în comentarii}
 translate L SetupBoard {Placă de configurare}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -1834,7 +1834,7 @@ translate R UndeleteGame {Отменить удаление игры}
 translate R ResetSort {Сбросить сортировку}
 translate R LayoutExists {Макет «%s» уже существует.}
 translate R ConfirmDeleteLayout {Вы уверены, что хотите удалить макет «%s»?}
-translate R ConfirmStripGames {Удалить аннотации из %d выбранных игр)?}
+translate R ConfirmStripGames {Удалить аннотации из %d выбранных игр?}
 
 translate R ConvertNullMove {Преобразовать пустые ходы в комментарии}
 translate R SetupBoard {Настроить доску}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -75,6 +75,8 @@ menuText R EditRedo "Вернуть" 0 {Вернуть изменения в п�
 menuText R EditStripComments "Комментарии" 0 \
   {Убрать все комментарии и аннотации из этой партии}
 menuText R EditStripVars "Варианты" 0 {Убрать все варианты из этой партии}
+menuText R EditStripAll "Комментарии и вариации" 0 \
+  {Удалить все комментарии, аннотации и варианты из этой игры.}
 menuText R EditStripBegin "Двигаться от начала" 1 \
   {Вырезает ходы от начала партии}
 menuText R EditStripEnd "Двигаться к концу" 0 \
@@ -1832,6 +1834,7 @@ translate R UndeleteGame {Отменить удаление игры}
 translate R ResetSort {Сбросить сортировку}
 translate R LayoutExists {Макет «%s» уже существует.}
 translate R ConfirmDeleteLayout {Вы уверены, что хотите удалить макет «%s»?}
+translate R ConfirmStripGames {Удалить аннотации из %d выбранных игр)?}
 
 translate R ConvertNullMove {Преобразовать пустые ходы в комментарии}
 translate R SetupBoard {Настроить доску}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -77,9 +77,8 @@ menuText Y EditRedo "Redo" 0 {Redo last game change}
 menuText Y EditStripComments "Komentare" 0 \
   {Ukloni sve komentare i napomene iz ove partije}
 menuText Y EditStripVars "Varijante" 0 {Ukloni sve varijante iz ove partije}
-# ====== TODO To be translated ======
-menuText Y EditStripAll "Comments and Variations" 0 \
-  {Strip all comments, annotations and variations from this game}
+menuText Y EditStripAll "Komentari i varijante" 0 \
+  {Ukloni sve komentare, napomene i varijante iz ove partije}
 menuText Y EditStripBegin "Moves from the beginning" 1 \
   {Strip moves from the beginning of the game} ;# ***
 menuText Y EditStripEnd "Moves to the end" 0 \
@@ -3085,7 +3084,7 @@ translate Y LayoutExists {Layout '%s' already exists.}
 # ====== TODO To be translated ======
 translate Y ConfirmDeleteLayout {Are you sure you want to delete the layout '%s'?}
 # ====== TODO To be translated ======
-translate Y ConfirmStripGames {Strip annotations from %d selected game(s)?}
+translate Y ConfirmStripGames {Ukloniti napomene iz %d izabranih partija?}
 # ====== TODO To be translated ======
 translate Y ConvertNullMove {Convert null moves to comments}
 # ====== TODO To be translated ======

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -77,6 +77,9 @@ menuText Y EditRedo "Redo" 0 {Redo last game change}
 menuText Y EditStripComments "Komentare" 0 \
   {Ukloni sve komentare i napomene iz ove partije}
 menuText Y EditStripVars "Varijante" 0 {Ukloni sve varijante iz ove partije}
+# ====== TODO To be translated ======
+menuText Y EditStripAll "Comments and Variations" 0 \
+  {Strip all comments, annotations and variations from this game}
 menuText Y EditStripBegin "Moves from the beginning" 1 \
   {Strip moves from the beginning of the game} ;# ***
 menuText Y EditStripEnd "Moves to the end" 0 \
@@ -3081,6 +3084,8 @@ translate Y ResetSort {Reset sort}
 translate Y LayoutExists {Layout '%s' already exists.}
 # ====== TODO To be translated ======
 translate Y ConfirmDeleteLayout {Are you sure you want to delete the layout '%s'?}
+# ====== TODO To be translated ======
+translate Y ConfirmStripGames {Strip annotations from %d selected game(s)?}
 # ====== TODO To be translated ======
 translate Y ConvertNullMove {Convert null moves to comments}
 # ====== TODO To be translated ======

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -78,6 +78,8 @@ menuText S EditRedo "Rehacer" 0 {Rehacer el último cambio de juego}
 menuText S EditStripComments "Comentarios" 0 \
   {Quita todos los comentarios y variaciones de esta partida}
 menuText S EditStripVars "Variaciones" 0 {Quita todas las variaciones de esta partida}
+menuText S EditStripAll "Comentarios y variaciones" 0 \
+  {Elimina todos los comentarios, anotaciones y variaciones de este juego.}
 menuText S EditStripBegin "Movimientos desde el principio" 1 \
   {Quita los movimientos desde el principio de la partida}
 menuText S EditStripEnd "Movimientos hasta el final" 0 \
@@ -1883,6 +1885,7 @@ translate S UndeleteGame {Recuperar juego}
 translate S ResetSort {Restablecer clasificación}
 translate S LayoutExists {El diseño '%s' ya existe.}
 translate S ConfirmDeleteLayout {¿Está seguro de que desea eliminar el diseño '%s'?}
+translate S ConfirmStripGames {¿Quitar anotaciones de %d juegos seleccionados)?}
 
 translate S ConvertNullMove {Convertir movimientos nulos en comentarios}
 translate S SetupBoard {Tablero de configuración}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -1885,7 +1885,7 @@ translate S UndeleteGame {Recuperar juego}
 translate S ResetSort {Restablecer clasificación}
 translate S LayoutExists {El diseño '%s' ya existe.}
 translate S ConfirmDeleteLayout {¿Está seguro de que desea eliminar el diseño '%s'?}
-translate S ConfirmStripGames {¿Quitar anotaciones de %d juegos seleccionados)?}
+translate S ConfirmStripGames {¿Quitar anotaciones de %d partidas seleccionadas?}
 
 translate S ConvertNullMove {Convertir movimientos nulos en comentarios}
 translate S SetupBoard {Tablero de configuración}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -1863,7 +1863,7 @@ translate U UndeleteGame {Peru pelin poisto}
 translate U ResetSort {Nollaa lajittelu}
 translate U LayoutExists {Asettelu '%s' on jo olemassa.}
 translate U ConfirmDeleteLayout {Haluatko varmasti poistaa asettelun '%s'?}
-translate U ConfirmStripGames {Poistetaanko huomautukset %d valitusta pelistä)?}
+translate U ConfirmStripGames {Poistetaanko huomautukset %d valitusta pelistä?}
 
 translate U ConvertNullMove {Muunna nollasiirrot kommenteiksi}
 translate U SetupBoard {Asennustaulu}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -107,6 +107,8 @@ menuText U EditRedo "Tee uudelleen" 0 {Tee uudelleen viimeisin muutos}
 menuText U EditStripComments "Kommentit" 1 \
   {Poista kaikki kommentit ja arvioinnit pelistä}
 menuText U EditStripVars "Muunnelmat" 3 {Poista kaikki muunnelmat pelistä}
+menuText U EditStripAll "Kommentteja ja muunnelmia" 0 \
+  {Poista kaikki kommentit, huomautukset ja muunnelmat tästä pelistä}
 menuText U EditStripBegin "Siirtoja alusta" 1 \
   {Poista siirtoja pelin alusta}
 menuText U EditStripEnd "Siirtoja lopusta" 3 \
@@ -1861,6 +1863,7 @@ translate U UndeleteGame {Peru pelin poisto}
 translate U ResetSort {Nollaa lajittelu}
 translate U LayoutExists {Asettelu '%s' on jo olemassa.}
 translate U ConfirmDeleteLayout {Haluatko varmasti poistaa asettelun '%s'?}
+translate U ConfirmStripGames {Poistetaanko huomautukset %d valitusta pelistä)?}
 
 translate U ConvertNullMove {Muunna nollasiirrot kommenteiksi}
 translate U SetupBoard {Asennustaulu}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -1810,7 +1810,7 @@ translate Z UndeleteGame {Ondoa mchezo}
 translate Z ResetSort {Weka upya kupanga}
 translate Z LayoutExists {Muundo '%s' tayari upo.}
 translate Z ConfirmDeleteLayout {Je, una uhakika unataka kufuta mpangilio wa '%s'?}
-translate Z ConfirmStripGames {Ungependa kufuta vidokezo kutoka michezo %d iliyochaguliwa)?}
+translate Z ConfirmStripGames {Ungependa kufuta vidokezo kutoka michezo %d iliyochaguliwa?}
 
 translate Z ConvertNullMove {Badilisha miondoko batili kuwa maoni}
 translate Z SetupBoard {Bodi ya Kuweka}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -69,6 +69,8 @@ menuText Z EditRedo "Rudia" 0 {Rudia mabadiliko ya mchezo uliopita}
 menuText Z EditStripComments "Maoni" 0 \
   {Ondoa maoni na vidokezo vyote kutoka kwa mchezo huu}
 menuText Z EditStripVars "Tofauti" 0 {Ondoa tofauti zote kutoka kwa mchezo huu}
+menuText Z EditStripAll "Maoni na Tofauti" 0 \
+  {Ondoa maoni yote, vidokezo na tofauti kutoka kwa mchezo huu}
 menuText Z EditStripBegin "Inasonga kutoka mwanzo" 1 \
   {Strip inasonga tangu mwanzo wa mchezo}
 menuText Z EditStripEnd "Inasonga hadi mwisho" 0 \
@@ -1808,6 +1810,7 @@ translate Z UndeleteGame {Ondoa mchezo}
 translate Z ResetSort {Weka upya kupanga}
 translate Z LayoutExists {Muundo '%s' tayari upo.}
 translate Z ConfirmDeleteLayout {Je, una uhakika unataka kufuta mpangilio wa '%s'?}
+translate Z ConfirmStripGames {Ungependa kufuta vidokezo kutoka michezo %d iliyochaguliwa)?}
 
 translate Z ConvertNullMove {Badilisha miondoko batili kuwa maoni}
 translate Z SetupBoard {Bodi ya Kuweka}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -73,6 +73,8 @@ menuText W EditRedo "Göra om" 0 {Gör om senaste spelbyte}
 menuText W EditStripComments "Kommentarer" 0 \
   {Avlägsna alla kommentarer och noteringar från partiet}
 menuText W EditStripVars "Varianter" 0 {Avlägsna alla varianter från partiet}
+menuText W EditStripAll "Kommentarer och variationer" 0 \
+  {Ta bort alla kommentarer, kommentarer och varianter från detta spel}
 menuText W EditStripBegin "Avlägsna tidigare drag" 9 \
   {Avlägsna dragen fram till den aktuella ställningen} 
 menuText W EditStripEnd "Avlägsna resterande drag" 0 \
@@ -1836,6 +1838,7 @@ translate W UndeleteGame {Återställ spel}
 translate W ResetSort {Återställ sortering}
 translate W LayoutExists {Layouten '%s' finns redan.}
 translate W ConfirmDeleteLayout {Är du säker på att du vill ta bort layouten '%s'?}
+translate W ConfirmStripGames {Vill du ta bort kommentarer från %d valda spel)?}
 
 translate W ConvertNullMove {Konvertera null-drag till kommentarer}
 translate W SetupBoard {Installationsbräda}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -1838,7 +1838,7 @@ translate W UndeleteGame {Återställ spel}
 translate W ResetSort {Återställ sortering}
 translate W LayoutExists {Layouten '%s' finns redan.}
 translate W ConfirmDeleteLayout {Är du säker på att du vill ta bort layouten '%s'?}
-translate W ConfirmStripGames {Vill du ta bort kommentarer från %d valda spel)?}
+translate W ConfirmStripGames {Vill du ta bort kommentarer och varianter från %d valda spel?}
 
 translate W ConvertNullMove {Konvertera null-drag till kommentarer}
 translate W SetupBoard {Installationsbräda}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -1814,7 +1814,7 @@ translate T UndeleteGame {Oyunun silinmesini geri al}
 translate T ResetSort {Sıralamayı sıfırla}
 translate T LayoutExists {'%s' düzeni zaten mevcut.}
 translate T ConfirmDeleteLayout {'%s' düzenini silmek istediğinizden emin misiniz?}
-translate T ConfirmStripGames {Seçili %d oyundaki ek açıklamalar kaldırılsın mı?)}
+translate T ConfirmStripGames {Seçili %d oyundaki ek açıklamalar kaldırılsın mı?}
 
 translate T ConvertNullMove {Boş hareketleri yorumlara dönüştürün}
 translate T SetupBoard {Kurulum Panosu}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -73,6 +73,8 @@ menuText T EditRedo "Yinele" 0 {Son oyun değişikliğini yeniden yap}
 menuText T EditStripComments "Yorumlar" 0 \
   {Bu oyundaki tüm yorumları ve ek açıklamaları kaldır}
 menuText T EditStripVars "Varyasyonlar" 0 {Bu oyundaki tüm varyasyonları çıkarın}
+menuText T EditStripAll "Yorumlar ve Varyasyonlar" 0 \
+  {Bu oyundaki tüm yorumları, açıklamaları ve varyasyonları kaldırın}
 menuText T EditStripBegin "Başlangıçtan itibaren hareket eder" 1 \
   {Oyunun başından itibaren şerit hareketleri}
 menuText T EditStripEnd "Sona doğru hareket eder" 0 \
@@ -1812,6 +1814,7 @@ translate T UndeleteGame {Oyunun silinmesini geri al}
 translate T ResetSort {Sıralamayı sıfırla}
 translate T LayoutExists {'%s' düzeni zaten mevcut.}
 translate T ConfirmDeleteLayout {'%s' düzenini silmek istediğinizden emin misiniz?}
+translate T ConfirmStripGames {Seçili %d oyundaki ek açıklamalar kaldırılsın mı?)}
 
 translate T ConvertNullMove {Boş hareketleri yorumlara dönüştürün}
 translate T SetupBoard {Kurulum Panosu}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -70,6 +70,8 @@ menuText Q EditRedo "Повторити" 0 {Повторити останню з
 menuText Q EditStripComments "Коментарі" 0 \
   {Видалити всі коментарі та анотації з цієї гри}
 menuText Q EditStripVars "Варіації" 0 {Зніміть усі варіації з цієї гри}
+menuText Q EditStripAll "Коментарі та варіації" 0 \
+  {Видалити всі коментарі, анотації та варіації з цієї гри}
 menuText Q EditStripBegin "Рухається з самого початку" 1 \
   {Стрип рухається з початку гри}
 menuText Q EditStripEnd "Рухається до кінця" 0 \
@@ -1809,6 +1811,7 @@ translate Q UndeleteGame {Відновити гру}
 translate Q ResetSort {Скинути сортування}
 translate Q LayoutExists {Макет "%s" вже існує.}
 translate Q ConfirmDeleteLayout {Ви впевнені, що бажаєте видалити макет «%s»?}
+translate Q ConfirmStripGames {Видалити анотації з %d вибраних ігор)?}
 
 translate Q ConvertNullMove {Перетворення нульових ходів на коментарі}
 translate Q SetupBoard {Налаштування дошки}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -1811,7 +1811,7 @@ translate Q UndeleteGame {Відновити гру}
 translate Q ResetSort {Скинути сортування}
 translate Q LayoutExists {Макет "%s" вже існує.}
 translate Q ConfirmDeleteLayout {Ви впевнені, що бажаєте видалити макет «%s»?}
-translate Q ConfirmStripGames {Видалити анотації з %d вибраних ігор)?}
+translate Q ConfirmStripGames {Видалити анотації з %d вибраних ігор?}
 
 translate Q ConvertNullMove {Перетворення нульових ходів на коментарі}
 translate Q SetupBoard {Налаштування дошки}

--- a/tcl/windows/gamelist.tcl
+++ b/tcl/windows/gamelist.tcl
@@ -1401,6 +1401,7 @@ proc glist.popupmenu_ {{w} {x} {y} {abs_x} {abs_y} {layout}} {
       if { [winfo exists $w.game_menu.copy] } { destroy $w.game_menu.copy }
       if { [winfo exists $w.game_menu.filter] } { destroy $w.game_menu.filter }
       if { [winfo exists $w.game_menu.export] } { destroy $w.game_menu.export }
+      if { [winfo exists $w.game_menu.strip] } { destroy $w.game_menu.strip }
       $w.game_menu delete 0 end
       #LOAD/BROWSE/MERGE GAME
       if {[llength $sel] == 1} {
@@ -1421,6 +1422,16 @@ proc glist.popupmenu_ {{w} {x} {y} {abs_x} {abs_y} {layout}} {
         $w.game_menu add command -label $::tr(BatchAnnotate) \
            -command [list ::batch_annotate::config $::glistBase($w) $sel_literal]
       }
+      menu $w.game_menu.strip
+      $w.game_menu.strip add command -label [tr EditStripComments] \
+        -command [list ::game::StripSelected $::glistBase($w) $sel_literal comments]
+      $w.game_menu.strip add command -label [tr EditStripVars] \
+        -command [list ::game::StripSelected $::glistBase($w) $sel_literal variations]
+      $w.game_menu.strip add command -label [tr EditStripAll] \
+        -command [list ::game::StripSelected $::glistBase($w) $sel_literal all]
+      set stripLabel [tr EditStrip]
+      if {[llength $sel] > 1} { set stripLabel "$stripLabel ([llength $sel])" }
+      $w.game_menu add cascade -label $stripLabel -menu $w.game_menu.strip
 
       set is_del 1
       foreach s $sel {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a game-list context-menu submenu for removing comments, variations, or both from selected games.
  - Actions request confirmation, process selected games, and report when the database has been modified.
  - Added an Edit-menu option to remove all comments, annotations, and variations from the current game.

- **Localization**
  - Added translations for the new menu options and confirmation prompts across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->