### PR TITLE
Import chess.com, Lichess and PGN into database skipping duplicates

### DIFF
--- a/src/sc_base.cpp
+++ b/src/sc_base.cpp
@@ -535,6 +535,40 @@ UI_res_t sc_base_import(scidBaseT* dbase, UI_handle_t ti, int argc,
 	return UI_Result(ti, OK, res);
 }
 
+/**
+ * sc_base_import_nodup() - import games from a PGN file skipping duplicates.
+ *
+ * A game is considered a duplicate if its normalized White and Black player
+ * names, exact Date, Result and exact move sequence all match a game already
+ * in the database (or one imported earlier in the same batch).
+ *
+ * Return:
+ *   On success, returns a list of three elements: the number of games
+ *   imported, the number of games skipped as duplicates, and a string
+ *   containing import errors or warnings.
+ */
+UI_res_t sc_base_import_nodup(scidBaseT* dbase, UI_handle_t ti, int argc,
+                              const char** argv) {
+	const char* usage = "Usage: sc_base import_nodup baseId filename";
+	if (argc != 4)
+		return UI_Result(ti, ERROR_BadArg, usage);
+
+	gamenumT nImported = 0;
+	gamenumT nSkipped = 0;
+	std::string errorMsg;
+	const auto filename = argv[3];
+	if (auto err = dbase->importGamesNoDup(ICodecDatabase::PGN, filename,
+	                                       UI_CreateProgress(ti), errorMsg,
+	                                       nImported, nSkipped))
+		return UI_Result(ti, err);
+
+	UI_List res(3);
+	res.push_back(nImported);
+	res.push_back(nSkipped);
+	res.push_back(errorMsg);
+	return UI_Result(ti, OK, res);
+}
+
 
 /**
  * sc_base_list() - return a baseId list of opened databases
@@ -964,7 +998,7 @@ UI_res_t sc_base (UI_extra_t cd, UI_handle_t ti, int argc, const char ** argv)
 	    "create",          "current",         "duplicates",
 	    "export",          "extra",           "filename",        "gameflag",
 	    "gamelocation",    "gameslist",       "getGame",         "import",
-	    "inUse",           "isReadOnly",      "list",            "numGames",        "open",
+	    "import_nodup",    "inUse",           "isReadOnly",      "list",            "numGames",        "open",
 	    "piecetrack",      "player_elo",      "slot",            "sortcache",       "stats",
 	    "strip",           "switch",          "taglist",         "tournaments",     "type",
 	    "gamesummary",
@@ -975,7 +1009,7 @@ UI_res_t sc_base (UI_extra_t cd, UI_handle_t ti, int argc, const char ** argv)
 	    BASE_CREATE,       BASE_CURRENT,      BASE_DUPLICATES,
 	    BASE_EXPORT,       BASE_EXTRA,        BASE_FILENAME,     BASE_GAMEFLAG,
 	    BASE_GAMELOCATION, BASE_GAMESLIST,    BASE_GETGAME,      BASE_IMPORT,
-	    BASE_INUSE,        BASE_ISREADONLY,   BASE_LIST,         BASE_NUMGAMES,     BASE_OPEN,
+	    BASE_IMPORT_NODUP, BASE_INUSE,        BASE_ISREADONLY,   BASE_LIST,         BASE_NUMGAMES,     BASE_OPEN,
 	    BASE_PTRACK,       BASE_PLAYER_ELO,   BASE_SLOT,         BASE_SORTCACHE,    BASE_STATS,
 	    BASE_STRIP,        BASE_SWITCH,       BASE_TAGLIST,      BASE_TOURNAMENTS,  BASE_TYPE,
 	    BASE_GAMESUMMARY
@@ -1048,6 +1082,9 @@ UI_res_t sc_base (UI_extra_t cd, UI_handle_t ti, int argc, const char ** argv)
 
 	case BASE_IMPORT:
 		return sc_base_import (dbase, ti, argc, argv);
+
+	case BASE_IMPORT_NODUP:
+		return sc_base_import_nodup(dbase, ti, argc, argv);
 
 	case BASE_ISREADONLY:
 		return UI_Result(ti, OK, dbase->isReadOnly());

--- a/src/scidbase.cpp
+++ b/src/scidbase.cpp
@@ -319,28 +319,78 @@ namespace {
 constexpr uint64_t kFnvOffsetBasis = 1469598103934665603ULL;
 constexpr uint64_t kFnvPrime = 1099511628211ULL;
 
+// Fold a code point to lowercase for the Latin-script ranges that occur in
+// chess player names (ASCII, Latin-1 Supplement and Latin Extended-A).
+// Characters outside these ranges are returned unchanged.
+uint32_t foldLatinCodepoint(uint32_t cp) {
+	if (cp < 0x80)
+		return (cp >= 'A' && cp <= 'Z') ? cp + ('a' - 'A') : cp;
+
+	// Latin-1 Supplement: U+00C0..U+00DE are the uppercase letters and map to
+	// U+00E0..U+00FE (U+00D7 is the multiplication sign, not a letter).
+	if (cp >= 0x00C0 && cp <= 0x00DE && cp != 0x00D7)
+		return cp + 0x20;
+
+	if (cp == 0x0130) // İ (Latin capital I with dot) has no precomposed
+		return 0x0069; // lowercase here; fold it to plain 'i'.
+	if (cp == 0x0178) // Ÿ (Latin capital Y with diaeresis)
+		return 0x00FF; //   -> ÿ
+
+	// Latin Extended-A: uppercase letters sit on even code points and their
+	// lowercase counterparts on the following odd code point. Exceptions that
+	// are already lowercase (U+0138 ĸ) are left alone.
+	if (cp >= 0x0100 && cp <= 0x017E && !(cp & 1) && cp != 0x0138)
+		return cp + 1;
+
+	return cp;
+}
+
 // Hash a normalized player name: leading/trailing whitespace is stripped and
-// the result is lowercased before hashing. This is the same normalization
-// used by the duplicate fingerprint, so "  CARLSEN, Magnus " and
-// "carlsen, magnus" hash to the same value.
+// the result is lowercased (ASCII and common Latin accents) before hashing.
+// This is the same normalization used by the duplicate fingerprint, so
+// "  CARLSEN, Magnus ", "carlsen, magnus", "DÍAZ" and "díaz" all hash to the
+// same value. Case folding is limited to the Latin ranges; other scripts are
+// left unchanged, which can only produce false negatives (a duplicate is
+// re-imported), never a false positive.
 uint64_t nameNormHash(const char* name) {
 	if (name == nullptr)
 		return kFnvOffsetBasis;
 
-	const char* s = name;
-	while (*s && std::isspace(static_cast<unsigned char>(*s)))
-		++s;
-	const char* e = s;
+	const unsigned char* s = reinterpret_cast<const unsigned char*>(name);
+	const unsigned char* e = s;
 	while (*e)
 		++e;
-	while (e > s && std::isspace(static_cast<unsigned char>(e[-1])))
+	while (s < e && std::isspace(*s))
+		++s;
+	while (e > s && std::isspace(e[-1]))
 		--e;
 
 	uint64_t hash = kFnvOffsetBasis;
-	for (const char* p = s; p < e; ++p) {
-		hash ^= static_cast<unsigned char>(
-		    std::tolower(static_cast<unsigned char>(*p)));
+	while (s < e) {
+		uint32_t cp = *s;
+		int len = 1;
+		if (cp >= 0xC0) {
+			if ((cp & 0xE0) == 0xC0 && s + 1 < e) {
+				cp = ((*s & 0x1F) << 6) | (s[1] & 0x3F);
+				len = 2;
+			} else if ((cp & 0xF0) == 0xE0 && s + 2 < e) {
+				cp = ((*s & 0x0F) << 12) | ((s[1] & 0x3F) << 6) |
+				     (s[2] & 0x3F);
+				len = 3;
+			} else if ((cp & 0xF8) == 0xF0 && s + 3 < e) {
+				cp = ((*s & 0x07) << 18) | ((s[1] & 0x3F) << 12) |
+				     ((s[2] & 0x3F) << 6) | (s[3] & 0x3F);
+				len = 4;
+			} else {
+				// Invalid/truncated sequence: hash the raw byte.
+				cp = *s;
+				len = 1;
+			}
+		}
+
+		hash ^= foldLatinCodepoint(cp);
 		hash *= kFnvPrime;
+		s += len;
 	}
 	return hash;
 }

--- a/src/scidbase.cpp
+++ b/src/scidbase.cpp
@@ -26,6 +26,7 @@
 #include "sortcache.h"
 #include "stored.h"
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <unordered_map>
@@ -299,6 +300,180 @@ errorT scidBaseT::importGames(ICodecDatabase::Codec dbtype,
 				err = OK;
 			}
 			return err;
+		});
+		errorMsg = pgn.parseErrors();
+		if (nChess960Errors) {
+			errorMsg.append("Ignored ");
+			errorMsg.append(std::to_string(nChess960Errors));
+			errorMsg.append(" chess960 game(s).\n");
+		}
+	}
+
+	auto res_endTrans = endTransaction();
+	return (res != OK) ? res : res_endTrans;
+}
+
+namespace {
+
+// FNV-1a 64-bit hashing constants.
+constexpr uint64_t kFnvOffsetBasis = 1469598103934665603ULL;
+constexpr uint64_t kFnvPrime = 1099511628211ULL;
+
+// Hash a normalized player name: leading/trailing whitespace is stripped and
+// the result is lowercased before hashing. This is the same normalization
+// used by the duplicate fingerprint, so "  CARLSEN, Magnus " and
+// "carlsen, magnus" hash to the same value.
+uint64_t nameNormHash(const char* name) {
+	if (name == nullptr)
+		return kFnvOffsetBasis;
+
+	const char* s = name;
+	while (*s && std::isspace(static_cast<unsigned char>(*s)))
+		++s;
+	const char* e = s;
+	while (*e)
+		++e;
+	while (e > s && std::isspace(static_cast<unsigned char>(e[-1])))
+		--e;
+
+	uint64_t hash = kFnvOffsetBasis;
+	for (const char* p = s; p < e; ++p) {
+		hash ^= static_cast<unsigned char>(
+		    std::tolower(static_cast<unsigned char>(*p)));
+		hash *= kFnvPrime;
+	}
+	return hash;
+}
+
+// Combine the individual fingerprint components into a single 64-bit key.
+uint64_t combineFingerprint(uint64_t whiteHash, uint64_t blackHash, dateT date,
+                            resultT result) {
+	uint64_t key = whiteHash;
+	key = (key ^ blackHash) * kFnvPrime;
+	key = (key ^ static_cast<uint64_t>(date)) * kFnvPrime;
+	key = (key ^ static_cast<uint64_t>(result)) * kFnvPrime;
+	return key;
+}
+
+} // namespace
+
+errorT scidBaseT::importGamesNoDup(ICodecDatabase::Codec dbtype,
+                                   const char* filename,
+                                   const Progress& progress,
+                                   std::string& errorMsg, gamenumT& nImported,
+                                   gamenumT& nSkipped) {
+	ASSERT(dbtype == ICodecDatabase::PGN);
+	nImported = 0;
+	nSkipped = 0;
+
+	if (auto errModify = beginTransaction())
+		return errModify;
+
+	// Build a fingerprint index of the games already in the database.
+	// Each game is keyed by (normalized White, normalized Black, exact Date,
+	// Result); the exact move sequence is compared only against the (few)
+	// games that share the same key, which keeps the check fast even for
+	// very large databases.
+	struct DupKey {
+		uint64_t key;
+		gamenumT gnum;
+		bool operator<(const DupKey& o) const { return key < o.key; }
+	};
+
+	const gamenumT numGames = this->numGames();
+	const NameBase* nb = getNameBase();
+
+	std::vector<uint64_t> nameHash(nb->GetNumNames(NAME_PLAYER));
+	for (idNumberT id = 0; id < nameHash.size(); ++id)
+		nameHash[id] = nameNormHash(nb->GetName(NAME_PLAYER, id));
+
+	std::vector<DupKey> index;
+	index.reserve(numGames);
+	for (gamenumT g = 0; g < numGames; ++g) {
+		if ((g & 0x1FFF) == 0 && !progress.report(g, numGames)) {
+			endTransaction();
+			return ERROR_UserCancel;
+		}
+		const IndexEntry* ie = getIndexEntry(g);
+		if (ie->GetDeleteFlag())
+			continue;
+		const auto whiteId = ie->GetWhite();
+		const auto blackId = ie->GetBlack();
+		const uint64_t wh = whiteId < nameHash.size()
+		                        ? nameHash[whiteId]
+		                        : nameNormHash("?");
+		const uint64_t bl = blackId < nameHash.size()
+		                        ? nameHash[blackId]
+		                        : nameNormHash("?");
+		index.push_back(
+		    {combineFingerprint(wh, bl, ie->GetDate(), ie->GetResult()), g});
+	}
+	std::sort(index.begin(), index.end());
+
+	// Fingerprints of games imported during this run, used to skip
+	// duplicates within the batch itself.
+	struct BatchEntry {
+		std::vector<std::string> moves;
+	};
+	std::unordered_map<uint64_t, std::vector<BatchEntry>> batch;
+
+	auto findExisting = [&](uint64_t key, const std::vector<std::string>& moves) {
+		auto range = std::equal_range(
+		    index.begin(), index.end(), DupKey{key, 0},
+		    [](const DupKey& a, const DupKey& b) { return a.key < b.key; });
+		for (auto it = range.first; it != range.second; ++it) {
+			Game existing;
+			if (getGame(*getIndexEntry(it->gnum), existing) != OK)
+				continue;
+			if (existing.mainLineUCI() == moves)
+				return true;
+		}
+		return false;
+	};
+
+	CodecPgn pgn;
+	auto res = pgn.open(filename, FMODE_ReadOnly);
+	if (res == OK) {
+		uint64_t nChess960Errors = 0;
+		std::vector<byte> buf;
+		res = CodecPgn::parseGames(progress, pgn, [&](Game& game) {
+			const uint64_t key = combineFingerprint(
+			    nameNormHash(game.GetWhiteStr()),
+			    nameNormHash(game.GetBlackStr()), game.GetDate(),
+			    game.GetResult());
+
+			auto moves = game.mainLineUCI();
+
+			// Skip duplicates against games imported earlier in this batch.
+			auto batchIt = batch.find(key);
+			if (batchIt != batch.end()) {
+				for (const auto& e : batchIt->second) {
+					if (e.moves == moves) {
+						++nSkipped;
+						return OK;
+					}
+				}
+			}
+
+			// Skip duplicates against games already in the database.
+			if (findExisting(key, moves)) {
+				++nSkipped;
+				return OK;
+			}
+
+			buf.clear();
+			auto [ie, tags] = game.Encode(buf);
+			auto err = codec_->addGame(ie, tags, {buf.data(), buf.size()});
+			if (err == ERROR_CodecChess960) {
+				++nChess960Errors;
+				return OK;
+			}
+			if (err != OK)
+				return err;
+
+			++nImported;
+			batch[key].push_back({std::move(moves)});
+			return OK;
 		});
 		errorMsg = pgn.parseErrors();
 		if (nChess960Errors) {

--- a/src/scidbase.cpp
+++ b/src/scidbase.cpp
@@ -395,6 +395,19 @@ uint64_t nameNormHash(const char* name) {
 	return hash;
 }
 
+// Hash an out-of-range name id. An index entry may reference a player-name id
+// that no longer exists in the NameBase (e.g. after a bad edit or upgrade);
+// hashing the id itself keeps games with *different* unknown players in
+// separate fingerprint buckets. Using a constant here (like the "?" name)
+// would make every such game share one bucket and could falsely match two
+// unrelated games that happen to have identical dates, results and moves.
+uint64_t nameHashOfUnknownId(idNumberT id) {
+	uint64_t hash = kFnvOffsetBasis ^ 0x9E3779B97F4A7C15ULL;
+	hash ^= static_cast<uint64_t>(id);
+	hash *= kFnvPrime;
+	return hash;
+}
+
 // Combine the individual fingerprint components into a single 64-bit key.
 uint64_t combineFingerprint(uint64_t whiteHash, uint64_t blackHash, dateT date,
                             resultT result) {
@@ -451,10 +464,10 @@ errorT scidBaseT::importGamesNoDup(ICodecDatabase::Codec dbtype,
 		const auto blackId = ie->GetBlack();
 		const uint64_t wh = whiteId < nameHash.size()
 		                        ? nameHash[whiteId]
-		                        : nameNormHash("?");
+		                        : nameHashOfUnknownId(whiteId);
 		const uint64_t bl = blackId < nameHash.size()
 		                        ? nameHash[blackId]
-		                        : nameNormHash("?");
+		                        : nameHashOfUnknownId(blackId);
 		index.push_back(
 		    {combineFingerprint(wh, bl, ie->GetDate(), ie->GetResult()), g});
 	}

--- a/src/scidbase.h
+++ b/src/scidbase.h
@@ -173,6 +173,9 @@ struct scidBaseT {
 	                   const Progress& progress);
 	errorT importGames(ICodecDatabase::Codec dbtype, const char* filename,
 	                   const Progress& progress, std::string& errorMsg);
+	errorT importGamesNoDup(ICodecDatabase::Codec dbtype, const char* filename,
+	                        const Progress& progress, std::string& errorMsg,
+	                        gamenumT& nImported, gamenumT& nSkipped);
 
 	/**
 	 * Add or replace a game into the database.

--- a/tcl/help/help.tcl
+++ b/tcl/help/help.tcl
@@ -1786,6 +1786,9 @@ set helpText(Import) {<h1>The Import window</h1>
   <p>
   First, you can import the games in the file to an existing database
   with the <menu>Tools: Import file of <a PGN>PGN</a> games...</menu> menu command.
+  Games that are already present in the database are automatically skipped:
+  a game is considered a duplicate when its normalized White and Black player
+  names, exact Date, Result and exact move sequence all match an existing game.
   </p>
   <p>
   The alternative is to open the <a PGN>PGN</a> file directly in scidCommunity. However, PGN
@@ -1947,14 +1950,11 @@ set helpText(ImportLichess) {<h1>Import my Lichess</h1>
   
   <h3>After download</h3>
   <p>
-  Once downloaded, the games are automatically opened in the Games List window.
-  You can then:
-  <ul>
-  <li>Browse through your games</li>
-  <li>Filter by various criteria</li>
-  <li>Import selected games into your database</li>
-  <li>Analyze games with chess engines</li>
-  </ul>
+  Once downloaded, you are asked to choose a destination database (the clipbase or
+  any open database). The games are imported directly into that database, and any
+  games that are already present are automatically skipped. A game is considered a
+  duplicate when its normalized White and Black player names, exact Date, Result and
+  exact move sequence all match an existing game.
   </p>
   
   <h3>Requirements</h3>
@@ -2007,8 +2007,10 @@ set helpText(ImportChessCom) {<h1>Import my chess.com</h1>
   <h3>After download</h3>
   <p>
   Once the download completes, all games are concatenated into a single <a PGN>PGN</a> file
-  and automatically opened in the Games List window. You can then filter, analyze,
-  or import the games into your scidCommunity database.
+  and you are asked to choose a destination database (the clipbase or any open
+  database). The games are imported directly into that database, and any games that
+  are already present (matching White and Black players, Date, Result and exact move
+  sequence) are automatically skipped.
   </p>
   
   <h3>Requirements</h3>

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -558,6 +558,18 @@ translate J StartPos {Почетна позиција}
 translate J Total {Укупно}
 translate J readonly {само за читање}
 
+# Import games (skip duplicates):
+translate J ImportInto {Увези у:}
+translate J Clipbase {Цлипбасе}
+translate J NoWritableDatabases {Нема отворених база података за писање. Прво отворите или креирајте базу података.}
+translate J Imported {Увезено}
+translate J Into {инто}
+translate J Skipped {Скиппед}
+translate J DuplicateGame {дупликат игре}
+translate J DuplicateGames {дупликате игара}
+translate J PgnErrorsWarnings {ПГН грешке/упозорења:}
+translate J NoPgnErrorsWarnings {без ПГН грешака или упозорења.}
+
 # Standard error messages:
 translate J ErrNotOpen {Ово није отворена база података.}
 translate J ErrReadOnly {Ова база података је само за читање; не може се мењати.}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -517,6 +517,18 @@ translate b StartPos {অবস্থান শুরু করুন}
 translate b Total {মোট}
 translate b readonly {শুধুমাত্র পড়ার জন্য}
 
+# Import games (skip duplicates):
+translate b ImportInto {এতে আমদানি করুন:}
+translate b Clipbase {ক্লিপবেস}
+translate b NoWritableDatabases {কোন লিখনযোগ্য ডাটাবেস খোলা নেই. অনুগ্রহ করে প্রথমে একটি ডাটাবেস খুলুন বা তৈরি করুন।}
+translate b Imported {আমদানিকৃত}
+translate b Into {মধ্যে}
+translate b Skipped {এড়িয়ে গেছে}
+translate b DuplicateGame {ডুপ্লিকেট খেলা}
+translate b DuplicateGames {ডুপ্লিকেট গেম}
+translate b PgnErrorsWarnings {PGN ত্রুটি/সতর্কতা:}
+translate b NoPgnErrorsWarnings {কোন PGN ত্রুটি বা সতর্কতা ছাড়া.}
+
 # Standard error messages:
 translate b ErrNotOpen {এটি একটি খোলা ডাটাবেস নয়।}
 translate b ErrReadOnly {এই ডাটাবেস শুধুমাত্র পঠনযোগ্য; এটা পরিবর্তন করা যাবে না।}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -558,6 +558,18 @@ translate g StartPos {Стартова позиция}
 translate g Total {Общо}
 translate g readonly {само за четене}
 
+# Import games (skip duplicates):
+translate g ImportInto {Импортиране в:}
+translate g Clipbase {Clipbase}
+translate g NoWritableDatabases {Няма отворени бази данни с възможност за запис. Моля, първо отворете или създайте база данни.}
+translate g Imported {Внесени}
+translate g Into {в}
+translate g Skipped {Пропуснато}
+translate g DuplicateGame {дублирана игра}
+translate g DuplicateGames {дублирани игри}
+translate g PgnErrorsWarnings {PGN грешки/предупреждения:}
+translate g NoPgnErrorsWarnings {без PGN грешки или предупреждения.}
+
 # Standard error messages:
 translate g ErrNotOpen {Това не е отворена база данни.}
 translate g ErrReadOnly {Тази база данни е само за четене; не може да бъде променено.}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -540,6 +540,18 @@ translate K StartPos {Posició inicial}
 translate K Total {Total}
 translate K readonly {només de lectura}
 
+# Import games (skip duplicates):
+translate K ImportInto {Importa a:}
+translate K Clipbase {Clipbase}
+translate K NoWritableDatabases {No hi ha bases de dades escrites obertes. Obriu o creeu una base de dades primer.}
+translate K Imported {Importat}
+translate K Into {a}
+translate K Skipped {Saltat}
+translate K DuplicateGame {joc duplicat}
+translate K DuplicateGames {jocs duplicats}
+translate K PgnErrorsWarnings {Errors/avisos PGN:}
+translate K NoPgnErrorsWarnings {sense errors ni avisos PGN.}
+
 # Standard error messages:
 translate K ErrNotOpen {La base de dades no está oberta.}
 translate K ErrReadOnly {Aquesta base de dades es només de lectura; no pot ser modificada.}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -493,6 +493,18 @@ translate M StartPos {Start position}
 translate M Total {总计}
 translate M readonly {read-only}
 
+# Import games (skip duplicates):
+translate M ImportInto {导入到：}
+translate M Clipbase {剪辑库}
+translate M NoWritableDatabases {没有打开的可写数据库。请先打开或创建数据库。}
+translate M Imported {进口}
+translate M Into {进入}
+translate M Skipped {跳过}
+translate M DuplicateGame {重复游戏}
+translate M DuplicateGames {重复游戏}
+translate M PgnErrorsWarnings {PGN 错误/警告：}
+translate M NoPgnErrorsWarnings {没有 PGN 错误或警告。}
+
 # Standard error messages:
 translate M ErrNotOpen {This is not an open database.}
 translate M ErrReadOnly {This database is read-only; it cannot be altered.}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -521,6 +521,18 @@ translate C StartPos {Poten pozice}
 translate C Total {Celkem}
 translate C readonly {jen ke ten}
 
+# Import games (skip duplicates):
+translate C ImportInto {Importovat do:}
+translate C Clipbase {Clipbase}
+translate C NoWritableDatabases {Nejsou otevřené žádné zapisovatelné databáze. Nejprve prosím otevřete nebo vytvořte databázi.}
+translate C Imported {Importováno}
+translate C Into {do}
+translate C Skipped {Přeskočeno}
+translate C DuplicateGame {duplicitní hra}
+translate C DuplicateGames {duplicitní hry}
+translate C PgnErrorsWarnings {Chyby/varování PGN:}
+translate C NoPgnErrorsWarnings {bez chyb nebo varování PGN.}
+
 # Standard error messages:
 translate C ErrNotOpen {To nen oteven databze.}
 translate C ErrReadOnly {Tato databze je jen ke ten; neme bt zmnna.}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -551,6 +551,18 @@ translate D StartPos {Stellung}
 translate D Total {Summe}
 translate D readonly {schreibgeschützt}
 
+# Import games (skip duplicates):
+translate D ImportInto {Importieren in:}
+translate D Clipbase {Clipbase}
+translate D NoWritableDatabases {Es sind keine beschreibbaren Datenbanken geöffnet. Bitte öffnen oder erstellen Sie zunächst eine Datenbank.}
+translate D Imported {Importiert}
+translate D Into {hinein}
+translate D Skipped {Übersprungen}
+translate D DuplicateGame {Spiel duplizieren}
+translate D DuplicateGames {doppelte Spiele}
+translate D PgnErrorsWarnings {PGN-Fehler/Warnungen:}
+translate D NoPgnErrorsWarnings {ohne PGN-Fehler oder Warnungen.}
+
 # Standard error messages:
 translate D ErrNotOpen {Dies ist keine geöffnete Datenbank.}
 translate D ErrReadOnly \

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -557,6 +557,18 @@ translate E StartPos {Start position}
 translate E Total {Total}
 translate E readonly {read-only}
 
+# Import games (skip duplicates):
+translate E ImportInto {Import into:}
+translate E Clipbase {Clipbase}
+translate E NoWritableDatabases {There are no writable databases open. Please open or create a database first.}
+translate E Imported {Imported}
+translate E Into {into}
+translate E Skipped {Skipped}
+translate E DuplicateGame {duplicate game}
+translate E DuplicateGames {duplicate games}
+translate E PgnErrorsWarnings {PGN errors/warnings:}
+translate E NoPgnErrorsWarnings {with no PGN errors or warnings.}
+
 # Standard error messages:
 translate E ErrNotOpen {This is not an open database.}
 translate E ErrReadOnly {This database is read-only; it cannot be altered.}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -533,6 +533,18 @@ translate F StartPos {Position de départ}
 translate F Total {Total}
 translate F readonly {lecture seule}
 
+# Import games (skip duplicates):
+translate F ImportInto {Importer dans :}
+translate F Clipbase {Base de clip}
+translate F NoWritableDatabases {Aucune base de données accessible en écriture n'est ouverte. Veuillez d'abord ouvrir ou créer une base de données.}
+translate F Imported {Importé}
+translate F Into {dans}
+translate F Skipped {Sauté}
+translate F DuplicateGame {jeu en double}
+translate F DuplicateGames {jeux en double}
+translate F PgnErrorsWarnings {Erreurs/avertissements PGN :}
+translate F NoPgnErrorsWarnings {sans erreurs ni avertissements PGN.}
+
 # Standard error messages:
 translate F ErrNotOpen {Ceci n'est pas une base ouverte.}
 translate F ErrReadOnly {Cette base est en lecture seule; elle ne peut être modifiée.}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -549,6 +549,18 @@ translate G StartPos {Εναρκτήρια θέση}
 translate G Total {Σύνολο}
 translate G readonly {μόνο για ανάγνωση}
 
+# Import games (skip duplicates):
+translate G ImportInto {Εισαγωγή σε:}
+translate G Clipbase {Clipbase}
+translate G NoWritableDatabases {Δεν υπάρχουν ανοιχτές βάσεις δεδομένων με δυνατότητα εγγραφής. Ανοίξτε ή δημιουργήστε πρώτα μια βάση δεδομένων.}
+translate G Imported {Εισαγόμενος}
+translate G Into {σε}
+translate G Skipped {Παράλειψη}
+translate G DuplicateGame {διπλό παιχνίδι}
+translate G DuplicateGames {διπλά παιχνίδια}
+translate G PgnErrorsWarnings {Σφάλματα/προειδοποιήσεις PGN:}
+translate G NoPgnErrorsWarnings {χωρίς σφάλματα ή προειδοποιήσεις PGN.}
+
 # Standard error messages:
 translate G ErrNotOpen {Αυτή η βάση δεδομένων δεν είναι ανοικτή.}
 translate G ErrReadOnly {Αυτή η βάση δεδομένων είναι μόνον για ανάγνωση. Δεν μπορεί να αντικατασταθεί.}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -518,6 +518,18 @@ translate V StartPos {עמדת התחלה}
 translate V Total {סַך הַכֹּל}
 translate V readonly {לקריאה בלבד}
 
+# Import games (skip duplicates):
+translate V ImportInto {ייבוא ​​לתוך:}
+translate V Clipbase {בסיס קליפ}
+translate V NoWritableDatabases {אין מסדי נתונים פתוחים לכתיבה. אנא פתח או צור מסד נתונים תחילה.}
+translate V Imported {מְיוֹבָּא}
+translate V Into {לְתוֹך}
+translate V Skipped {דילג}
+translate V DuplicateGame {משחק משוכפל}
+translate V DuplicateGames {משחקים כפולים}
+translate V PgnErrorsWarnings {שגיאות/אזהרות PGN:}
+translate V NoPgnErrorsWarnings {ללא שגיאות או אזהרות PGN.}
+
 # Standard error messages:
 translate V ErrNotOpen {זה לא מסד נתונים פתוח.}
 translate V ErrReadOnly {מסד נתונים זה הוא לקריאה בלבד; לא ניתן לשנות אותו.}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -517,6 +517,18 @@ translate h StartPos {आरंभ स्थिति}
 translate h Total {कुल}
 translate h readonly {केवल पढ़ने के लिए}
 
+# Import games (skip duplicates):
+translate h ImportInto {इसमें आयात करें:}
+translate h Clipbase {क्लिपबेस}
+translate h NoWritableDatabases {कोई लिखने योग्य डेटाबेस खुला नहीं है. कृपया पहले एक डेटाबेस खोलें या बनाएं।}
+translate h Imported {आयातित}
+translate h Into {में}
+translate h Skipped {छोड़ा गया}
+translate h DuplicateGame {डुप्लिकेट गेम}
+translate h DuplicateGames {डुप्लिकेट गेम}
+translate h PgnErrorsWarnings {पीजीएन त्रुटियाँ/चेतावनियाँ:}
+translate h NoPgnErrorsWarnings {बिना पीजीएन त्रुटियों या चेतावनियों के।}
+
 # Standard error messages:
 translate h ErrNotOpen {यह एक खुला डेटाबेस नहीं है.}
 translate h ErrReadOnly {यह डेटाबेस केवल पढ़ने योग्य है; इसे बदला नहीं जा सकता.}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -525,6 +525,18 @@ translate H StartPos {Kezdõállás}
 translate H Total {Összesen}
 translate H readonly {read-only} ;# ***
 
+# Import games (skip duplicates):
+translate H ImportInto {Importálás ide:}
+translate H Clipbase {Klipbázis}
+translate H NoWritableDatabases {Nincsenek nyitva írható adatbázisok. Először nyissa meg vagy hozzon létre egy adatbázist.}
+translate H Imported {Importált}
+translate H Into {-ba}
+translate H Skipped {Kihagyva}
+translate H DuplicateGame {duplikált játék}
+translate H DuplicateGames {duplikált játékok}
+translate H PgnErrorsWarnings {PGN hibák/figyelmeztetések:}
+translate H NoPgnErrorsWarnings {PGN hibák vagy figyelmeztetések nélkül.}
+
 # Standard error messages:
 translate H ErrNotOpen {Ez az adatbázis nincs megnyitva.}
 translate H ErrReadOnly {Ez az adatbázis csak olvasható; nem lehet megváltoztatni.}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -525,6 +525,18 @@ translate I StartPos {Posizione iniziale}
 translate I Total {Totale}
 translate I readonly {sola lettura}
 
+# Import games (skip duplicates):
+translate I ImportInto {Importa in:}
+translate I Clipbase {Clipbase}
+translate I NoWritableDatabases {Non ci sono database scrivibili aperti. Per prima cosa apri o crea un database.}
+translate I Imported {Importato}
+translate I Into {in}
+translate I Skipped {Saltato}
+translate I DuplicateGame {gioco duplicato}
+translate I DuplicateGames {giochi duplicati}
+translate I PgnErrorsWarnings {Errori/avvisi PGN:}
+translate I NoPgnErrorsWarnings {senza errori o avvisi PGN.}
+
 # Standard error messages:
 translate I ErrNotOpen {Questo database non è aperto.}
 translate I ErrReadOnly {Questo database è di sola lettura; non può essere modificato.}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -558,6 +558,18 @@ translate A StartPos {開始位置}
 translate A Total {合計}
 translate A readonly {読み取り専用}
 
+# Import games (skip duplicates):
+translate A ImportInto {インポート先:}
+translate A Clipbase {クリップベース}
+translate A NoWritableDatabases {開いている書き込み可能なデータベースがありません。まずデータベースを開くか作成してください。}
+translate A Imported {輸入品}
+translate A Into {の中へ}
+translate A Skipped {スキップされました}
+translate A DuplicateGame {重複したゲーム}
+translate A DuplicateGames {重複したゲーム}
+translate A PgnErrorsWarnings {PGN エラー/警告:}
+translate A NoPgnErrorsWarnings {PGN エラーや警告はありません。}
+
 # Standard error messages:
 translate A ErrNotOpen {これはオープンなデータベースではありません。}
 translate A ErrReadOnly {このデータベースは読み取り専用です。変更することはできません。}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -558,6 +558,18 @@ translate k StartPos {시작 위치}
 translate k Total {총}
 translate k readonly {인구의 승리}
 
+# Import games (skip duplicates):
+translate k ImportInto {다음으로 가져오기:}
+translate k Clipbase {클립베이스}
+translate k NoWritableDatabases {쓰기 가능한 데이터베이스가 열려 있지 않습니다. 먼저 데이터베이스를 열거나 생성하세요.}
+translate k Imported {수입됨}
+translate k Into {~ 안으로}
+translate k Skipped {건너뛰었습니다.}
+translate k DuplicateGame {중복 게임}
+translate k DuplicateGames {중복 게임}
+translate k PgnErrorsWarnings {PGN 오류/경고:}
+translate k NoPgnErrorsWarnings {PGN 오류나 경고가 없습니다.}
+
 # Standard error messages:
 translate k ErrNotOpen {이는 공개 데이터베이스가 아닙니다.}
 translate k ErrReadOnly {이 데이터베이스는 선두입니다. 대응할 수 없습니다.}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -546,6 +546,18 @@ translate N StartPos {Begin stelling}
 translate N Total {Totaal}
 translate N readonly {alleen-lezen}
 
+# Import games (skip duplicates):
+translate N ImportInto {Importeren in:}
+translate N Clipbase {Clipbasis}
+translate N NoWritableDatabases {Er zijn geen beschrijfbare databases geopend. Open of maak eerst een database.}
+translate N Imported {Geïmporteerd}
+translate N Into {naar binnen}
+translate N Skipped {Overgeslagen}
+translate N DuplicateGame {duplicaat spel}
+translate N DuplicateGames {dubbele spellen}
+translate N PgnErrorsWarnings {PGN-fouten/waarschuwingen:}
+translate N NoPgnErrorsWarnings {zonder PGN-fouten of waarschuwingen.}
+
 # Standard error messages:
 translate N ErrNotOpen {Deze database is niet geopend.} ;
 translate N ErrReadOnly {Deze database is alleen lezen; kan niet veranderd worded.} ;

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -527,6 +527,18 @@ translate O StartPos {Utgangsstilling}
 translate O Total {Sammenlagt}
 translate O readonly {skrivebeskyttet}
 
+# Import games (skip duplicates):
+translate O ImportInto {Importer til:}
+translate O Clipbase {Klippbase}
+translate O NoWritableDatabases {Det er ingen skrivbare databaser åpne. Vennligst åpne eller opprett en database først.}
+translate O Imported {Importert}
+translate O Into {inn i}
+translate O Skipped {Hoppet over}
+translate O DuplicateGame {duplikatspill}
+translate O DuplicateGames {dupliserte spill}
+translate O PgnErrorsWarnings {PGN-feil/advarsler:}
+translate O NoPgnErrorsWarnings {uten PGN-feil eller advarsler.}
+
 # Standard error messages:
 translate O ErrNotOpen {This is not an open database.} ;# ***
 translate O ErrReadOnly {This database is read-only; it cannot be altered.} ;# ***

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -459,6 +459,18 @@ translate P StartPos {Pozycja początkowa}
 translate P Total {Razem}
 translate P readonly {tylko do odczytu}
 
+# Import games (skip duplicates):
+translate P ImportInto {Importuj do:}
+translate P Clipbase {Baza klipów}
+translate P NoWritableDatabases {Nie ma otwartych żadnych zapisywalnych baz danych. Najpierw otwórz lub utwórz bazę danych.}
+translate P Imported {Importowany}
+translate P Into {do}
+translate P Skipped {Pominięte}
+translate P DuplicateGame {zduplikowana gra}
+translate P DuplicateGames {duplikaty gier}
+translate P PgnErrorsWarnings {Błędy/ostrzeżenia PGN:}
+translate P NoPgnErrorsWarnings {bez błędów i ostrzeżeń PGN.}
+
 # Standard error messages:
 translate P ErrNotOpen {To nie jest otwarta baza.}
 translate P ErrReadOnly {Ta baza jest tylko do odczytu; nie można jej zmieniać.}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -526,6 +526,18 @@ translate B StartPos {Posição Inicial}
 translate B Total {Total}
 translate B readonly {apenas leitura}
 
+# Import games (skip duplicates):
+translate B ImportInto {Importar para:}
+translate B Clipbase {Base de clipe}
+translate B NoWritableDatabases {Não há bancos de dados graváveis ​​abertos. Abra ou crie um banco de dados primeiro.}
+translate B Imported {Importado}
+translate B Into {em}
+translate B Skipped {Ignorado}
+translate B DuplicateGame {jogo duplicado}
+translate B DuplicateGames {jogos duplicados}
+translate B PgnErrorsWarnings {Erros/avisos de PGN:}
+translate B NoPgnErrorsWarnings {sem erros ou avisos de PGN.}
+
 # Standard error messages:
 translate B ErrNotOpen {Esta base não está aberta.} 
 translate B ErrReadOnly {Esta base  apenas para leitura; não pode ser alterada.} 

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -558,6 +558,18 @@ translate L StartPos {Poziția de pornire}
 translate L Total {Total}
 translate L readonly {numai pentru citire}
 
+# Import games (skip duplicates):
+translate L ImportInto {Import în:}
+translate L Clipbase {Clipbase}
+translate L NoWritableDatabases {Nu există baze de date inscriptibile deschise. Mai întâi deschideți sau creați o bază de date.}
+translate L Imported {Importat}
+translate L Into {în}
+translate L Skipped {Sărit}
+translate L DuplicateGame {joc duplicat}
+translate L DuplicateGames {jocuri duplicate}
+translate L PgnErrorsWarnings {Erori/avertismente PGN:}
+translate L NoPgnErrorsWarnings {fără erori sau avertismente PGN.}
+
 # Standard error messages:
 translate L ErrNotOpen {Aceasta nu este o bază de date deschisă.}
 translate L ErrReadOnly {Această bază de date este doar pentru citire; nu poate fi alterat.}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -524,6 +524,18 @@ translate R StartPos {Стартовая позиция}
 translate R Total {Всего}
 translate R readonly {Только для чтения}
 
+# Import games (skip duplicates):
+translate R ImportInto {Импортировать в:}
+translate R Clipbase {База клипов}
+translate R NoWritableDatabases {Нет открытых доступных для записи баз данных. Пожалуйста, сначала откройте или создайте базу данных.}
+translate R Imported {Импортировано}
+translate R Into {в}
+translate R Skipped {Пропущено}
+translate R DuplicateGame {дубликат игры}
+translate R DuplicateGames {дубликаты игр}
+translate R PgnErrorsWarnings {Ошибки/предупреждения PGN:}
+translate R NoPgnErrorsWarnings {без ошибок или предупреждений PGN.}
+
 # Standard error messages:
 translate R ErrNotOpen {Эта база данных не открыта.}
 translate R ErrReadOnly {Эта база данных только для чтения; она не может быть изменена.}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -782,6 +782,26 @@ translate Y Total {Total}
 # ====== TODO To be translated ======
 translate Y readonly {read-only}
 # ====== TODO To be translated ======
+translate Y ImportInto {Import into:}
+# ====== TODO To be translated ======
+translate Y Clipbase {Clipbase}
+# ====== TODO To be translated ======
+translate Y NoWritableDatabases {There are no writable databases open. Please open or create a database first.}
+# ====== TODO To be translated ======
+translate Y Imported {Imported}
+# ====== TODO To be translated ======
+translate Y Into {into}
+# ====== TODO To be translated ======
+translate Y Skipped {Skipped}
+# ====== TODO To be translated ======
+translate Y DuplicateGame {duplicate game}
+# ====== TODO To be translated ======
+translate Y DuplicateGames {duplicate games}
+# ====== TODO To be translated ======
+translate Y PgnErrorsWarnings {PGN errors/warnings:}
+# ====== TODO To be translated ======
+translate Y NoPgnErrorsWarnings {with no PGN errors or warnings.}
+# ====== TODO To be translated ======
 translate Y ErrNotOpen {This is not an open database.}
 # ====== TODO To be translated ======
 translate Y ErrReadOnly {This database is read-only; it cannot be altered.}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -558,6 +558,18 @@ translate S StartPos {Posición inicial}
 translate S Total {Total}
 translate S readonly {sólo lectura}
 
+# Import games (skip duplicates):
+translate S ImportInto {Importar a:}
+translate S Clipbase {Base de clips}
+translate S NoWritableDatabases {No hay bases de datos grabables abiertas. Primero abra o cree una base de datos.}
+translate S Imported {Importado}
+translate S Into {en}
+translate S Skipped {Saltado}
+translate S DuplicateGame {juego duplicado}
+translate S DuplicateGames {juegos duplicados}
+translate S PgnErrorsWarnings {Errores/advertencias de PGN:}
+translate S NoPgnErrorsWarnings {sin errores ni advertencias de PGN.}
+
 # Standard error messages:
 translate S ErrNotOpen {Esta base de datos no está abierta.}
 translate S ErrReadOnly {Esta base de datos es de sólo lectura; no puede ser cambiada.}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -556,6 +556,18 @@ translate U StartPos {Alkuasema}
 translate U Total {Yhteensä}
 translate U readonly {vain luku}
 
+# Import games (skip duplicates):
+translate U ImportInto {Tuo kohteeseen:}
+translate U Clipbase {Clipbase}
+translate U NoWritableDatabases {Kirjoitettavia tietokantoja ei ole auki. Avaa tai luo ensin tietokanta.}
+translate U Imported {Tuotu}
+translate U Into {sisään}
+translate U Skipped {Ohitettu}
+translate U DuplicateGame {kaksoispeli}
+translate U DuplicateGames {päällekkäisiä pelejä}
+translate U PgnErrorsWarnings {PGN-virheet/varoitukset:}
+translate U NoPgnErrorsWarnings {ilman PGN-virheitä tai varoituksia.}
+
 # Standard error messages:
 translate U ErrNotOpen {Tämä ei ole avoin tietokanta.}
 translate U ErrReadOnly {Tämä tietokanta on vain luku -moodissa; sitä ei voi muokata.}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -517,6 +517,18 @@ translate Z StartPos {Nafasi ya kuanza}
 translate Z Total {Jumla}
 translate Z readonly {kusoma tu}
 
+# Import games (skip duplicates):
+translate Z ImportInto {Ingiza kwenye:}
+translate Z Clipbase {Clipbase}
+translate Z NoWritableDatabases {Hakuna hifadhidata zinazoweza kuandikwa zilizofunguliwa. Tafadhali fungua au unda hifadhidata kwanza.}
+translate Z Imported {Imeingizwa}
+translate Z Into {ndani}
+translate Z Skipped {Imerukwa}
+translate Z DuplicateGame {mchezo wa kurudia}
+translate Z DuplicateGames {michezo ya nakala}
+translate Z PgnErrorsWarnings {Makosa/maonyo ya PGN:}
+translate Z NoPgnErrorsWarnings {bila makosa au maonyo ya PGN.}
+
 # Standard error messages:
 translate Z ErrNotOpen {Hii si hifadhidata iliyo wazi.}
 translate Z ErrReadOnly {Hifadhidata hii ni ya kusoma tu; haiwezi kubadilishwa.}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -528,6 +528,18 @@ translate W StartPos {Utgångsställning}
 translate W Total {Totalt}
 translate W readonly {bara läsbar} ;# ***
 
+# Import games (skip duplicates):
+translate W ImportInto {Importera till:}
+translate W Clipbase {Clipbase}
+translate W NoWritableDatabases {Det finns inga skrivbara databaser öppna. Öppna eller skapa en databas först.}
+translate W Imported {Importerad}
+translate W Into {till}
+translate W Skipped {Hoppade över}
+translate W DuplicateGame {dubblettspel}
+translate W DuplicateGames {dubbletter av spel}
+translate W PgnErrorsWarnings {PGN-fel/varningar:}
+translate W NoPgnErrorsWarnings {utan PGN-fel eller varningar.}
+
 # Standard error messages:
 translate W ErrNotOpen {Databasen är inte öppen.}
 translate W ErrReadOnly {Databasen är skrivskyddad. Du kan inte ändra i den.}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -521,6 +521,18 @@ translate T StartPos {Başlangıç ​​konumu}
 translate T Total {Toplam}
 translate T readonly {salt okunur}
 
+# Import games (skip duplicates):
+translate T ImportInto {Şuraya aktar:}
+translate T Clipbase {Klip tabanı}
+translate T NoWritableDatabases {Açık yazılabilir veritabanları yok. Lütfen önce bir veritabanı açın veya oluşturun.}
+translate T Imported {İthal}
+translate T Into {içine}
+translate T Skipped {Atlandı}
+translate T DuplicateGame {yinelenen oyun}
+translate T DuplicateGames {yinelenen oyunlar}
+translate T PgnErrorsWarnings {PGN hataları/uyarıları:}
+translate T NoPgnErrorsWarnings {PGN hatası veya uyarısı olmadan.}
+
 # Standard error messages:
 translate T ErrNotOpen {Bu açık bir veritabanı değil.}
 translate T ErrReadOnly {Bu veritabanı salt okunurdur; değiştirilemez.}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -518,6 +518,18 @@ translate Q StartPos {Стартова позиція}
 translate Q Total {Всього}
 translate Q readonly {тільки для читання}
 
+# Import games (skip duplicates):
+translate Q ImportInto {Імпортувати в:}
+translate Q Clipbase {Кліпбаза}
+translate Q NoWritableDatabases {Немає відкритих баз даних для запису. Спочатку відкрийте або створіть базу даних.}
+translate Q Imported {Імпортні}
+translate Q Into {в}
+translate Q Skipped {Пропущено}
+translate Q DuplicateGame {дублююча гра}
+translate Q DuplicateGames {дубльовані ігри}
+translate Q PgnErrorsWarnings {Помилки/попередження PGN:}
+translate Q NoPgnErrorsWarnings {без помилок або попереджень PGN.}
+
 # Standard error messages:
 translate Q ErrNotOpen {Це не відкрита база даних.}
 translate Q ErrReadOnly {Ця база даних доступна лише для читання; це не можна змінити.}

--- a/tcl/tools/chesscom.tcl
+++ b/tcl/tools/chesscom.tcl
@@ -294,7 +294,8 @@ proc ::chesscom::downloadWithHTTP {apiurl outfile} {
 }
 
 # ::chesscom::openPGN
-#   Open concatenated PGN and clean up
+#   Import the concatenated PGN into a user-chosen database, skipping
+#   duplicate games, then clean up.
 proc ::chesscom::openPGN {pgnfile username startYear} {
   set ::chesscom::downloading 0
   catch {.menu.file entryconfig "Import my chess.com*" -state normal}
@@ -305,13 +306,11 @@ proc ::chesscom::openPGN {pgnfile username startYear} {
   }
 
   if {[catch {
-    ::file::Open $pgnfile
-    tk_messageBox -icon info -type ok -title "Chess.com Import Complete" \
-      -message "Successfully downloaded games for Chess.com user '$username' starting from $startYear.\n\nThe games are now open in the Games List window."
+    importPgnNoDup $pgnfile "Import My Chess.com Games"
     after 5000 [list catch [list file delete -force $::chesscom::tempDir]]
   } err]} {
     catch {file delete -force $::chesscom::tempDir}
-    error "Error opening PGN file: $err"
+    error "Error importing PGN file: $err"
   }
 }
 

--- a/tcl/tools/chesscom.tcl
+++ b/tcl/tools/chesscom.tcl
@@ -306,9 +306,12 @@ proc ::chesscom::openPGN {pgnfile username startYear} {
   }
 
   # importPgnNoDup reports its own outcome (success, import error, or
-  # cancellation), so no further error handling is needed here.
-  importPgnNoDup $pgnfile "Import My Chess.com Games"
-  after 5000 [list catch [list file delete -force $::chesscom::tempDir]]
+  # cancellation). Only on success is the downloaded PGN deleted; on
+  # failure/cancel it is kept so a retry does not require downloading
+  # everything again.
+  if {[importPgnNoDup $pgnfile "Import My Chess.com Games"]} {
+    after 5000 [list catch [list file delete -force $::chesscom::tempDir]]
+  }
 }
 
 # ::chesscom::getTempDir

--- a/tcl/tools/chesscom.tcl
+++ b/tcl/tools/chesscom.tcl
@@ -305,13 +305,10 @@ proc ::chesscom::openPGN {pgnfile username startYear} {
     error "No games were downloaded. Please check the username or start year/month."
   }
 
-  if {[catch {
-    importPgnNoDup $pgnfile "Import My Chess.com Games"
-    after 5000 [list catch [list file delete -force $::chesscom::tempDir]]
-  } err]} {
-    catch {file delete -force $::chesscom::tempDir}
-    error "Error importing PGN file: $err"
-  }
+  # importPgnNoDup reports its own outcome (success, import error, or
+  # cancellation), so no further error handling is needed here.
+  importPgnNoDup $pgnfile "Import My Chess.com Games"
+  after 5000 [list catch [list file delete -force $::chesscom::tempDir]]
 }
 
 # ::chesscom::getTempDir

--- a/tcl/tools/import.tcl
+++ b/tcl/tools/import.tcl
@@ -231,7 +231,9 @@ proc importPgnFile {{base} {fnames ""}} {
 #   sequence all match a game already present (or an earlier game in the
 #   same batch) are skipped.
 #
-#   Returns 1 on success, 0 if the user cancelled.
+#   Reports the outcome itself (success summary, import error, or the
+#   "no writable database" message) and returns 1 on success, 0 otherwise
+#   (cancelled, no writable database, or import failure). It never raises.
 proc importPgnNoDup {pgnfile title} {
   set bases {}
   foreach i [sc_base list] {
@@ -292,7 +294,7 @@ proc importPgnNoDup {pgnfile title} {
   closeProgressWindow true
   if {$err} {
     ERROR::MessageBox
-    error $result
+    return 0
   }
 
   set nImported [lindex $result 0]

--- a/tcl/tools/import.tcl
+++ b/tcl/tools/import.tcl
@@ -183,21 +183,26 @@ proc importPgnFile {{base} {fnames ""}} {
     $w.text insert end "$::tr(ImportingFrom) [file tail $fname]...\n"
     $w.text configure -state disabled
     progressBarSet $w.progress 401 21
-    set err [catch {sc_base import $base $fname} result]
+    set err [catch {sc_base import_nodup $base $fname} result]
     $w.text configure -state normal
     if {$err == 1} {
       set autoclose 0
       $w.text insert end "[ERROR::getErrorMsg]\n$result\n\n"
     } else {
       set nImported [lindex $result 0]
-      set warnings [lindex $result 1]
-      set str "Imported $nImported "
-      if {$nImported == 1} { append str "game" } else { append str "games" }
+      set nSkipped  [lindex $result 1]
+      set warnings  [lindex $result 2]
+      set str "[tr Imported] $nImported "
+      if {$nImported == 1} { append str [tr game] } else { append str [tr games] }
+      if {$nSkipped > 0} {
+        append str ", [tr Skipped] $nSkipped "
+        if {$nSkipped == 1} { append str [tr DuplicateGame] } else { append str [tr DuplicateGames] }
+      }
       if {$warnings == ""} {
-        append str " with no PGN errors or warnings."
+        append str " [tr NoPgnErrorsWarnings]"
       } else {
         set autoclose 0
-        append str ".\nPGN errors/warnings:\n$warnings"
+        append str ".\n[tr PgnErrorsWarnings]\n$warnings"
       }
       $w.text insert end "$str\n\n"
       if {$err == 3} {
@@ -216,6 +221,101 @@ proc importPgnFile {{base} {fnames ""}} {
 
   after idle "::notify::DatabaseModified $base"
   if { $autoclose } { destroy $w }
+}
+
+### Import a PGN file into a chosen database, skipping duplicate games.
+#
+#   Prompts the user to pick a destination database (the clipbase or any
+#   open, writable database) and imports the PGN file into it. Games whose
+#   normalized White and Black players, exact Date, Result and exact move
+#   sequence all match a game already present (or an earlier game in the
+#   same batch) are skipped.
+#
+#   Returns 1 on success, 0 if the user cancelled.
+proc importPgnNoDup {pgnfile title} {
+  set bases {}
+  foreach i [sc_base list] {
+    if {[sc_base isReadOnly $i]} { continue }
+    if {$i == $::clipbase_db} {
+      lappend bases [list $i [tr Clipbase]]
+    } else {
+      lappend bases [list $i "Base $i: [::file::BaseName $i]"]
+    }
+  }
+  if {[llength $bases] == 0} {
+    tk_messageBox -icon error -type ok -title $title \
+      -message [tr NoWritableDatabases]
+    return 0
+  }
+
+  set w .importBaseDialog
+  if {[winfo exists $w]} { destroy $w }
+  toplevel $w
+  wm title $w $title
+  wm resizable $w 0 0
+  setWinLocation $w
+
+  # Default to the current database if it is writable, else the first one.
+  set ::importBaseChoice [lindex [lindex $bases 0] 0]
+  if {$::curr_db != $::clipbase_db && ![sc_base isReadOnly $::curr_db]} {
+    set ::importBaseChoice $::curr_db
+  }
+
+  ttk::frame $w.content -padding {10 10}
+  ttk::label $w.content.lbl -text [tr ImportInto] -anchor w
+  pack $w.content.lbl -side top -anchor w -pady {0 6}
+  foreach b $bases {
+    lassign $b baseId label
+    ttk::radiobutton $w.content.rb$baseId -text $label \
+      -variable ::importBaseChoice -value $baseId
+    pack $w.content.rb$baseId -side top -anchor w
+  }
+  pack $w.content -side top -fill both -expand 1
+
+  ttk::frame $w.buttons -padding {10 10}
+  ttk::button $w.buttons.ok -text [tr Import] -command "set ::importBaseResult 1; destroy $w"
+  ttk::button $w.buttons.cancel -text [tr Cancel] -command "set ::importBaseResult 0; destroy $w"
+  pack $w.buttons.ok $w.buttons.cancel -side left -padx 5
+  pack $w.buttons -side top -fill x
+
+  set ::importBaseResult 0
+  bind $w <Return> "$w.buttons.ok invoke"
+  bind $w <Escape> "$w.buttons.cancel invoke"
+  grab $w
+  tkwait window $w
+
+  if {!$::importBaseResult} { return 0 }
+  set base $::importBaseChoice
+
+  progressWindow "scidCommunity" "$::tr(ImportingIn) [::file::BaseName $base]..." $::tr(Cancel)
+  set err [catch {sc_base import_nodup $base $pgnfile} result]
+  closeProgressWindow true
+  if {$err} {
+    ERROR::MessageBox
+    error $result
+  }
+
+  set nImported [lindex $result 0]
+  set nSkipped  [lindex $result 1]
+  set warnings  [lindex $result 2]
+
+  after idle "::notify::DatabaseModified $base"
+
+  set msg "[tr Imported] $nImported "
+  if {$nImported == 1} { append msg [tr game] } else { append msg [tr games] }
+  append msg " [tr Into] [::file::BaseName $base]."
+  if {$nSkipped > 0} {
+    if {$nSkipped == 1} {
+      append msg "\n\n[tr Skipped] $nSkipped [tr DuplicateGame]."
+    } else {
+      append msg "\n\n[tr Skipped] $nSkipped [tr DuplicateGames]."
+    }
+  }
+  if {$warnings ne ""} {
+    append msg "\n\n[tr PgnErrorsWarnings]\n$warnings"
+  }
+  tk_messageBox -icon info -type ok -title $title -message $msg
+  return 1
 }
 
 ###

--- a/tcl/tools/lichess.tcl
+++ b/tcl/tools/lichess.tcl
@@ -383,12 +383,12 @@ proc ::lichess::openPGN {pgnfile username} {
   
   # Import the PGN file into a database chosen by the user (clipbase or any
   # open database), skipping duplicates. importPgnNoDup reports its own
-  # outcome (success, import error, or cancellation), so no further error
-  # handling is needed here.
-  importPgnNoDup $pgnfile "Import My Lichess Games"
-  
-  # Clean up temp directory after a delay to allow the file to be read
-  after 5000 [list catch [list file delete -force $::lichess::tempDir]]
+  # outcome (success, import error, or cancellation). Only on success is the
+  # downloaded PGN deleted; on failure/cancel it is kept so a retry does not
+  # require downloading everything again.
+  if {[importPgnNoDup $pgnfile "Import My Lichess Games"]} {
+    after 5000 [list catch [list file delete -force $::lichess::tempDir]]
+  }
 }
 
 # lichess::getTempDir

--- a/tcl/tools/lichess.tcl
+++ b/tcl/tools/lichess.tcl
@@ -373,29 +373,25 @@ proc ::lichess::downloadWithHTTP {apiurl pgnfile {userAgent "Mozilla/5.0"} {toke
 }
 
 # lichess::openPGN
-#   Open the downloaded PGN file in a Games List window
+#   Import the downloaded PGN file into a user-chosen database, skipping
+#   duplicate games.
 #
 proc ::lichess::openPGN {pgnfile username} {
   # Re-enable menu
   set ::lichess::downloading 0
   catch {.menu.file entryconfig "Import my Lichess*" -state normal}
   
-  # Import the PGN file into a temporary database
-  # Use the same approach as TWIC by invoking the standard file importer
+  # Import the PGN file into a database chosen by the user (clipbase or any
+  # open database), skipping duplicates.
   if {[catch {
-    # Open the PGN file via the existing file import flow
-    ::file::Open $pgnfile
+    importPgnNoDup $pgnfile "Import My Lichess Games"
     
-    # Show success message
-    tk_messageBox -icon info -type ok -title "Lichess Import Complete" \
-      -message "Successfully downloaded games for Lichess user '$username'.\n\nThe games are now open in the Games List window."
-    
-    # Clean up temp directory after a delay to allow file to be read
+    # Clean up temp directory after a delay to allow the file to be read
     after 5000 [list catch [list file delete -force $::lichess::tempDir]]
   } err]} {
     # Clean up on error
     catch {file delete -force $::lichess::tempDir}
-    error "Error opening PGN file: $err"
+    error "Error importing PGN file: $err"
   }
 }
 

--- a/tcl/tools/lichess.tcl
+++ b/tcl/tools/lichess.tcl
@@ -382,17 +382,13 @@ proc ::lichess::openPGN {pgnfile username} {
   catch {.menu.file entryconfig "Import my Lichess*" -state normal}
   
   # Import the PGN file into a database chosen by the user (clipbase or any
-  # open database), skipping duplicates.
-  if {[catch {
-    importPgnNoDup $pgnfile "Import My Lichess Games"
-    
-    # Clean up temp directory after a delay to allow the file to be read
-    after 5000 [list catch [list file delete -force $::lichess::tempDir]]
-  } err]} {
-    # Clean up on error
-    catch {file delete -force $::lichess::tempDir}
-    error "Error importing PGN file: $err"
-  }
+  # open database), skipping duplicates. importPgnNoDup reports its own
+  # outcome (success, import error, or cancellation), so no further error
+  # handling is needed here.
+  importPgnNoDup $pgnfile "Import My Lichess Games"
+  
+  # Clean up temp directory after a delay to allow the file to be read
+  after 5000 [list catch [list file delete -force $::lichess::tempDir]]
 }
 
 # lichess::getTempDir

--- a/tcl/utils/win.tcl
+++ b/tcl/utils/win.tcl
@@ -281,6 +281,10 @@ proc ::win::createDialog {w {y 10}} {
 	catch { wm transient $w . }
 	catch { wm group $w . }
 	catch { wm attributes $w -type dialog }
+
+	if {[isHyprlandSession]} {
+		after idle [list centerWindowHyprland $w]
+	}
 }
 
 # Make sure that a window is visible

--- a/tcl/windows.tcl
+++ b/tcl/windows.tcl
@@ -103,7 +103,26 @@ proc setWinLocation {win} {
   if {[info exists winX${suffix}($win)]  &&  [info exists winY${suffix}($win)]  && \
         [set winX${suffix}($win)] >= 0  &&  [set winY${suffix}($win)] >= 0} {
     catch [list wm geometry $win "+[set winX${suffix}($win)]+[set winY${suffix}($win)]"]
+  } elseif {[isHyprlandSession]} {
+    after idle [list centerWindowHyprland $win]
   }
+}
+
+# Hyprland (XWayland) does not center floating windows, so they appear at the
+# top-left of the screen, often partially off-screen. Center a toplevel on its
+# screen once its contents have been laid out. This is only used under
+# Hyprland, so KDE, GNOME, Windows and other desktops keep their native
+# window placement.
+proc centerWindowHyprland {w} {
+  if {![winfo exists $w]} { return }
+  update idletasks
+  set ww [winfo reqwidth $w]
+  set wh [winfo reqheight $w]
+  set x [expr {([winfo screenwidth $w] - $ww) / 2}]
+  set y [expr {([winfo screenheight $w] - $wh) / 2}]
+  if {$x < 0} { set x 0 }
+  if {$y < 0} { set y 0 }
+  catch { wm geometry $w +$x+$y }
 }
 
 proc setWinSize {win} {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Import PGN games while automatically skipping duplicates, including duplicates within the same file.
  - View imported and skipped game counts, along with PGN errors or warnings.
  - Choose a destination database, including the clipbase, for Lichess and Chess.com imports.
  - Dialogs now center correctly in Hyprland sessions.

- **Documentation**
  - Updated import help to explain duplicate detection and direct database importing.

- **Localization**
  - Added import-related translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->