### PR TITLE
Add strip comments, not annotations

### DIFF
--- a/src/tkscid.cpp
+++ b/src/tkscid.cpp
@@ -4030,8 +4030,10 @@ int sc_game_strip(ClientData, Tcl_Interp *ti, int argc, const char **argv) {
     db->game->strip(true, false, false);
   } else if (argc == 3 && !strcmp("comments", argv[2])) {
     db->game->strip(false, true, true);
+  } else if (argc == 3 && !strcmp("commentsnonag", argv[2])) {
+    db->game->strip(false, true, false);
   } else {
-    return errorResult(ti, "Usage: sc_game strip [comments|variations]");
+    return errorResult(ti, "Usage: sc_game strip [comments|variations|commentsnonag]");
   }
   db->gameAltered = true;
   return UI_Result(ti, OK);

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -109,6 +109,8 @@ menuText J EditUndo "Поништи" 0 {Опозови последњу пром
 menuText J EditRedo "Понови" 0 {Понови последњу промену игре}
 menuText J EditStripComments "Коментари" 0 \
   {Уклоните све коментаре и белешке из ове игре}
+menuText J EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText J EditStripVars "Варијације" 0 {Скините све варијације из ове игре}
 menuText J EditStripAll "Коментари и варијације" 0 \
   {Уклоните све коментаре, напомене и варијације из ове игре}

--- a/tcl/lang/SerbCyr.tcl
+++ b/tcl/lang/SerbCyr.tcl
@@ -109,8 +109,8 @@ menuText J EditUndo "Поништи" 0 {Опозови последњу пром
 menuText J EditRedo "Понови" 0 {Понови последњу промену игре}
 menuText J EditStripComments "Коментари" 0 \
   {Уклоните све коментаре и белешке из ове игре}
-menuText J EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText J EditStripCommentsNotAnnos "Коментари, не напомене" 0 \
+  {Уклоните коментаре, али задржите напомене (NAG) из ове партије}
 menuText J EditStripVars "Варијације" 0 {Скините све варијације из ове игре}
 menuText J EditStripAll "Коментари и варијације" 0 \
   {Уклоните све коментаре, напомене и варијације из ове игре}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -68,8 +68,8 @@ menuText b EditUndo "পূর্বাবস্থায় ফেরান" 0 
 menuText b EditRedo "আবার করুন" 0 {শেষ খেলা পরিবর্তন পুনরায় করুন}
 menuText b EditStripComments "মন্তব্য" 0 \
   {এই গেম থেকে সমস্ত মন্তব্য এবং টীকা ছিনিয়ে নিন}
-menuText b EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText b EditStripCommentsNotAnnos "মন্তব্য, টীকা নয়" 0 \
+  {এই গেম থেকে মন্তব্যগুলি সরান, তবে টীকাগুলি (NAGs) রাখুন}
 menuText b EditStripVars "বৈচিত্র" 0 {এই গেম থেকে সমস্ত বৈচিত্র বাদ দিন}
 menuText b EditStripAll "মন্তব্য এবং বৈচিত্র" 0 \
   {এই গেম থেকে সমস্ত মন্তব্য, টীকা এবং বৈচিত্র বাদ দিন}

--- a/tcl/lang/bengali.tcl
+++ b/tcl/lang/bengali.tcl
@@ -68,6 +68,8 @@ menuText b EditUndo "পূর্বাবস্থায় ফেরান" 0 
 menuText b EditRedo "আবার করুন" 0 {শেষ খেলা পরিবর্তন পুনরায় করুন}
 menuText b EditStripComments "মন্তব্য" 0 \
   {এই গেম থেকে সমস্ত মন্তব্য এবং টীকা ছিনিয়ে নিন}
+menuText b EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText b EditStripVars "বৈচিত্র" 0 {এই গেম থেকে সমস্ত বৈচিত্র বাদ দিন}
 menuText b EditStripAll "মন্তব্য এবং বৈচিত্র" 0 \
   {এই গেম থেকে সমস্ত মন্তব্য, টীকা এবং বৈচিত্র বাদ দিন}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -109,8 +109,8 @@ menuText g EditUndo "Отмяна" 0 {Отмяна на последната п�
 menuText g EditRedo "Повторете" 0 {Повторете последната промяна в играта}
 menuText g EditStripComments "Коментари" 0 \
   {Премахнете всички коментари и анотации от тази игра}
-menuText g EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText g EditStripCommentsNotAnnos "Коментари, без анотации" 0 \
+  {Премахнете коментарите, но запазете анотациите (NAGs) от тази игра}
 menuText g EditStripVars "Вариации" 0 {Отстранете всички варианти от тази игра}
 menuText g EditStripAll "Коментари и вариации" 0 \
   {Премахнете всички коментари, анотации и вариации от тази игра}

--- a/tcl/lang/bulgarian.tcl
+++ b/tcl/lang/bulgarian.tcl
@@ -109,6 +109,8 @@ menuText g EditUndo "Отмяна" 0 {Отмяна на последната п�
 menuText g EditRedo "Повторете" 0 {Повторете последната промяна в играта}
 menuText g EditStripComments "Коментари" 0 \
   {Премахнете всички коментари и анотации от тази игра}
+menuText g EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText g EditStripVars "Вариации" 0 {Отстранете всички варианти от тази игра}
 menuText g EditStripAll "Коментари и вариации" 0 \
   {Премахнете всички коментари, анотации и вариации от тази игра}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -75,8 +75,8 @@ menuText K EditUndo "Desfés" 0 {Desfés l'últim canvi de la partida}
 menuText K EditRedo "Refés" 0 {Refés l'últim canvi de la partida}
 menuText K EditStripComments "Comentaris" 0 \
   {Esborra tots els comentaris i variants d'aquesta partida}
-menuText K EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText K EditStripCommentsNotAnnos "Comentaris, no anotacions" 0 \
+  {Esborra els comentaris, però conserva les anotacions (NAGs) d'aquesta partida}
 menuText K EditStripVars "Variants" 0 {Esborra totes les variants d'aquesta partida}
 menuText K EditStripAll "Comentaris i variacions" 0 \
   {Elimina tots els comentaris, anotacions i variacions d'aquest joc}

--- a/tcl/lang/catalan.tcl
+++ b/tcl/lang/catalan.tcl
@@ -75,6 +75,8 @@ menuText K EditUndo "Desfés" 0 {Desfés l'últim canvi de la partida}
 menuText K EditRedo "Refés" 0 {Refés l'últim canvi de la partida}
 menuText K EditStripComments "Comentaris" 0 \
   {Esborra tots els comentaris i variants d'aquesta partida}
+menuText K EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText K EditStripVars "Variants" 0 {Esborra totes les variants d'aquesta partida}
 menuText K EditStripAll "Comentaris i variacions" 0 \
   {Elimina tots els comentaris, anotacions i variacions d'aquest joc}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -65,6 +65,8 @@ menuText M EditStrip "删除" 0 {从此游戏中删除注释或变化}
 menuText M EditUndo "撤销" 0 {撤销上次游戏更改}
 menuText M EditRedo "重做" 0 {重做上次游戏更改}
 menuText M EditStripComments "注释" 0 {从此游戏中删除所有注释和标注}
+menuText M EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText M EditStripVars "变化" 0 {从此游戏中删除所有变化}
 menuText M EditStripAll "评论和变化" 0 \
   {删除该游戏的所有评论、注释和变体}

--- a/tcl/lang/chinese.tcl
+++ b/tcl/lang/chinese.tcl
@@ -65,8 +65,8 @@ menuText M EditStrip "删除" 0 {从此游戏中删除注释或变化}
 menuText M EditUndo "撤销" 0 {撤销上次游戏更改}
 menuText M EditRedo "重做" 0 {重做上次游戏更改}
 menuText M EditStripComments "注释" 0 {从此游戏中删除所有注释和标注}
-menuText M EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText M EditStripCommentsNotAnnos "注释，不含标注" 0 \
+  {从此游戏中删除注释，但保留标注（NAG）}
 menuText M EditStripVars "变化" 0 {从此游戏中删除所有变化}
 menuText M EditStripAll "评论和变化" 0 \
   {删除该游戏的所有评论、注释和变体}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -70,8 +70,8 @@ menuText C EditUndo "Vzt zpt" 0 {Vzt zpt posledn zmnu v partii}
 menuText C EditRedo "Pedlat" 0 {Opakujte posledn zmnu hry}
 menuText C EditStripComments "Komente" 0 \
   {Odstranit vechny poznmky a anotace z tto partie}
-menuText C EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText C EditStripCommentsNotAnnos "Komentáře, ne anotace" 0 \
+  {Odstranit komentáře, ale ponechat anotace (NAG) v této partii}
 menuText C EditStripVars "Varianty" 0 {Odstranit vechny varianty z tto partie}
 menuText C EditStripAll "Komentáře a variace" 0 \
   {Odstraňte z této hry všechny komentáře, anotace a variace}

--- a/tcl/lang/czech.tcl
+++ b/tcl/lang/czech.tcl
@@ -70,6 +70,8 @@ menuText C EditUndo "Vzt zpt" 0 {Vzt zpt posledn zmnu v partii}
 menuText C EditRedo "Pedlat" 0 {Opakujte posledn zmnu hry}
 menuText C EditStripComments "Komente" 0 \
   {Odstranit vechny poznmky a anotace z tto partie}
+menuText C EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText C EditStripVars "Varianty" 0 {Odstranit vechny varianty z tto partie}
 menuText C EditStripAll "Komentáře a variace" 0 \
   {Odstraňte z této hry všechny komentáře, anotace a variace}

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -89,8 +89,8 @@ menuText D EditUndo "Rückgängig" 0 {Macht die letzte Änderung rückgängig}
 menuText D EditRedo "Wiederherstellen" 0 {Redo last game change}
 menuText D EditStripComments "Kommentare" 0 \
   {Alle Kommentare und Kommentarzeichen aus dieser Partie entfernen}
-menuText D EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText D EditStripCommentsNotAnnos "Kommentare, keine Anmerkungen" 0 \
+  {Kommentare entfernen, aber Anmerkungen (NAGs) dieser Partie beibehalten}
 menuText D EditStripVars "Varianten" 0 \
   {Alle Varianten aus der Partie entfernen}
 menuText D EditStripAll "Kommentare und Variationen" 0 \

--- a/tcl/lang/deutsch.tcl
+++ b/tcl/lang/deutsch.tcl
@@ -89,6 +89,8 @@ menuText D EditUndo "Rückgängig" 0 {Macht die letzte Änderung rückgängig}
 menuText D EditRedo "Wiederherstellen" 0 {Redo last game change}
 menuText D EditStripComments "Kommentare" 0 \
   {Alle Kommentare und Kommentarzeichen aus dieser Partie entfernen}
+menuText D EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText D EditStripVars "Varianten" 0 \
   {Alle Varianten aus der Partie entfernen}
 menuText D EditStripAll "Kommentare und Variationen" 0 \

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -108,7 +108,7 @@ menuText E EditUndo "Undo" 0 {Undo last game change}
 menuText E EditRedo "Redo" 0 {Redo last game change}
 menuText E EditStripComments "Comments" 0 \
   {Strip all comments and annotations from this game}
-menuText E EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+menuText E EditStripCommentsNotAnnos "Comments, not annotations" 14 \
   {Strip comments but keep annotations (NAGs) from this game}
 menuText E EditStripVars "Variations" 0 {Strip all variations from this game}
 menuText E EditStripAll "Comments and Variations" 0 \

--- a/tcl/lang/english.tcl
+++ b/tcl/lang/english.tcl
@@ -108,6 +108,8 @@ menuText E EditUndo "Undo" 0 {Undo last game change}
 menuText E EditRedo "Redo" 0 {Redo last game change}
 menuText E EditStripComments "Comments" 0 \
   {Strip all comments and annotations from this game}
+menuText E EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText E EditStripVars "Variations" 0 {Strip all variations from this game}
 menuText E EditStripAll "Comments and Variations" 0 \
   {Strip all comments, annotations and variations from this game}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -72,6 +72,8 @@ menuText F EditUndo "Annuler" 0 {Annuler la dernière modification de cette part
 menuText F EditRedo "Rétablir" 0 {Refaire la dernière modification de cette partie}
 menuText F EditStripComments "Commentaires" 0 \
   {Épurer cette partie de tous les commentaires et annotations}
+menuText F EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText F EditStripVars "Variantes" 0 {Épurer cette partie des variantes}
 menuText F EditStripAll "Commentaires et variantes" 0 \
   {Supprimez tous les commentaires, annotations et variantes de ce jeu}

--- a/tcl/lang/francais.tcl
+++ b/tcl/lang/francais.tcl
@@ -72,8 +72,8 @@ menuText F EditUndo "Annuler" 0 {Annuler la dernière modification de cette part
 menuText F EditRedo "Rétablir" 0 {Refaire la dernière modification de cette partie}
 menuText F EditStripComments "Commentaires" 0 \
   {Épurer cette partie de tous les commentaires et annotations}
-menuText F EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText F EditStripCommentsNotAnnos "Commentaires, pas les annotations" 0 \
+  {Épurer cette partie des commentaires, mais conserver les annotations (NAGs)}
 menuText F EditStripVars "Variantes" 0 {Épurer cette partie des variantes}
 menuText F EditStripAll "Commentaires et variantes" 0 \
   {Supprimez tous les commentaires, annotations et variantes de ce jeu}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -99,6 +99,8 @@ menuText G EditUndo "Επαναφορά" 0 {Επαναφέρετε την τελ
 menuText G EditRedo "Ξανακάνω" 0 {Επαναλάβετε την τελευταία αλλαγή παιχνιδιού}
 menuText G EditStripComments "Σχόλια" 0 \
   {Απομακρύνετε όλα τα σχόλια και τον υπομνηματισμό από αυτή τη παρτίδα}
+menuText G EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText G EditStripVars "Βαριάντες" 0 {Απομακρύνετε όλες τις βαριάντες από αυτή τη παρτίδα}
 menuText G EditStripAll "Σχόλια και παραλλαγές" 0 \
   {Αφαιρέστε όλα τα σχόλια, τους σχολιασμούς και τις παραλλαγές από αυτό το παιχνίδι}

--- a/tcl/lang/greek.tcl
+++ b/tcl/lang/greek.tcl
@@ -99,8 +99,8 @@ menuText G EditUndo "Επαναφορά" 0 {Επαναφέρετε την τελ
 menuText G EditRedo "Ξανακάνω" 0 {Επαναλάβετε την τελευταία αλλαγή παιχνιδιού}
 menuText G EditStripComments "Σχόλια" 0 \
   {Απομακρύνετε όλα τα σχόλια και τον υπομνηματισμό από αυτή τη παρτίδα}
-menuText G EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText G EditStripCommentsNotAnnos "Σχόλια, όχι σχολιασμοί" 0 \
+  {Απομακρύνετε τα σχόλια, αλλά διατηρήστε τους σχολιασμούς (NAGs) σε αυτή την παρτίδα}
 menuText G EditStripVars "Βαριάντες" 0 {Απομακρύνετε όλες τις βαριάντες από αυτή τη παρτίδα}
 menuText G EditStripAll "Σχόλια και παραλλαγές" 0 \
   {Αφαιρέστε όλα τα σχόλια, τους σχολιασμούς και τις παραλλαγές από αυτό το παιχνίδι}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -69,6 +69,8 @@ menuText V EditUndo "לְבַטֵל" 0 {בטל את השינוי במשחק הא
 menuText V EditRedo "לַעֲשׂוֹת שׁוּב" 0 {בצע מחדש את השינוי במשחק האחרון}
 menuText V EditStripComments "הערות" 0 \
   {הסר את כל ההערות וההערות מהמשחק הזה}
+menuText V EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText V EditStripVars "וריאציות" 0 {הסר את כל הווריאציות מהמשחק הזה}
 menuText V EditStripAll "הערות וגיוונים" 0 \
   {הסר את כל ההערות, ההערות והווריאציות מהמשחק הזה}

--- a/tcl/lang/hebrew.tcl
+++ b/tcl/lang/hebrew.tcl
@@ -69,8 +69,8 @@ menuText V EditUndo "לְבַטֵל" 0 {בטל את השינוי במשחק הא
 menuText V EditRedo "לַעֲשׂוֹת שׁוּב" 0 {בצע מחדש את השינוי במשחק האחרון}
 menuText V EditStripComments "הערות" 0 \
   {הסר את כל ההערות וההערות מהמשחק הזה}
-menuText V EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText V EditStripCommentsNotAnnos "הערות, לא סימני הערכה" 0 \
+  {הסר את ההערות אך השאר את סימני ההערכה (NAGs) במשחק הזה}
 menuText V EditStripVars "וריאציות" 0 {הסר את כל הווריאציות מהמשחק הזה}
 menuText V EditStripAll "הערות וגיוונים" 0 \
   {הסר את כל ההערות, ההערות והווריאציות מהמשחק הזה}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -68,6 +68,8 @@ menuText h EditUndo "पूर्ववत" 0 {अंतिम गेम पर�
 menuText h EditRedo "फिर से करना" 0 {अंतिम गेम परिवर्तन फिर से करें}
 menuText h EditStripComments "टिप्पणियाँ" 0 \
   {इस गेम से सभी टिप्पणियाँ और टिप्पणियाँ हटा दें}
+menuText h EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText h EditStripVars "बदलाव" 0 {इस खेल से सभी विविधताएँ हटाएँ}
 menuText h EditStripAll "टिप्पणियाँ और विविधताएँ" 0 \
   {इस गेम से सभी टिप्पणियाँ और विविधताएँ हटा दें}

--- a/tcl/lang/hindi.tcl
+++ b/tcl/lang/hindi.tcl
@@ -68,8 +68,8 @@ menuText h EditUndo "पूर्ववत" 0 {अंतिम गेम पर�
 menuText h EditRedo "फिर से करना" 0 {अंतिम गेम परिवर्तन फिर से करें}
 menuText h EditStripComments "टिप्पणियाँ" 0 \
   {इस गेम से सभी टिप्पणियाँ और टिप्पणियाँ हटा दें}
-menuText h EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText h EditStripCommentsNotAnnos "टिप्पणियाँ, विश्लेषण चिह्न नहीं" 0 \
+  {इस खेल से टिप्पणियाँ हटाएँ, लेकिन विश्लेषण चिह्न (NAGs) रखें}
 menuText h EditStripVars "बदलाव" 0 {इस खेल से सभी विविधताएँ हटाएँ}
 menuText h EditStripAll "टिप्पणियाँ और विविधताएँ" 0 \
   {इस गेम से सभी टिप्पणियाँ और विविधताएँ हटा दें}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -70,6 +70,8 @@ menuText H EditUndo "Visszavonás" 0 {Az utolsó játékmódosítás visszavoná
 menuText H EditRedo "Újra" 0 {Hajtsa végre a legutóbbi játékmódosítást}
 menuText H EditStripComments "Megjegyzések" 0 \
   {Eltávolítja az összes megjegyzést és elemzést ebbõl a játszmából.}
+menuText H EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText H EditStripVars "Változatok" 0 {Eltávolítja az összes változatot ebbõl a játszmából.}
 menuText H EditStripAll "Megjegyzések és variációk" 0 \
   {Távolíts el minden megjegyzést és változatot ebből a játékból}

--- a/tcl/lang/hungary.tcl
+++ b/tcl/lang/hungary.tcl
@@ -70,8 +70,8 @@ menuText H EditUndo "Visszavonás" 0 {Az utolsó játékmódosítás visszavoná
 menuText H EditRedo "Újra" 0 {Hajtsa végre a legutóbbi játékmódosítást}
 menuText H EditStripComments "Megjegyzések" 0 \
   {Eltávolítja az összes megjegyzést és elemzést ebbõl a játszmából.}
-menuText H EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText H EditStripCommentsNotAnnos "Megjegyzések, nem értékelő jelek" 0 \
+  {Eltávolítja a megjegyzéseket, de megtartja az értékelő jeleket (NAG-kat) ebből a játszmából.}
 menuText H EditStripVars "Változatok" 0 {Eltávolítja az összes változatot ebbõl a játszmából.}
 menuText H EditStripAll "Megjegyzések és variációk" 0 \
   {Távolíts el minden megjegyzést és változatot ebből a játékból}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -74,6 +74,8 @@ menuText I EditUndo "Annulla" 0 {Annulla l'ultima modifica della partita}
 menuText I EditRedo "Ripeti" 0 {Ripete l'ultima modifica della partita}
 menuText I EditStripComments "Commenti" 0 \
   {Elimina tutti i commenti e le annotazioni dalla parita corrente}
+menuText I EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText I EditStripVars "Varianti" 0 {Elimina tutte le varianti dalla partita corrente}
 menuText I EditStripAll "Commenti e variazioni" 0 \
   {Elimina tutti i commenti, le annotazioni e le variazioni da questo gioco}

--- a/tcl/lang/italian.tcl
+++ b/tcl/lang/italian.tcl
@@ -74,8 +74,8 @@ menuText I EditUndo "Annulla" 0 {Annulla l'ultima modifica della partita}
 menuText I EditRedo "Ripeti" 0 {Ripete l'ultima modifica della partita}
 menuText I EditStripComments "Commenti" 0 \
   {Elimina tutti i commenti e le annotazioni dalla parita corrente}
-menuText I EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText I EditStripCommentsNotAnnos "Commenti, non annotazioni" 0 \
+  {Elimina i commenti, ma conserva le annotazioni (NAG) dalla partita corrente}
 menuText I EditStripVars "Varianti" 0 {Elimina tutte le varianti dalla partita corrente}
 menuText I EditStripAll "Commenti e variazioni" 0 \
   {Elimina tutti i commenti, le annotazioni e le variazioni da questo gioco}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -109,8 +109,8 @@ menuText A EditUndo "元に戻す" 0 {最後のゲーム変更を元に戻す}
 menuText A EditRedo "やり直し" 0 {最後のゲーム変更をやり直す}
 menuText A EditStripComments "コメント" 0 \
   {このゲームからすべてのコメントと注釈を削除します}
-menuText A EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText A EditStripCommentsNotAnnos "コメント（注釈を除く）" 0 \
+  {このゲームからコメントを削除しますが、注釈（NAG）は残します}
 menuText A EditStripVars "バリエーション" 0 {このゲームからすべてのバリエーションを削除}
 menuText A EditStripAll "コメントとバリエーション" 0 \
   {このゲームからすべてのコメント、注釈、バリエーションを削除します}

--- a/tcl/lang/japanese.tcl
+++ b/tcl/lang/japanese.tcl
@@ -109,6 +109,8 @@ menuText A EditUndo "元に戻す" 0 {最後のゲーム変更を元に戻す}
 menuText A EditRedo "やり直し" 0 {最後のゲーム変更をやり直す}
 menuText A EditStripComments "コメント" 0 \
   {このゲームからすべてのコメントと注釈を削除します}
+menuText A EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText A EditStripVars "バリエーション" 0 {このゲームからすべてのバリエーションを削除}
 menuText A EditStripAll "コメントとバリエーション" 0 \
   {このゲームからすべてのコメント、注釈、バリエーションを削除します}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -109,8 +109,8 @@ menuText k EditUndo "실행 취소" 0 {현재 변경 취소}
 menuText k EditRedo "다시 실행" 0 {마지막 게임 변경 다시 실행}
 menuText k EditStripComments "댓글" 0 \
   {이 게임의 모든 댓글과 설명을 제거합니다.}
-menuText k EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText k EditStripCommentsNotAnnos "댓글만 제거" 0 \
+  {이 게임에서 댓글은 제거하지만 주석(NAG)은 유지합니다.}
 menuText k EditStripVars "변형" 0 {이 게임의 모든 변형 제거}
 menuText k EditStripAll "의견 및 변형" 0 \
   {이 게임의 모든 댓글, 주석 및 변형을 제거합니다.}

--- a/tcl/lang/korean.tcl
+++ b/tcl/lang/korean.tcl
@@ -109,6 +109,8 @@ menuText k EditUndo "실행 취소" 0 {현재 변경 취소}
 menuText k EditRedo "다시 실행" 0 {마지막 게임 변경 다시 실행}
 menuText k EditStripComments "댓글" 0 \
   {이 게임의 모든 댓글과 설명을 제거합니다.}
+menuText k EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText k EditStripVars "변형" 0 {이 게임의 모든 변형 제거}
 menuText k EditStripAll "의견 및 변형" 0 \
   {이 게임의 모든 댓글, 주석 및 변형을 제거합니다.}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -77,8 +77,8 @@ menuText N EditUndo "Ongedaan" 0 {Maak laatset verandering ongedaan}
 menuText N EditRedo "Opnieuw uitvoeren" 0 {Voer de laatste spelwijziging opnieuw uit}
 menuText N EditStripComments "Commentaar" 0 \
   {Verwijder alle commentaar en annotaties uit deze partij}
-menuText N EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText N EditStripCommentsNotAnnos "Commentaar, geen annotaties" 0 \
+  {Verwijder commentaar, maar behoud annotaties (NAG's) in deze partij}
 menuText N EditStripVars "Varianten" 0 {Verwijder alle varianten uit deze partij}
 menuText N EditStripAll "Opmerkingen en variaties" 0 \
   {Verwijder alle opmerkingen, annotaties en variaties uit dit spel}

--- a/tcl/lang/nederlan.tcl
+++ b/tcl/lang/nederlan.tcl
@@ -77,6 +77,8 @@ menuText N EditUndo "Ongedaan" 0 {Maak laatset verandering ongedaan}
 menuText N EditRedo "Opnieuw uitvoeren" 0 {Voer de laatste spelwijziging opnieuw uit}
 menuText N EditStripComments "Commentaar" 0 \
   {Verwijder alle commentaar en annotaties uit deze partij}
+menuText N EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText N EditStripVars "Varianten" 0 {Verwijder alle varianten uit deze partij}
 menuText N EditStripAll "Opmerkingen en variaties" 0 \
   {Verwijder alle opmerkingen, annotaties en variaties uit dit spel}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -72,6 +72,8 @@ menuText O EditUndo "Angre" 0 {Angre siste spillendring}
 menuText O EditRedo "Gjenta" 0 {Gjenta siste spillendring}
 menuText O EditStripComments "Kommentarer" 0 \
   {Fjern alle kommentarer og annotasjoner fra dette partiet}
+menuText O EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText O EditStripVars "Variasjoner" 0 {Fjern alle variasjoner fra dette partiet}
 menuText O EditStripAll "Kommentarer og varianter" 0 \
   {Fjern alle kommentarer, merknader og varianter fra dette spillet}

--- a/tcl/lang/norsk.tcl
+++ b/tcl/lang/norsk.tcl
@@ -72,8 +72,8 @@ menuText O EditUndo "Angre" 0 {Angre siste spillendring}
 menuText O EditRedo "Gjenta" 0 {Gjenta siste spillendring}
 menuText O EditStripComments "Kommentarer" 0 \
   {Fjern alle kommentarer og annotasjoner fra dette partiet}
-menuText O EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText O EditStripCommentsNotAnnos "Kommentarer, ikke annotasjoner" 0 \
+  {Fjern kommentarer, men behold annotasjoner (NAG-er) i dette partiet}
 menuText O EditStripVars "Variasjoner" 0 {Fjern alle variasjoner fra dette partiet}
 menuText O EditStripAll "Kommentarer og varianter" 0 \
   {Fjern alle kommentarer, merknader og varianter fra dette spillet}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -51,8 +51,8 @@ menuText P EditStrip {Usuń} 0 {Usuń komentarze lub warianty z tej partii}
 menuText P EditUndo {Cofnij} 0 {Cofnij ostatnią zmianę w partii}
 menuText P EditRedo {Ponów} 0 {Ponów ostatnią zmianę w partii}
 menuText P EditStripComments {Komentarze} 0 {Usuń wszystkie komentarze i adnotacje z tej partii}
-menuText P EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText P EditStripCommentsNotAnnos "Komentarze, bez adnotacji" 0 \
+  {Usuń komentarze, ale zachowaj adnotacje (NAG) w tej partii}
 menuText P EditStripVars {Warianty} 0 {Usuń wszystkie warianty z tej partii}
 menuText P EditStripAll "Komentarze i warianty" 0 \
   {Usuń wszystkie komentarze, adnotacje i warianty tej gry}

--- a/tcl/lang/polish.tcl
+++ b/tcl/lang/polish.tcl
@@ -51,6 +51,8 @@ menuText P EditStrip {Usuń} 0 {Usuń komentarze lub warianty z tej partii}
 menuText P EditUndo {Cofnij} 0 {Cofnij ostatnią zmianę w partii}
 menuText P EditRedo {Ponów} 0 {Ponów ostatnią zmianę w partii}
 menuText P EditStripComments {Komentarze} 0 {Usuń wszystkie komentarze i adnotacje z tej partii}
+menuText P EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText P EditStripVars {Warianty} 0 {Usuń wszystkie warianty z tej partii}
 menuText P EditStripAll "Komentarze i warianty" 0 \
   {Usuń wszystkie komentarze, adnotacje i warianty tej gry}

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -70,8 +70,8 @@ menuText B EditUndo "Desfazer" 0 {Desfaz última mudança no jogo}
 menuText B EditRedo "Repetir" 0 {Repete última mudança no jogo}
 menuText B EditStripComments "Limpar Comentários" 0 \
   {Limpa comentários e anotações no jogo atual}
-menuText B EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText B EditStripCommentsNotAnnos "Comentários, não anotações" 0 \
+  {Limpa os comentários, mas mantém as anotações (NAGs) no jogo atual}
 menuText B EditStripVars "Limpar Variantes" 0 \
   {Limpa todas as variantes no jogo atual}
 menuText B EditStripAll "Comentários e variações" 0 \

--- a/tcl/lang/portbr.tcl
+++ b/tcl/lang/portbr.tcl
@@ -70,6 +70,8 @@ menuText B EditUndo "Desfazer" 0 {Desfaz última mudança no jogo}
 menuText B EditRedo "Repetir" 0 {Repete última mudança no jogo}
 menuText B EditStripComments "Limpar Comentários" 0 \
   {Limpa comentários e anotações no jogo atual}
+menuText B EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText B EditStripVars "Limpar Variantes" 0 \
   {Limpa todas as variantes no jogo atual}
 menuText B EditStripAll "Comentários e variações" 0 \

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -109,6 +109,8 @@ menuText L EditUndo "Anula" 0 {Anulați ultima modificare a jocului}
 menuText L EditRedo "Reface" 0 {Reface ultima schimbare de joc}
 menuText L EditStripComments "Comentarii" 0 \
   {Eliminați toate comentariile și adnotările din acest joc}
+menuText L EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText L EditStripVars "Variante" 0 {Eliminați toate variantele din acest joc}
 menuText L EditStripAll "Comentarii și variații" 0 \
   {Eliminați toate comentariile, adnotările și variațiile din acest joc}

--- a/tcl/lang/romanian.tcl
+++ b/tcl/lang/romanian.tcl
@@ -109,8 +109,8 @@ menuText L EditUndo "Anula" 0 {Anulați ultima modificare a jocului}
 menuText L EditRedo "Reface" 0 {Reface ultima schimbare de joc}
 menuText L EditStripComments "Comentarii" 0 \
   {Eliminați toate comentariile și adnotările din acest joc}
-menuText L EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText L EditStripCommentsNotAnnos "Comentarii, nu adnotări" 0 \
+  {Eliminați comentariile, dar păstrați adnotările (NAG) din acest joc}
 menuText L EditStripVars "Variante" 0 {Eliminați toate variantele din acest joc}
 menuText L EditStripAll "Comentarii și variații" 0 \
   {Eliminați toate comentariile, adnotările și variațiile din acest joc}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -74,6 +74,8 @@ menuText R EditUndo "Отменить" 0 {Отменить изменения в
 menuText R EditRedo "Вернуть" 0 {Вернуть изменения в последней партии}
 menuText R EditStripComments "Комментарии" 0 \
   {Убрать все комментарии и аннотации из этой партии}
+menuText R EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText R EditStripVars "Варианты" 0 {Убрать все варианты из этой партии}
 menuText R EditStripAll "Комментарии и вариации" 0 \
   {Удалить все комментарии, аннотации и варианты из этой игры.}

--- a/tcl/lang/russian.tcl
+++ b/tcl/lang/russian.tcl
@@ -74,8 +74,8 @@ menuText R EditUndo "Отменить" 0 {Отменить изменения в
 menuText R EditRedo "Вернуть" 0 {Вернуть изменения в последней партии}
 menuText R EditStripComments "Комментарии" 0 \
   {Убрать все комментарии и аннотации из этой партии}
-menuText R EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText R EditStripCommentsNotAnnos "Комментарии, без аннотаций" 0 \
+  {Убрать комментарии, но сохранить аннотации (NAG) в этой партии}
 menuText R EditStripVars "Варианты" 0 {Убрать все варианты из этой партии}
 menuText R EditStripAll "Комментарии и вариации" 0 \
   {Удалить все комментарии, аннотации и варианты из этой игры.}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -76,9 +76,8 @@ menuText Y EditUndo "Undo" 0 {Undo last game change}
 menuText Y EditRedo "Redo" 0 {Redo last game change}
 menuText Y EditStripComments "Komentare" 0 \
   {Ukloni sve komentare i napomene iz ove partije}
-# ====== TODO To be translated ======
-menuText Y EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText Y EditStripCommentsNotAnnos "Komentari, ne napomene" 0 \
+  {Ukloni komentare, ali zadrži napomene (NAG) iz ove partije}
 menuText Y EditStripVars "Varijante" 0 {Ukloni sve varijante iz ove partije}
 menuText Y EditStripAll "Komentari i varijante" 0 \
   {Ukloni sve komentare, napomene i varijante iz ove partije}

--- a/tcl/lang/serbian.tcl
+++ b/tcl/lang/serbian.tcl
@@ -76,6 +76,9 @@ menuText Y EditUndo "Undo" 0 {Undo last game change}
 menuText Y EditRedo "Redo" 0 {Redo last game change}
 menuText Y EditStripComments "Komentare" 0 \
   {Ukloni sve komentare i napomene iz ove partije}
+# ====== TODO To be translated ======
+menuText Y EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText Y EditStripVars "Varijante" 0 {Ukloni sve varijante iz ove partije}
 menuText Y EditStripAll "Komentari i varijante" 0 \
   {Ukloni sve komentare, napomene i varijante iz ove partije}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -77,8 +77,8 @@ menuText S EditUndo "Deshacer" 0 {Deshace el último cambio en la partida}
 menuText S EditRedo "Rehacer" 0 {Rehacer el último cambio de juego}
 menuText S EditStripComments "Comentarios" 0 \
   {Quita todos los comentarios y variaciones de esta partida}
-menuText S EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText S EditStripCommentsNotAnnos "Comentarios, no anotaciones" 0 \
+  {Quita los comentarios, pero conserva las anotaciones (NAGs) de esta partida}
 menuText S EditStripVars "Variaciones" 0 {Quita todas las variaciones de esta partida}
 menuText S EditStripAll "Comentarios y variaciones" 0 \
   {Elimina todos los comentarios, anotaciones y variaciones de este juego.}

--- a/tcl/lang/spanish.tcl
+++ b/tcl/lang/spanish.tcl
@@ -77,6 +77,8 @@ menuText S EditUndo "Deshacer" 0 {Deshace el último cambio en la partida}
 menuText S EditRedo "Rehacer" 0 {Rehacer el último cambio de juego}
 menuText S EditStripComments "Comentarios" 0 \
   {Quita todos los comentarios y variaciones de esta partida}
+menuText S EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText S EditStripVars "Variaciones" 0 {Quita todas las variaciones de esta partida}
 menuText S EditStripAll "Comentarios y variaciones" 0 \
   {Elimina todos los comentarios, anotaciones y variaciones de este juego.}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -106,8 +106,8 @@ menuText U EditUndo "Kumoa" 1 {Peruuta viimeisin muutos}
 menuText U EditRedo "Tee uudelleen" 0 {Tee uudelleen viimeisin muutos}
 menuText U EditStripComments "Kommentit" 1 \
   {Poista kaikki kommentit ja arvioinnit pelistä}
-menuText U EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText U EditStripCommentsNotAnnos "Kommentit, ei arviointeja" 0 \
+  {Poista kommentit, mutta säilytä arvioinnit (NAG:t) pelissä}
 menuText U EditStripVars "Muunnelmat" 3 {Poista kaikki muunnelmat pelistä}
 menuText U EditStripAll "Kommentteja ja muunnelmia" 0 \
   {Poista kaikki kommentit, huomautukset ja muunnelmat tästä pelistä}

--- a/tcl/lang/suomi.tcl
+++ b/tcl/lang/suomi.tcl
@@ -106,6 +106,8 @@ menuText U EditUndo "Kumoa" 1 {Peruuta viimeisin muutos}
 menuText U EditRedo "Tee uudelleen" 0 {Tee uudelleen viimeisin muutos}
 menuText U EditStripComments "Kommentit" 1 \
   {Poista kaikki kommentit ja arvioinnit pelistä}
+menuText U EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText U EditStripVars "Muunnelmat" 3 {Poista kaikki muunnelmat pelistä}
 menuText U EditStripAll "Kommentteja ja muunnelmia" 0 \
   {Poista kaikki kommentit, huomautukset ja muunnelmat tästä pelistä}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -68,8 +68,8 @@ menuText Z EditUndo "Tendua" 0 {Tendua mabadiliko ya mchezo uliopita}
 menuText Z EditRedo "Rudia" 0 {Rudia mabadiliko ya mchezo uliopita}
 menuText Z EditStripComments "Maoni" 0 \
   {Ondoa maoni na vidokezo vyote kutoka kwa mchezo huu}
-menuText Z EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText Z EditStripCommentsNotAnnos "Maoni, si vidokezo" 0 \
+  {Ondoa maoni lakini uhifadhi vidokezo (NAGs) kutoka kwa mchezo huu}
 menuText Z EditStripVars "Tofauti" 0 {Ondoa tofauti zote kutoka kwa mchezo huu}
 menuText Z EditStripAll "Maoni na Tofauti" 0 \
   {Ondoa maoni yote, vidokezo na tofauti kutoka kwa mchezo huu}

--- a/tcl/lang/swahili.tcl
+++ b/tcl/lang/swahili.tcl
@@ -68,6 +68,8 @@ menuText Z EditUndo "Tendua" 0 {Tendua mabadiliko ya mchezo uliopita}
 menuText Z EditRedo "Rudia" 0 {Rudia mabadiliko ya mchezo uliopita}
 menuText Z EditStripComments "Maoni" 0 \
   {Ondoa maoni na vidokezo vyote kutoka kwa mchezo huu}
+menuText Z EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText Z EditStripVars "Tofauti" 0 {Ondoa tofauti zote kutoka kwa mchezo huu}
 menuText Z EditStripAll "Maoni na Tofauti" 0 \
   {Ondoa maoni yote, vidokezo na tofauti kutoka kwa mchezo huu}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -72,8 +72,8 @@ menuText W EditUndo "Ångra" 0 {Ångra senaste ändring i parti}
 menuText W EditRedo "Göra om" 0 {Gör om senaste spelbyte}
 menuText W EditStripComments "Kommentarer" 0 \
   {Avlägsna alla kommentarer och noteringar från partiet}
-menuText W EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText W EditStripCommentsNotAnnos "Kommentarer, inte noteringar" 0 \
+  {Avlägsna kommentarer men behåll noteringar (NAG:er) i partiet}
 menuText W EditStripVars "Varianter" 0 {Avlägsna alla varianter från partiet}
 menuText W EditStripAll "Kommentarer och variationer" 0 \
   {Ta bort alla kommentarer, kommentarer och varianter från detta spel}

--- a/tcl/lang/swedish.tcl
+++ b/tcl/lang/swedish.tcl
@@ -72,6 +72,8 @@ menuText W EditUndo "Ångra" 0 {Ångra senaste ändring i parti}
 menuText W EditRedo "Göra om" 0 {Gör om senaste spelbyte}
 menuText W EditStripComments "Kommentarer" 0 \
   {Avlägsna alla kommentarer och noteringar från partiet}
+menuText W EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText W EditStripVars "Varianter" 0 {Avlägsna alla varianter från partiet}
 menuText W EditStripAll "Kommentarer och variationer" 0 \
   {Ta bort alla kommentarer, kommentarer och varianter från detta spel}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -72,6 +72,8 @@ menuText T EditUndo "Geri al" 0 {Son oyun değişikliğini geri al}
 menuText T EditRedo "Yinele" 0 {Son oyun değişikliğini yeniden yap}
 menuText T EditStripComments "Yorumlar" 0 \
   {Bu oyundaki tüm yorumları ve ek açıklamaları kaldır}
+menuText T EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText T EditStripVars "Varyasyonlar" 0 {Bu oyundaki tüm varyasyonları çıkarın}
 menuText T EditStripAll "Yorumlar ve Varyasyonlar" 0 \
   {Bu oyundaki tüm yorumları, açıklamaları ve varyasyonları kaldırın}

--- a/tcl/lang/turkish.tcl
+++ b/tcl/lang/turkish.tcl
@@ -72,8 +72,8 @@ menuText T EditUndo "Geri al" 0 {Son oyun değişikliğini geri al}
 menuText T EditRedo "Yinele" 0 {Son oyun değişikliğini yeniden yap}
 menuText T EditStripComments "Yorumlar" 0 \
   {Bu oyundaki tüm yorumları ve ek açıklamaları kaldır}
-menuText T EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText T EditStripCommentsNotAnnos "Yorumlar, ek açıklamalar değil" 0 \
+  {Bu oyundaki yorumları kaldır, ancak ek açıklamaları (NAG'leri) koru}
 menuText T EditStripVars "Varyasyonlar" 0 {Bu oyundaki tüm varyasyonları çıkarın}
 menuText T EditStripAll "Yorumlar ve Varyasyonlar" 0 \
   {Bu oyundaki tüm yorumları, açıklamaları ve varyasyonları kaldırın}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -69,6 +69,8 @@ menuText Q EditUndo "Скасувати" 0 {Скасувати останню з
 menuText Q EditRedo "Повторити" 0 {Повторити останню зміну гри}
 menuText Q EditStripComments "Коментарі" 0 \
   {Видалити всі коментарі та анотації з цієї гри}
+menuText Q EditStripCommentsNotAnnos "Comments, not annotations" 0 \
+  {Strip comments but keep annotations (NAGs) from this game}
 menuText Q EditStripVars "Варіації" 0 {Зніміть усі варіації з цієї гри}
 menuText Q EditStripAll "Коментарі та варіації" 0 \
   {Видалити всі коментарі, анотації та варіації з цієї гри}

--- a/tcl/lang/ukrainian.tcl
+++ b/tcl/lang/ukrainian.tcl
@@ -69,8 +69,8 @@ menuText Q EditUndo "Скасувати" 0 {Скасувати останню з
 menuText Q EditRedo "Повторити" 0 {Повторити останню зміну гри}
 menuText Q EditStripComments "Коментарі" 0 \
   {Видалити всі коментарі та анотації з цієї гри}
-menuText Q EditStripCommentsNotAnnos "Comments, not annotations" 0 \
-  {Strip comments but keep annotations (NAGs) from this game}
+menuText Q EditStripCommentsNotAnnos "Коментарі, без анотацій" 0 \
+  {Видалити коментарі, але зберегти анотації (NAG) у цій грі}
 menuText Q EditStripVars "Варіації" 0 {Зніміть усі варіації з цієї гри}
 menuText Q EditStripAll "Коментарі та варіації" 0 \
   {Видалити всі коментарі, анотації та варіації з цієї гри}

--- a/tcl/windows/gamelist.tcl
+++ b/tcl/windows/gamelist.tcl
@@ -1425,6 +1425,8 @@ proc glist.popupmenu_ {{w} {x} {y} {abs_x} {abs_y} {layout}} {
       menu $w.game_menu.strip
       $w.game_menu.strip add command -label [tr EditStripComments] \
         -command [list ::game::StripSelected $::glistBase($w) $sel_literal comments]
+      $w.game_menu.strip add command -label [tr EditStripCommentsNotAnnos] \
+        -command [list ::game::StripSelected $::glistBase($w) $sel_literal commentsnonag]
       $w.game_menu.strip add command -label [tr EditStripVars] \
         -command [list ::game::StripSelected $::glistBase($w) $sel_literal variations]
       $w.game_menu.strip add command -label [tr EditStripAll] \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Comments, not annotations” option that removes game comments while preserving annotation symbols (NAGs).
  - Available from the game-list context menu and the `sc_game strip` command.
  - Command usage guidance now includes the new option.

- **Localization**
  - Added or updated translated menu labels and help text across supported languages.
  - Improved the English menu mnemonic for easier keyboard access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->